### PR TITLE
[COFFE] VPR Arch Patching 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 [submodule "fpga21-scaled-tech"]
 	path = third_party/fpga21-scaled-tech
 	url = git@github.com:StephenMoreOSU/fpga21-scaled-tech.git
+[submodule "third_party/vtr"]
+	path = third_party/vtr
+	url = https://github.com/verilog-to-routing/vtr-verilog-to-routing.git

--- a/env_setup.sh
+++ b/env_setup.sh
@@ -35,6 +35,7 @@ fi
 export RAD_GEN_HOME=$PWD
 export THIRD_PARTY_HOME=$RAD_GEN_HOME/third_party
 export HAMMER_HOME=$THIRD_PARTY_HOME/hammer
+export VTR_HOME=$THIRD_PARTY_HOME/vtr
 
 pathadd "PYTHONPATH" "$RAD_GEN_HOME"
 
@@ -116,7 +117,14 @@ while true; do
     fi 
     i=$((i+1))
 done
-#
+
+if [ ! -d $VTR_HOME/build ]; then
+	echo "Compiling VTR..."
+	cd $VTR_HOME
+	make 
+	cd $RAD_GEN_HOME
+fi
+pathadd "PATH" $VTR_HOME/vpr
 
 # Copy the newly set env to pytest.ini
 ${RAD_GEN_HOME}/scripts/cur_env_to_pytest.sh

--- a/py_install.sh
+++ b/py_install.sh
@@ -81,3 +81,14 @@ else
     echo "Please install above dependancies and try again"
     return 1
 fi
+
+if [ ! -d $VTR_HOME/build ] && ["$ENV_INIT" = "1"]; then
+	cd $VTR_HOME
+	git submodule update --init --recursive .
+	pip install -r requirements.txt
+	cd - > /dev/null
+else
+    echo "Conda not found. OR system python3 version < 3.9 OR venv module not installed"
+    echo "Please install above dependancies and try again"
+    return 1
+fi

--- a/src/coffe/cb_mux.py
+++ b/src/coffe/cb_mux.py
@@ -28,6 +28,7 @@ import src.coffe.constants as consts
 @dataclass
 class ConnectionBlockMux(mux.Mux2Lvl):
     name: str                                       = "cb_mux"
+    vpr_name: str | None                        = None # Original VPR switch name for this CB mux, if available
     # src_wires: Dict[Type[c_ds.Wire], int]       = None
     # sink_wire: c_ds.Wire        = None
 

--- a/src/coffe/coffe.py
+++ b/src/coffe/coffe.py
@@ -51,6 +51,8 @@ def run_coffe_flow(coffe_info: rg_ds.Coffe):
         run_options = args,
         spice_interface = spice_interface,
     )   # telemetry_file_path
+
+    fpga_inst.print_vpr_mux_names(report_file_path)
     
     ###############################################################
     ## GENERATE FILES

--- a/src/coffe/fpga.py
+++ b/src/coffe/fpga.py
@@ -1005,9 +1005,7 @@ class FPGA:
                     vpr_name = vpr_name,
                 )
                 self.sb_muxes.append(sb_mux)
-<<<<<<< HEAD
             # Build per-wire load freq dicts from RRG mux_stats fanout info.
-=======
             self.sb_mux = c_ds.Block(
                 ckt_defs = self.sb_muxes,
                 total_num_per_tile = sum([sb_mux.num_per_tile for sb_mux in self.sb_muxes])
@@ -1073,7 +1071,6 @@ class FPGA:
             # Convert fanout information from RRG into a Dict[c_ds.GenRoutingWire, Dict[sb_mux_lib.SwitchBlockMux, Dict[str, int] ] ]
             # The inner most dict will have keys "freq" and "ISBD"
 
->>>>>>> 81deaa5 (FEAT: Added CB and SB delay and area patching logic)
             # TODO implement "ISBD" type metrics from parsing RR_graph data
             sb_mux: sb_mux_lib.SwitchBlockMux
             for sb_mux in self.sb_muxes:

--- a/src/coffe/fpga.py
+++ b/src/coffe/fpga.py
@@ -844,6 +844,13 @@ class FPGA:
                     c_ds.SwitchRRG
                 )
                 rr_switches.append(rr_sw)
+            vpr_switch_name_lookup: Dict[str, str] = {}
+            for rr_sw in rr_switches:
+                if rr_sw.name is None:
+                    continue
+                key = rr_sw.name.lower()
+                if key not in vpr_switch_name_lookup:
+                    vpr_switch_name_lookup[key] = rr_sw.name
             # drv_type: num_of_this_mux
 
             rr_wire_stats: List[dict] = rg_utils.read_csv_to_list(wire_stats_fpath)
@@ -982,6 +989,10 @@ class FPGA:
                 sink_wire: c_ds.GenRoutingWire = self.gen_r_wires[wire_type]
                 # TODO find a better fix for this but RRG was giving like close but not quite enough of the expected SB per tile, so we will use below formula instead
                 num_sb_per_tile: int = int( 4 * sink_wire.freq // (2 * sink_wire.length) )
+                drv_type: str | None = seg_2_drv_lookup.get(wire_type)
+                vpr_name: str | None = None
+                if drv_type and drv_type != "lb_opin":
+                    vpr_name = vpr_switch_name_lookup.get(drv_type)
 
                 # Required size inferred from src_wires
                 # num_sb_per_tile inferred from sink_wire.num_starting_per_tile -> from RRG
@@ -991,9 +1002,78 @@ class FPGA:
                     sink_wire = self.gen_r_wires[wire_type],
                     num_per_tile = num_sb_per_tile,
                     use_tgate = self.specs.use_tgate,
+                    vpr_name = vpr_name,
                 )
                 self.sb_muxes.append(sb_mux)
+<<<<<<< HEAD
             # Build per-wire load freq dicts from RRG mux_stats fanout info.
+=======
+            self.sb_mux = c_ds.Block(
+                ckt_defs = self.sb_muxes,
+                total_num_per_tile = sum([sb_mux.num_per_tile for sb_mux in self.sb_muxes])
+            )
+            ######################################
+            ### CREATE CONNECTION BLOCK OBJECT ###
+            ######################################
+            self.cb_muxes: List[cb_mux_lib.ConnectionBlockMux] = []
+            # Calculate connection block mux size
+            cb_mux_size_required = int(self.specs.W * self.specs.Fcin)
+            num_cb_mux_per_tile = self.specs.I
+            # Initialize the connection block
+            cb_vpr_name: str | None = vpr_switch_name_lookup.get("ipin_cblock")
+            cb_mux = cb_mux_lib.ConnectionBlockMux(
+                id = 0,
+                required_size = cb_mux_size_required,
+                num_per_tile = num_cb_mux_per_tile,
+                use_tgate = self.specs.use_tgate,
+                vpr_name = cb_vpr_name,
+                # self.sb_muxes[0], self.gen_routing_wire_loads[0]
+            )
+            self.cb_muxes.append(cb_mux)
+            self.cb_mux = c_ds.Block(
+                ckt_defs = self.cb_muxes,
+                total_num_per_tile = sum([cb_mux.num_per_tile for cb_mux in self.cb_muxes])
+            )
+            ###########################
+            ### CREATE LOAD OBJECTS ###
+            ###########################
+            # Create Dict holding the % distributions of logic block outputs per mux type
+            #   For each BLE output, what is the chance that its going into each mux type? 
+            ble_sb_mux_load_dist: Dict[sb_mux_lib.SwitchBlockMux, float] = {}
+            ble_sb_mux_load_freq: Dict[sb_mux_lib.SwitchBlockMux, int] = {}
+            sb_mux: sb_mux_lib.SwitchBlockMux
+            for sb_mux in self.sb_muxes:
+                # Check to see if this takes the general_ble_output wire as an input, this means its loading BLEs
+                for src_wire, src_wire_freq in sb_mux.src_wires.items():
+                    # TODO ideally we wouldn't be using the name of a wire to determine if its a BLE output load but fine for now
+                    if src_wire.name == "wire_general_ble_output_load":
+                        ble_sb_mux_load_freq[sb_mux] = src_wire_freq
+                        # Break because we only care about ble output wires
+                        break
+            # Calculate the distribution of BLE outputs per SB Mux
+            for sb_mux, freq in ble_sb_mux_load_freq.items():
+                ble_sb_mux_load_dist[sb_mux] = freq / sum(ble_sb_mux_load_freq.values())
+            # Use the distribution to create the BLE Output Load Circuits
+            self.gen_ble_output_loads: List[gen_r_load_lib.GeneralBLEOutputLoad] = []
+            # TODO bring this to the user level
+            # For now we will pick whatever SB mux has the most BLE outputs as inputs to determine which SB mux should be ON in the load
+            #   And we assume fanout is 1, with a single SB Mux being ON
+            most_likely_on_sb: sb_mux_lib.SwitchBlockMux = max(ble_sb_mux_load_freq, key=ble_sb_mux_load_freq.get)
+            sb_mux_on_assumption_freqs: Dict[sb_mux_lib.SwitchBlockMux, int] = { most_likely_on_sb: 1 }
+            # Even with multiple SB types we will still create a single BLE output load, containing each type of SB Mux that could act as a load
+            ble_output_load: gen_r_load_lib.GeneralBLEOutputLoad = gen_r_load_lib.GeneralBLEOutputLoad(
+                id = 0,
+                channel_usage_assumption = constants.CHAN_USAGE_ASSUMPTION,
+                sb_mux_on_assumption_freqs = sb_mux_on_assumption_freqs,
+                sb_mux_load_dist = ble_sb_mux_load_dist
+            )
+            # We still keep to format of having list for every circuit and during simulation doing some user defined sweep (geometric, linear, etc.) over circuit list combos
+            self.gen_ble_output_loads.append(ble_output_load) 
+
+            # Convert fanout information from RRG into a Dict[c_ds.GenRoutingWire, Dict[sb_mux_lib.SwitchBlockMux, Dict[str, int] ] ]
+            # The inner most dict will have keys "freq" and "ISBD"
+
+>>>>>>> 81deaa5 (FEAT: Added CB and SB delay and area patching logic)
             # TODO implement "ISBD" type metrics from parsing RR_graph data
             sb_mux: sb_mux_lib.SwitchBlockMux
             for sb_mux in self.sb_muxes:
@@ -3228,6 +3308,33 @@ class FPGA:
         print("")
         print("|------------------------------------------------------------------------------|")
         print("")
+
+
+    def print_vpr_mux_names(self, report_fpath: str):
+
+        report_file = open(report_fpath, 'a')
+
+        utils.print_and_write(report_file, "-------------------------------------------------")
+        utils.print_and_write(report_file, "  VPR SWITCH NAMES (RRG)")
+        utils.print_and_write(report_file, "-------------------------------------------------")
+
+        sb_muxes = self.sb_muxes or []
+        cb_muxes = self.cb_muxes or []
+
+        if not sb_muxes and not cb_muxes:
+            utils.print_and_write(report_file, "  (none)")
+        else:
+            for sb_mux in sb_muxes:
+                sb_label = sb_mux.sp_name or sb_mux.name or "sb_mux"
+                vpr_name = sb_mux.vpr_name or "None"
+                utils.print_and_write(report_file, f"  SB mux {sb_label}: {vpr_name}")
+            for cb_mux in cb_muxes:
+                cb_label = cb_mux.sp_name or cb_mux.name or "cb_mux"
+                vpr_name = cb_mux.vpr_name or "None"
+                utils.print_and_write(report_file, f"  CB mux {cb_label}: {vpr_name}")
+
+        utils.print_and_write(report_file, "")
+        report_file.close()
         
         
     def print_details(self, report_fpath: str):

--- a/src/coffe/sb_mux.py
+++ b/src/coffe/sb_mux.py
@@ -23,6 +23,7 @@ import src.coffe.constants as consts
 class SwitchBlockMux(mux.Mux2Lvl):
     name: str                                       = "sb_mux" # Basename of the Spice subckt, identifies the circuit type itself
     sp_name: str                                = None # Name of the SPICE subckt, Ex. sb_mux_uid_0
+    vpr_name: str | None                        = None # Original VPR switch name for this SB mux, if available
     # This info is not required to create the circuit definition
     src_wires: Dict[Type[c_ds.Wire], int]                         = None # Dict of source wires and the number of mux inputs they occupy
     sink_wire: c_ds.GenRoutingWire                  = None # The sink wire for this mux

--- a/src/coffe/utils.py
+++ b/src/coffe/utils.py
@@ -536,6 +536,7 @@ def print_vpr_areas(report_file, fpga_inst):
     ipin_mux_size_keys = [key for key in list(fpga_inst.area_dict.keys()) if "ipin_mux_trans_size" in key]
     for ipin_mux_size_key in ipin_mux_size_keys:
         print_and_write(report_file, f"  {ipin_mux_size_key} (connection block mux)".ljust(50) + str(fpga_inst.area_dict[ipin_mux_size_key] / fpga_inst.specs.min_width_tran_area))
+    print_and_write(report_file, f"  cb_buf_size (connection block mux)".ljust(50) + str(fpga_inst.area_dict["cb_buf_size"] / fpga_inst.specs.min_width_tran_area))
     switch_mux_size_keys = [key for key in list(fpga_inst.area_dict.keys()) if "switch_mux" in key]
     for switch_mux_size_key in switch_mux_size_keys:
         print_and_write(report_file, f"  {switch_mux_size_key} (routing switch)".ljust(50) + str(fpga_inst.area_dict[switch_mux_size_key] / fpga_inst.specs.min_width_tran_area))

--- a/src/coffe/vpr.py
+++ b/src/coffe/vpr.py
@@ -2,6 +2,47 @@ import sys
 import os
 from lxml import etree
 
+
+def _first_or_none(value):
+    if isinstance(value, list):
+        return value[0] if value else None
+    return value
+
+
+def _get_ckt_delay(ckt, delay_dict):
+    if ckt is None:
+        return None
+    sp_name = None
+    if hasattr(ckt, "sp_name") and ckt.sp_name:
+        sp_name = ckt.sp_name
+    elif hasattr(ckt, "name"):
+        sp_name = ckt.name
+    if delay_dict and sp_name in delay_dict:
+        return delay_dict[sp_name]
+    if hasattr(ckt, "delay"):
+        return ckt.delay
+    return None
+
+
+def _set_delay_constant(delay_node, delay_value):
+    if delay_node is None or delay_value is None:
+        return
+    delay_node.set("max", str(delay_value))
+    if delay_node.get("min") is not None:
+        delay_node.set("min", str(delay_value))
+
+
+def _lut_delay_vector(lut_input_delays, count):
+    if count <= 0:
+        return []
+    ordered_names = sorted(lut_input_delays.keys())
+    ordered_delays = [lut_input_delays[name] for name in ordered_names]
+    if not ordered_delays:
+        return []
+    if len(ordered_delays) < count:
+        ordered_delays += [ordered_delays[-1]] * (count - len(ordered_delays))
+    return ordered_delays[:count]
+
 def print_vpr_file_memory(vpr_file, fpga_inst):
 
     # get delay values
@@ -586,7 +627,10 @@ def print_vpr_file_memory(vpr_file, fpga_inst):
 
 
 
-def print_vpr_file_flut_hard(vpr_file, fpga_inst):
+def print_vpr_file_flut_hard(vpr_file, fpga_inst, input_xml="arch.xml", output_xml="patch.xml", delay_dict=None):
+
+    if delay_dict is None and hasattr(fpga_inst, "delay_dict"):
+        delay_dict = fpga_inst.delay_dict
 
     # get archetecture parameters
     Rfb = fpga_inst.specs.Rfb
@@ -601,21 +645,65 @@ def print_vpr_file_flut_hard(vpr_file, fpga_inst):
     # get areas
     grid_logic_tile_area = fpga_inst.area_dict["logic_cluster"]/fpga_inst.specs.min_width_tran_area
 
-    tree = etree.parse("arch.xml")
+    tree = etree.parse(input_xml)
     root = tree.getroot()
 
     logic_tile = root.xpath("//device/area")[0]
     boxes = root.xpath("//switchlist/switch")
-    lut_delay_matrices = root.xpath("//delay_matrix") 
+    lut_delay_matrices = root.xpath("//delay_matrix")
 
     lut_input_names = list(fpga_inst.lut_inputs.keys())
     lut_input_names.sort()
-    lut_delays = []
+    lut_input_delays = {}
     for input_name in lut_input_names:
-        lut_input = fpga_inst.lut_inputs[input_name][0] #TODO add multi ckt support
+        lut_delay_key = f"lut_{input_name}"
+        if delay_dict and lut_delay_key in delay_dict:
+            lut_input_delays[input_name] = delay_dict[lut_delay_key]
+            continue
+        lut_input = fpga_inst.lut_inputs[input_name][0]  # TODO add multi ckt support
         driver_delay = max(lut_input.driver.delay, lut_input.not_driver.delay)
         path_delay = lut_input.delay
-        lut_delays.append(driver_delay + path_delay)
+        lut_input_delays[input_name] = driver_delay + path_delay
+
+    lut_mode_vectors = {}
+    for lut_name, lut_size in (("lut6", 6), ("lut5", 5), ("lut4", 4)):
+        if delay_dict and lut_name in delay_dict:
+            lut_mode_vectors[lut_name] = [delay_dict[lut_name]] * lut_size
+        else:
+            lut_mode_vectors[lut_name] = _lut_delay_vector(lut_input_delays, lut_size)
+
+    logic_cluster = getattr(fpga_inst, "logic_cluster", None)
+    local_mux_ckt = _first_or_none(getattr(fpga_inst, "local_muxes", None))
+    if local_mux_ckt is None and logic_cluster is not None:
+        local_mux_ckt = getattr(logic_cluster, "local_mux", None)
+    local_feedback_ckt = _first_or_none(getattr(fpga_inst, "local_ble_outputs", None))
+    if local_feedback_ckt is None and logic_cluster is not None and hasattr(logic_cluster, "ble"):
+        local_feedback_ckt = getattr(logic_cluster.ble, "local_output", None)
+    general_output_ckt = _first_or_none(getattr(fpga_inst, "general_ble_outputs", None))
+    if general_output_ckt is None and logic_cluster is not None and hasattr(logic_cluster, "ble"):
+        general_output_ckt = getattr(logic_cluster.ble, "general_output", None)
+
+    local_mux_delay = _get_ckt_delay(local_mux_ckt, delay_dict)
+    local_feedback_delay = _get_ckt_delay(local_feedback_ckt, delay_dict)
+    logic_block_output_delay = _get_ckt_delay(general_output_ckt, delay_dict)
+
+    carry_chain_delay = None
+    if getattr(fpga_inst.specs, "enable_carry_chain", False):
+        carry_inter = _first_or_none(getattr(fpga_inst, "carry_chain_inter_clusters", None))
+        carry_per = _first_or_none(getattr(fpga_inst, "carry_chain_periphs", None))
+        carry_mux = _first_or_none(getattr(fpga_inst, "carry_chain_muxes", None))
+        carry_chain = _first_or_none(getattr(fpga_inst, "carry_chains", None))
+        carry_parts = [
+            _get_ckt_delay(carry_inter, delay_dict),
+            _get_ckt_delay(carry_per, delay_dict),
+            _get_ckt_delay(carry_mux, delay_dict),
+        ]
+        carry_parts = [delay for delay in carry_parts if delay is not None]
+        if not carry_parts and carry_chain is not None:
+            carry_parts = [_get_ckt_delay(carry_chain, delay_dict)]
+        carry_parts = [delay for delay in carry_parts if delay is not None]
+        if carry_parts:
+            carry_chain_delay = sum(carry_parts)
 
     logic_tile.set("grid_logic_tile_area", str(grid_logic_tile_area))
 
@@ -635,10 +723,46 @@ def print_vpr_file_flut_hard(vpr_file, fpga_inst):
                 box.set("buf_size", str(fpga_inst.area_dict["cb_buf_size"]/fpga_inst.specs.min_width_tran_area))
                 break
     for delay in lut_delay_matrices:
-        if "lut" in delay.get("in_port"):
-            delay.text = "\n" + "".join(f"{lut}\n" for lut in lut_delays)
+        in_port = delay.get("in_port") or ""
+        for lut_name, lut_values in lut_mode_vectors.items():
+            if not lut_values:
+                continue
+            if in_port.startswith(f"{lut_name}."):
+                delay.text = "\n" + "".join(f"{lut}\n" for lut in lut_values)
+                break
 
-    tree.write("patch.xml", pretty_print=True)
+    if local_mux_delay is not None or local_feedback_delay is not None:
+        for complete in root.xpath("//interconnect/complete"):
+            for delay_node in complete.xpath("./delay_constant"):
+                in_port = delay_node.get("in_port") or ""
+                out_port = delay_node.get("out_port") or ""
+                if "clb.I" in in_port and ".in" in out_port:
+                    _set_delay_constant(delay_node, local_mux_delay)
+                elif ".out" in in_port and ".in" in out_port:
+                    _set_delay_constant(delay_node, local_feedback_delay)
+
+    if logic_block_output_delay is not None:
+        for mux in root.xpath("//mux[contains(@input, 'ff.Q')]"):
+            for delay_node in mux.xpath("./delay_constant"):
+                _set_delay_constant(delay_node, logic_block_output_delay)
+
+    if carry_chain_delay is not None:
+        for direct in root.xpath("//direct[@name='carry_in']"):
+            delay_nodes = direct.xpath("./delay_constant")
+            if delay_nodes:
+                for delay_node in delay_nodes:
+                    _set_delay_constant(delay_node, carry_chain_delay)
+            else:
+                in_port = direct.get("input")
+                out_port = direct.get("output")
+                if in_port and out_port:
+                    new_delay = etree.SubElement(direct, "delay_constant")
+                    new_delay.set("max", str(carry_chain_delay))
+                    new_delay.set("min", str(carry_chain_delay))
+                    new_delay.set("in_port", in_port)
+                    new_delay.set("out_port", out_port)
+
+    tree.write(output_xml, pretty_print=True)
 def print_vpr_file(fpga_inst, arch_folder, enable_bram_module):
 
     vpr_file = open(arch_folder + "/vpr_arch.xml", 'w')

--- a/src/coffe/vpr.py
+++ b/src/coffe/vpr.py
@@ -1,1744 +1,638 @@
 import sys
 import os
+from lxml import etree
 
 def print_vpr_file_memory(vpr_file, fpga_inst):
 
-	# get delay values
-	Tdel = fpga_inst.sb_mux.delay
-	T_ipin_cblock = fpga_inst.cb_mux.delay
-	local_CLB_routing = fpga_inst.logic_cluster.local_mux.delay
-	local_feedback = fpga_inst.logic_cluster.ble.local_output.delay
-	logic_block_output = fpga_inst.logic_cluster.ble.general_output.delay
+    # get delay values
+    Tdel = fpga_inst.sb_mux.delay
+    T_ipin_cblock = fpga_inst.cb_mux.delay
+    local_CLB_routing = fpga_inst.logic_cluster.local_mux.delay
+    local_feedback = fpga_inst.logic_cluster.ble.local_output.delay
+    logic_block_output = fpga_inst.logic_cluster.ble.general_output.delay
 
-	# get lut delays
-	lut_input_names = list(fpga_inst.logic_cluster.ble.lut.input_drivers.keys())
-	lut_input_names.sort()
-	lut_delays = {}
-	for input_name in lut_input_names:
-		lut_input = fpga_inst.logic_cluster.ble.lut.input_drivers[input_name]
-		driver_delay = max(lut_input.driver.delay, lut_input.not_driver.delay)
-		path_delay = lut_input.delay
-		lut_delays[input_name] = driver_delay+path_delay
+    # get lut delays
+    lut_input_names = list(fpga_inst.logic_cluster.ble.lut.input_drivers.keys())
+    lut_input_names.sort()
+    lut_delays = {}
+    for input_name in lut_input_names:
+        lut_input = fpga_inst.logic_cluster.ble.lut.input_drivers[input_name]
+        driver_delay = max(lut_input.driver.delay, lut_input.not_driver.delay)
+        path_delay = lut_input.delay
+        lut_delays[input_name] = driver_delay+path_delay
 
-	# get archetecture parameters
-	Rfb = fpga_inst.specs.Rfb
-	Fcin = fpga_inst.specs.Fcin
-	Fcout = fpga_inst.specs.Fcout
-	Fs = fpga_inst.specs.Fs
-	N = fpga_inst.specs.N
-	K = fpga_inst.specs.K
-	L = fpga_inst.specs.L
+    # get archetecture parameters
+    Rfb = fpga_inst.specs.Rfb
+    Fcin = fpga_inst.specs.Fcin
+    Fcout = fpga_inst.specs.Fcout
+    Fs = fpga_inst.specs.Fs
+    N = fpga_inst.specs.N
+    K = fpga_inst.specs.K
+    L = fpga_inst.specs.L
 
-		
-	# get areas
-	grid_logic_tile_area = fpga_inst.area_dict["logic_cluster"]/fpga_inst.specs.min_width_tran_area
-	if grid_logic_tile_area < 1.00 :
-		grid_logic_tile_area = 1.00
-	ipin_mux_trans_size = fpga_inst.area_dict["ipin_mux_trans_size"]/fpga_inst.specs.min_width_tran_area
-	if ipin_mux_trans_size < 1.00 :
-		ipin_mux_trans_size = 1.00
-	mux_trans_size = fpga_inst.area_dict["switch_mux_trans_size"]/fpga_inst.specs.min_width_tran_area
-	if mux_trans_size < 1.00 :
-		mux_trans_size = 1.00
-	buf_size = fpga_inst.area_dict["switch_buf_size"]/fpga_inst.specs.min_width_tran_area
-	if buf_size < 1.00 :
-		buf_size = 1.00
-
-	# get memory information
-	memory_height = int(round(fpga_inst.area_dict["ram"]/fpga_inst.area_dict["tile"], 0))
-	memory_max_width =  2 ** fpga_inst.RAM.conf_decoder_bits
-	memory_address_bits = fpga_inst.specs.row_decoder_bits + fpga_inst.specs.col_decoder_bits + fpga_inst.specs.conf_decoder_bits
-	memory_max_depth = 2 ** (fpga_inst.specs.row_decoder_bits + fpga_inst.specs.col_decoder_bits + fpga_inst.specs.conf_decoder_bits)
-	memory_clktoq = fpga_inst.RAM.frequency
-	memory_setup_time = fpga_inst.RAM.RAM_local_mux.delay + 52.3e-12
-	memory_input_mux_size = 25
-	# Todo: I can add output mux size and create a crossbar at the output. Not sure if it will actually help. 
-	cb_buf_size = fpga_inst.area_dict["cb_buf_size"]/fpga_inst.specs.min_width_tran_area
-	if cb_buf_size < 1.00:
-		cb_buf_size = 1.00
-
-	vpr_file.write("<architecture>  \n")
-	vpr_file.write("<!-- ODIN II specific config -->\n")
-	vpr_file.write("<models>\n")
-	vpr_file.write("  <model name=\"multiply\">\n")
-	vpr_file.write("    <input_ports>\n")
-	vpr_file.write("    <port name=\"a\" combinational_sink_ports=\"out\"/> \n")
-	vpr_file.write("    <port name=\"b\" combinational_sink_ports=\"out\"/>\n")
-	vpr_file.write("    </input_ports>\n")
-	vpr_file.write("    <output_ports>\n")
-	vpr_file.write("    <port name=\"out\"/>\n")
-	vpr_file.write("    </output_ports>\n")
-	vpr_file.write("  </model>\n")
-	    
-	vpr_file.write("<model name=\"single_port_ram\">\n")
-	vpr_file.write("  <input_ports>\n")
-	vpr_file.write("  <port name=\"we\" clock=\"clk\"/>     <!-- control -->\n")
-	vpr_file.write("  <port name=\"addr\" clock=\"clk\"/>  <!-- address lines -->\n")
-	vpr_file.write("  <port name=\"data\" clock=\"clk\"/>  <!-- data lines can be broken down into smaller bit widths minimum size 1 -->\n")
-	vpr_file.write("  <port name=\"clk\" is_clock=\"1\"/>  <!-- memories are often clocked -->\n")
-	vpr_file.write("  </input_ports>\n")
-	vpr_file.write("  <output_ports>\n")
-	vpr_file.write("  <port name=\"out\" clock=\"clk\"/>   <!-- output can be broken down into smaller bit widths minimum size 1 -->\n")
-	vpr_file.write("  </output_ports>\n")
-	vpr_file.write("</model>\n")
-
-	vpr_file.write("<model name=\"dual_port_ram\">\n")
-	vpr_file.write("  <input_ports>\n")
-	vpr_file.write("  <port name=\"we1\" clock=\"clk\"/>     <!-- write enable -->\n")
-	vpr_file.write("  <port name=\"we2\" clock=\"clk\"/>     <!-- write enable -->\n")
-	vpr_file.write("  <port name=\"addr1\" clock=\"clk\"/>  <!-- address lines -->\n")
-	vpr_file.write("  <port name=\"addr2\" clock=\"clk\"/>  <!-- address lines -->\n")
-	vpr_file.write("  <port name=\"data1\" clock=\"clk\"/>  <!-- data lines can be broken down into smaller bit widths minimum size 1 -->\n")
-	vpr_file.write("  <port name=\"data2\" clock=\"clk\"/>  <!-- data lines can be broken down into smaller bit widths minimum size 1 -->\n")
-	vpr_file.write("  <port name=\"clk\" is_clock=\"1\"/>  <!-- memories are often clocked -->\n")
-	vpr_file.write("  </input_ports>\n")
-	vpr_file.write("  <output_ports>\n")
-	vpr_file.write("  <port name=\"out1\" clock=\"clk\"/>   <!-- output can be broken down into smaller bit widths minimum size 1 -->\n")
-	vpr_file.write("  <port name=\"out2\" clock=\"clk\"/>   <!-- output can be broken down into smaller bit widths minimum size 1 -->\n")
-	vpr_file.write("  </output_ports>\n")
-	vpr_file.write("</model>\n")
-
-	vpr_file.write("</models>\n")
-	vpr_file.write("<!-- ODIN II specific config ends -->\n")
-	vpr_file.write("<!-- Physical descriptions begin -->\n")
-	vpr_file.write("<layout>\n")
-	vpr_file.write("<auto_layout aspect_ratio=\"1.0\">\n")
-	vpr_file.write("<perimeter type=\"io\" priority=\"100\"/>\n")
-	vpr_file.write("<corners type=\"EMPTY\" priority=\"101\"/>\n")
-	vpr_file.write("<fill type=\"clb\" priority=\"10\"/>\n")
-	vpr_file.write("<col type=\"mult_36\" startx=\"4\" starty=\"1\" repeatx=\"8\" priority=\"20\" />\n")
-	vpr_file.write("<col type=\"EMPTY\" startx=\"4\" starty=\"1\" repeatx=\"8\" priority=\"19\" />\n")
-	vpr_file.write("<col type=\"memory\" startx=\"2\" starty=\"1\" repeatx=\"8\" priority=\"20\" />\n")
-	vpr_file.write("<col type=\"EMPTY\" startx=\"2\" starty=\"1\" repeatx=\"8\" priority=\"19\" />\n")
-	vpr_file.write("</auto_layout>\n")
-	vpr_file.write("</layout>\n")
-
-	vpr_file.write("  <device>\n")
-	vpr_file.write("    <sizing R_minW_nmos=\"13090.000000\" R_minW_pmos=\"19086.831111\"/> \n") #ipin_mux_trans_size=\"" + str(ipin_mux_trans_size)+ "\"/>\n
-	vpr_file.write("    <area grid_logic_tile_area=\"" + str(grid_logic_tile_area) +"\"/>\n")
-	vpr_file.write("    <chan_width_distr>\n")
-	vpr_file.write("      <x distr=\"uniform\" peak=\"1.000000\"/>\n")
-	vpr_file.write("      <y distr=\"uniform\" peak=\"1.000000\"/>\n")
-	vpr_file.write("    </chan_width_distr>\n")
-	vpr_file.write("    <switch_block type=\"wilton\" fs=\"" + str(Fs) + "\"/>\n")
-	vpr_file.write("    <connection_block input_switch_name=\"ipin_cblock\"/>\n")
-	vpr_file.write("  </device>\n")
-
-	
-	vpr_file.write("  <switchlist>\n")
-	vpr_file.write("    <switch type=\"mux\" name=\"0\" R=\"0.000000\" Cin=\"0.000000e+00\" Cout=\"0.000000e+00\" Tdel=\"" + str(Tdel) + "\" mux_trans_size=\"" + str(mux_trans_size) + "\" buf_size=\"" + str(buf_size) + "\"/>\n")
-	vpr_file.write("    <switch type=\"mux\" name=\"ipin_cblock\" R=\"0.000000\" Cin=\"0.000000e+00\" Cout=\"0.000000e+00\" Tdel=\"" + str(T_ipin_cblock) + "\" mux_trans_size=\"" + str(ipin_mux_trans_size) + "\" buf_size=\"" + str(cb_buf_size) + "\"/>\n")
-	vpr_file.write("  </switchlist>\n")
-
-	vpr_file.write("  <segmentlist>\n")
-	vpr_file.write("    <segment freq=\"1.000000\" length=\"" + str(L) + "\" type=\"unidir\" Rmetal=\"0.000000\" Cmetal=\"0.000000e+00\">\n")
-	vpr_file.write("    <mux name=\"0\"/>\n")
-	vpr_file.write("    <sb type=\"pattern\">1 1 1 1 1</sb>\n")
-	vpr_file.write("    <cb type=\"pattern\">1 1 1 1</cb>\n")
-	vpr_file.write("    </segment>\n")
-	vpr_file.write("  </segmentlist>\n")
-
-	vpr_file.write("  <complexblocklist>\n")
-	vpr_file.write("      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->\n")
-	vpr_file.write("     <pb_type name=\"io\" capacity=\"8\">\n")
-	vpr_file.write("       <input name=\"outpad\" num_pins=\"1\"/>\n")
-	vpr_file.write("       <output name=\"inpad\" num_pins=\"1\"/>\n")
-	vpr_file.write("       <clock name=\"clock\" num_pins=\"1\"/>\n")
-	vpr_file.write("    <!-- IOs can operate as either inputs or outputs -->\n")
-	vpr_file.write("    <mode name=\"inpad\">\n")
-	vpr_file.write("      <pb_type name=\"inpad\" blif_model=\".input\" num_pb=\"1\">\n")
-	vpr_file.write("        <output name=\"inpad\" num_pins=\"1\"/>\n")
-	vpr_file.write("      </pb_type>\n")
-	vpr_file.write("      <interconnect>\n")
-	vpr_file.write("        <direct name=\"inpad\" input=\"inpad.inpad\" output=\"io.inpad\">\n")
-	vpr_file.write("        <delay_constant max=\"4.243e-11\" in_port=\"inpad.inpad\" out_port=\"io.inpad\"/>\n")
-	vpr_file.write("        </direct>\n")
-	vpr_file.write("      </interconnect>  \n")
-	vpr_file.write("    </mode>\n")
-	vpr_file.write("    <mode name=\"outpad\">\n")
-	vpr_file.write("      <pb_type name=\"outpad\" blif_model=\".output\" num_pb=\"1\">\n")
-	vpr_file.write("        <input name=\"outpad\" num_pins=\"1\"/>\n")
-	vpr_file.write("      </pb_type>\n")
-	vpr_file.write("      <interconnect>\n")
-	vpr_file.write("        <direct name=\"outpad\" input=\"io.outpad\" output=\"outpad.outpad\">\n")
-	vpr_file.write("        <delay_constant max=\"1.394e-11\" in_port=\"io.outpad\" out_port=\"outpad.outpad\"/>\n")
-	vpr_file.write("        </direct>\n")
-	vpr_file.write("      </interconnect>\n")
-	vpr_file.write("    </mode>\n")
-	vpr_file.write("    <fc default_in_type=\"frac\" default_in_val=\"0.15\" default_out_type=\"frac\" default_out_val=\"0.10\"/>\n")
-	vpr_file.write("    <!-- IOs go on the periphery of the FPGA, for consistency, \n")
-	vpr_file.write("      make it physically equivalent on all sides so that only one definition of I/Os is needed.\n")
-	vpr_file.write("      If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA\n")
-	vpr_file.write("    -->\n")
-	vpr_file.write("    <pinlocations pattern=\"custom\">\n")
-	vpr_file.write("      <loc side=\"left\">io.outpad io.inpad io.clock</loc>\n")
-	vpr_file.write("      <loc side=\"top\">io.outpad io.inpad io.clock</loc>\n")
-	vpr_file.write("      <loc side=\"right\">io.outpad io.inpad io.clock</loc>\n")
-	vpr_file.write("      <loc side=\"bottom\">io.outpad io.inpad io.clock</loc>\n")
-	vpr_file.write("    </pinlocations>\n")
-
-	vpr_file.write("  </pb_type>\n")
-	vpr_file.write("  <!-- Logic cluster definition -->\n")
-	vpr_file.write("  <pb_type name=\"clb\" area=\""+str(grid_logic_tile_area)+"\">\n")
-	vpr_file.write("    <input name=\"I1\" num_pins=\"" + str(N) + "\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <input name=\"I2\" num_pins=\"" + str(N) + "\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <input name=\"I3\" num_pins=\"" + str(N) + "\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <input name=\"I4\" num_pins=\"" + str(N) + "\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O1\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O2\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O3\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O4\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O5\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O6\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O7\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O8\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O9\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O10\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <clock name=\"clk\" num_pins=\"1\"/>")
-
-	vpr_file.write("  <!-- Basic logic element definition -->\n")
-	vpr_file.write("  <pb_type name=\"ble6\" num_pb=\"" + str(N) + "\">\n")
-	vpr_file.write("  <input name=\"in_A\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_B\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_C\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_D\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_E\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_F\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <output name=\"out_local\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <output name=\"out_routing\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("  <clock name=\"clk\" num_pins=\"1\"/> \n")
-	vpr_file.write("  <pb_type name=\"lut6\" blif_model=\".names\" num_pb=\"1\" class=\"lut\">\n")
-	vpr_file.write("  <input name=\"in\" num_pins=\"" + str(K) + "\" port_class=\"lut_in\"/>\n")
-	vpr_file.write("  <output name=\"out\" num_pins=\"1\" port_class=\"lut_out\"/>\n")
-	vpr_file.write("  <!-- We define the LUT delays on the LUT pins instead of through the LUT -->\n")
-	vpr_file.write("  <delay_matrix type=\"max\" in_port=\"lut6.in\" out_port=\"lut6.out\">\n")
-	vpr_file.write("     0\n")
-	vpr_file.write("     0\n")
-	vpr_file.write("     0\n")
-	vpr_file.write("     0\n")
-	vpr_file.write("     0\n")
-	vpr_file.write("     0\n")
-	vpr_file.write("  </delay_matrix>\n")
-	vpr_file.write("  </pb_type>\n")
-	vpr_file.write("  <pb_type name=\"ff\" blif_model=\".latch\" num_pb=\"1\" class=\"flipflop\">\n")
-	vpr_file.write("  <input name=\"D\" num_pins=\"1\" port_class=\"D\"/>\n")
-	vpr_file.write("  <output name=\"Q\" num_pins=\"1\" port_class=\"Q\"/>\n")
-	vpr_file.write("  <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
-	vpr_file.write("  <T_setup value=\"1.891e-11\" port=\"ff.D\" clock=\"clk\"/>\n")
-	vpr_file.write("  <T_clock_to_Q max=\"6.032e-11\" port=\"ff.Q\" clock=\"clk\"/>\n")
-	vpr_file.write("  </pb_type>\n")
-
-	vpr_file.write("      <interconnect>\n")
-
-
-	feedback_mux = {}
-	input_num = 0
-	direct_num = 1
-	for input_name in lut_input_names:
-		if Rfb.count(input_name) != 1 :
-			vpr_file.write("    <direct name=\"direct" + str(input_num) + "\" input=\"ble6.in_" + input_name.upper() + "\" output=\"lut6.in[" + str(input_num) + ":" + str(input_num) + "]\">\n")
-			vpr_file.write("      <delay_constant max=\"" + str(lut_delays[input_name]) + "\" in_port=\"ble6.in_" + input_name.upper() + "\" out_port=\"lut6.in[" + str(input_num) + ":" + str(input_num) + "]\" />\n")
-			vpr_file.write("    </direct>\n")
-			direct_num = direct_num + 1
-
-		else:
-			feedback_mux[input_name] = input_num
-
-		input_num = input_num + 1
-
-	vpr_file.write("      <!--Clock -->\n")
-	vpr_file.write("      <direct name=\"direct" + str(direct_num) + "\" input=\"ble6.clk\" output=\"ff.clk\"/>\n")
-
-
-	mux_num = 1
-	for name in feedback_mux :
-		vpr_file.write("      <!-- Register feedback mux -->   \n")
-		vpr_file.write("      <mux name=\"mux" + str(mux_num) + "\" input=\"ble6.in_" + name.upper() + " ff.Q\" output=\"lut6.in[" + str(feedback_mux[name]) + ":" + str(feedback_mux[name]) + "]\">\n")
-		vpr_file.write("        <delay_constant max=\"" + str(lut_delays[name]) + "\" in_port=\"ble6.in_" + name.upper() + "\" out_port=\"lut6.in[" + str(feedback_mux[name]) + ":" + str(feedback_mux[name]) + "]\" />\n")
-		vpr_file.write("        <delay_constant max=\"" + str(lut_delays[name]) + "\" in_port=\"ff.Q\" out_port=\"lut6.in[" + str(feedback_mux[name]) + ":" + str(feedback_mux[name]) + "]\" />  \n")
-		vpr_file.write("      </mux>\n")
-		mux_num = mux_num + 1
-		vpr_file.write("      <!-- FF input selection mux -->\n")
-		vpr_file.write("      <mux name=\"" + str(mux_num) + "\" input=\"lut6.out ble6.in_" + name.upper() + "\" output=\"ff.D\">\n")
-		vpr_file.write("        <delay_constant max=\"1.74588e-11\" in_port=\"lut6.out\" out_port=\"ff.D\" />\n")
-		vpr_file.write("        <delay_constant max=\"1.74588e-11\" in_port=\"ble6.in_" + name.upper() + "\" out_port=\"ff.D\" />\n")
-		vpr_file.write("      </mux>\n")
-		mux_num = mux_num + 1
-
-
-	vpr_file.write("      <!-- BLE output (local) -->\n")
-	vpr_file.write("      <mux name=\"mux" + str(mux_num) + "\" input=\"ff.Q lut6.out\" output=\"ble6.out_local\">\n")
-	vpr_file.write("        <delay_constant max=\"" + str(local_feedback) + "\" in_port=\"ff.Q\" out_port=\"ble6.out_local\" />\n")
-	vpr_file.write("        <delay_constant max=\"" + str(local_feedback) + "\" in_port=\"lut6.out\" out_port=\"ble6.out_local\" />\n")
-	vpr_file.write("      </mux>\n")
-	mux_num = mux_num + 1
-
-	vpr_file.write("      <!-- BLE output (routing 1) --> \n")
-	vpr_file.write("      <mux name=\"mux" + str(mux_num) + "\" input=\"ff.Q lut6.out\" output=\"ble6.out_routing[0:0]\">\n")
-	vpr_file.write("        <delay_constant max=\"" + str(logic_block_output)+ "\" in_port=\"ff.Q\" out_port=\"ble6.out_routing[0:0]\" />\n")
-	vpr_file.write("        <delay_constant max=\"" + str(logic_block_output)+ "\" in_port=\"lut6.out\" out_port=\"ble6.out_routing[0:0]\" />\n")
-	vpr_file.write("      </mux>\n")
-	mux_num = mux_num + 1
-
-	vpr_file.write("      <!-- BLE output (routing 2) --> \n")
-	vpr_file.write("      <mux name=\"mux" + str(mux_num) + "\" input=\"ff.Q lut6.out\" output=\"ble6.out_routing[1:1]\">\n")
-	vpr_file.write("        <delay_constant max=\"" + str(logic_block_output)+ "\" in_port=\"ff.Q\" out_port=\"ble6.out_routing[1:1]\" />\n")
-	vpr_file.write("        <delay_constant max=\"" + str(logic_block_output)+ "\" in_port=\"lut6.out\" out_port=\"ble6.out_routing[1:1]\" />\n")
-	vpr_file.write("      </mux>\n")
-	vpr_file.write("      </interconnect>\n")
-	vpr_file.write("    </pb_type>\n")
         
-	vpr_file.write("    <interconnect>\n")
-	vpr_file.write("    <!-- 50% sparsely populated local routing -->\n")
-	vpr_file.write("    <complete name=\"lutA\" input=\"clb.I4 clb.I3 ble6[1:0].out_local ble6[3:2].out_local ble6[8:8].out_local\" output=\"ble6[9:0].in_A\">\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I4\" out_port=\"ble6.in_A\" />\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I3\" out_port=\"ble6.in_A\" />\n")
-	vpr_file.write("      </complete>\n")
-	vpr_file.write("    <complete name=\"lutB\" input=\"clb.I3 clb.I2 ble6[3:2].out_local ble6[5:4].out_local ble6[9:9].out_local\" output=\"ble6[9:0].in_B\">\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I3\" out_port=\"ble6.in_B\" />\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I2\" out_port=\"ble6.in_B\" />\n")
-	vpr_file.write("      </complete>\n")
-	vpr_file.write("    <complete name=\"lutC\" input=\"clb.I2 clb.I1 ble6[5:4].out_local ble6[7:6].out_local ble6[8:8].out_local\" output=\"ble6[9:0].in_C\">\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I2\" out_port=\"ble6.in_C\" />\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I1\" out_port=\"ble6.in_C\" />\n")
-	vpr_file.write("      </complete>\n")
-	vpr_file.write("    <complete name=\"lutD\" input=\"clb.I4 clb.I2 ble6[1:0].out_local ble6[5:4].out_local ble6[9:9].out_local\" output=\"ble6[9:0].in_D\">\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I4\" out_port=\"ble6.in_D\" />\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I2\" out_port=\"ble6.in_D\" />\n")
-	vpr_file.write("      </complete>\n")
-	vpr_file.write("    <complete name=\"lutE\" input=\"clb.I3 clb.I1 ble6[3:2].out_local ble6[7:6].out_local ble6[8:8].out_local\" output=\"ble6[9:0].in_E\">\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I3\" out_port=\"ble6.in_E\" />\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I1\" out_port=\"ble6.in_E\" />\n")
-	vpr_file.write("      </complete>\n")
-	vpr_file.write("    <complete name=\"lutF\" input=\"clb.I4 clb.I1 ble6[1:0].out_local ble6[7:6].out_local ble6[9:9].out_local\" output=\"ble6[9:0].in_F\">\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I4\" out_port=\"ble6.in_F\" />\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I1\" out_port=\"ble6.in_F\" />\n")
-	vpr_file.write("      </complete>\n")
-	vpr_file.write("      <complete name=\"clks\" input=\"clb.clk\" output=\"ble6[9:0].clk\">\n")
-	vpr_file.write("      </complete>\n")
-	          
-	vpr_file.write("      <!-- Direct connections to CLB outputs -->\n")
-	vpr_file.write("      <direct name=\"clbouts1\" input=\"ble6[0:0].out_routing\" output=\"clb.O1\"/>\n")
-	vpr_file.write("      <direct name=\"clbouts2\" input=\"ble6[1:1].out_routing\" output=\"clb.O2\"/>\n")
-	vpr_file.write("      <direct name=\"clbouts3\" input=\"ble6[2:2].out_routing\" output=\"clb.O3\"/>\n")
-	vpr_file.write("      <direct name=\"clbouts4\" input=\"ble6[3:3].out_routing\" output=\"clb.O4\"/>\n")
-	vpr_file.write("      <direct name=\"clbouts5\" input=\"ble6[4:4].out_routing\" output=\"clb.O5\"/>\n")
-	vpr_file.write("      <direct name=\"clbouts6\" input=\"ble6[5:5].out_routing\" output=\"clb.O6\"/>\n")
-	vpr_file.write("      <direct name=\"clbouts7\" input=\"ble6[6:6].out_routing\" output=\"clb.O7\"/>\n")
-	vpr_file.write("      <direct name=\"clbouts8\" input=\"ble6[7:7].out_routing\" output=\"clb.O8\"/>\n")
-	vpr_file.write("      <direct name=\"clbouts9\" input=\"ble6[8:8].out_routing\" output=\"clb.O9\"/>\n")
-	vpr_file.write("      <direct name=\"clbouts10\" input=\"ble6[9:9].out_routing\" output=\"clb.O10\"/>\n")
+    # get areas
+    grid_logic_tile_area = fpga_inst.area_dict["logic_cluster"]/fpga_inst.specs.min_width_tran_area
+    if grid_logic_tile_area < 1.00 :
+        grid_logic_tile_area = 1.00
+    ipin_mux_trans_size = fpga_inst.area_dict["ipin_mux_trans_size"]/fpga_inst.specs.min_width_tran_area
+    if ipin_mux_trans_size < 1.00 :
+        ipin_mux_trans_size = 1.00
+    mux_trans_size = fpga_inst.area_dict["switch_mux_trans_size"]/fpga_inst.specs.min_width_tran_area
+    if mux_trans_size < 1.00 :
+        mux_trans_size = 1.00
+    buf_size = fpga_inst.area_dict["switch_buf_size"]/fpga_inst.specs.min_width_tran_area
+    if buf_size < 1.00 :
+        buf_size = 1.00
 
-	vpr_file.write("    </interconnect>\n")
-	vpr_file.write("    <fc default_in_type=\"frac\" default_in_val=\"" + str(Fcin) + "\" default_out_type=\"frac\" default_out_val=\"" + str(Fcout) + "\"/>\n")
-	vpr_file.write("    <!-- Two sided connectivity CLB architecture--> \n")
-	vpr_file.write("    <pinlocations pattern=\"custom\">\n")
-	vpr_file.write("  <loc side=\"right\">clb.O1 clb.O2 clb.O3 clb.O4 clb.O5 clb.I1 clb.I3 clb.clk</loc> \n")
-	vpr_file.write("      <loc side=\"bottom\">clb.O6 clb.O7 clb.O8 clb.O9 clb.O10 clb.I2 clb.I4 clb.clk</loc>      \n")
-	vpr_file.write("    </pinlocations>\n")
-	vpr_file.write("  </pb_type>\n")
+    # get memory information
+    memory_height = int(round(fpga_inst.area_dict["ram"]/fpga_inst.area_dict["tile"], 0))
+    memory_max_width =  2 ** fpga_inst.RAM.conf_decoder_bits
+    memory_address_bits = fpga_inst.specs.row_decoder_bits + fpga_inst.specs.col_decoder_bits + fpga_inst.specs.conf_decoder_bits
+    memory_max_depth = 2 ** (fpga_inst.specs.row_decoder_bits + fpga_inst.specs.col_decoder_bits + fpga_inst.specs.conf_decoder_bits)
+    memory_clktoq = fpga_inst.RAM.frequency
+    memory_setup_time = fpga_inst.RAM.RAM_local_mux.delay + 52.3e-12
+    memory_input_mux_size = 25
+    # Todo: I can add output mux size and create a crossbar at the output. Not sure if it will actually help. 
+    cb_buf_size = fpga_inst.area_dict["cb_buf_size"]/fpga_inst.specs.min_width_tran_area
+    if cb_buf_size < 1.00:
+        cb_buf_size = 1.00
 
-	vpr_file.write("  <!-- This is the 36*36 uniform mult -->\n")
-	vpr_file.write("  <pb_type name=\"mult_36\" height=\"4\" area=\"118800\">\n")
-	vpr_file.write("      <input name=\"a\" num_pins=\"36\"/>\n")
-	vpr_file.write("      <input name=\"b\" num_pins=\"36\"/>\n")
-	vpr_file.write("      <output name=\"out\" num_pins=\"72\"/>\n")
+    vpr_file.write("<architecture>  \n")
+    vpr_file.write("<!-- ODIN II specific config -->\n")
+    vpr_file.write("<models>\n")
+    vpr_file.write("  <model name=\"multiply\">\n")
+    vpr_file.write("    <input_ports>\n")
+    vpr_file.write("    <port name=\"a\" combinational_sink_ports=\"out\"/> \n")
+    vpr_file.write("    <port name=\"b\" combinational_sink_ports=\"out\"/>\n")
+    vpr_file.write("    </input_ports>\n")
+    vpr_file.write("    <output_ports>\n")
+    vpr_file.write("    <port name=\"out\"/>\n")
+    vpr_file.write("    </output_ports>\n")
+    vpr_file.write("  </model>\n")
+        
+    vpr_file.write("<model name=\"single_port_ram\">\n")
+    vpr_file.write("  <input_ports>\n")
+    vpr_file.write("  <port name=\"we\" clock=\"clk\"/>     <!-- control -->\n")
+    vpr_file.write("  <port name=\"addr\" clock=\"clk\"/>  <!-- address lines -->\n")
+    vpr_file.write("  <port name=\"data\" clock=\"clk\"/>  <!-- data lines can be broken down into smaller bit widths minimum size 1 -->\n")
+    vpr_file.write("  <port name=\"clk\" is_clock=\"1\"/>  <!-- memories are often clocked -->\n")
+    vpr_file.write("  </input_ports>\n")
+    vpr_file.write("  <output_ports>\n")
+    vpr_file.write("  <port name=\"out\" clock=\"clk\"/>   <!-- output can be broken down into smaller bit widths minimum size 1 -->\n")
+    vpr_file.write("  </output_ports>\n")
+    vpr_file.write("</model>\n")
 
-	vpr_file.write("      <mode name=\"two_divisible_mult_18x18\">\n")
-	vpr_file.write("        <pb_type name=\"divisible_mult_18x18\" num_pb=\"2\">\n")
-	vpr_file.write("          <input name=\"a\" num_pins=\"18\"/>\n")
-	vpr_file.write("          <input name=\"b\" num_pins=\"18\"/>\n")
-	vpr_file.write("          <output name=\"out\" num_pins=\"36\"/>\n")
+    vpr_file.write("<model name=\"dual_port_ram\">\n")
+    vpr_file.write("  <input_ports>\n")
+    vpr_file.write("  <port name=\"we1\" clock=\"clk\"/>     <!-- write enable -->\n")
+    vpr_file.write("  <port name=\"we2\" clock=\"clk\"/>     <!-- write enable -->\n")
+    vpr_file.write("  <port name=\"addr1\" clock=\"clk\"/>  <!-- address lines -->\n")
+    vpr_file.write("  <port name=\"addr2\" clock=\"clk\"/>  <!-- address lines -->\n")
+    vpr_file.write("  <port name=\"data1\" clock=\"clk\"/>  <!-- data lines can be broken down into smaller bit widths minimum size 1 -->\n")
+    vpr_file.write("  <port name=\"data2\" clock=\"clk\"/>  <!-- data lines can be broken down into smaller bit widths minimum size 1 -->\n")
+    vpr_file.write("  <port name=\"clk\" is_clock=\"1\"/>  <!-- memories are often clocked -->\n")
+    vpr_file.write("  </input_ports>\n")
+    vpr_file.write("  <output_ports>\n")
+    vpr_file.write("  <port name=\"out1\" clock=\"clk\"/>   <!-- output can be broken down into smaller bit widths minimum size 1 -->\n")
+    vpr_file.write("  <port name=\"out2\" clock=\"clk\"/>   <!-- output can be broken down into smaller bit widths minimum size 1 -->\n")
+    vpr_file.write("  </output_ports>\n")
+    vpr_file.write("</model>\n")
 
-	vpr_file.write("          <mode name=\"two_mult_9x9\">\n")
-	vpr_file.write("            <pb_type name=\"mult_9x9_slice\" num_pb=\"2\">\n")
-	vpr_file.write("              <input name=\"A_cfg\" num_pins=\"9\"/>\n")
-	vpr_file.write("              <input name=\"B_cfg\" num_pins=\"9\"/>\n")
-	vpr_file.write("              <output name=\"OUT_cfg\" num_pins=\"18\"/>\n")
+    vpr_file.write("</models>\n")
+    vpr_file.write("<!-- ODIN II specific config ends -->\n")
+    vpr_file.write("<!-- Physical descriptions begin -->\n")
+    vpr_file.write("<layout>\n")
+    vpr_file.write("<auto_layout aspect_ratio=\"1.0\">\n")
+    vpr_file.write("<perimeter type=\"io\" priority=\"100\"/>\n")
+    vpr_file.write("<corners type=\"EMPTY\" priority=\"101\"/>\n")
+    vpr_file.write("<fill type=\"clb\" priority=\"10\"/>\n")
+    vpr_file.write("<col type=\"mult_36\" startx=\"4\" starty=\"1\" repeatx=\"8\" priority=\"20\" />\n")
+    vpr_file.write("<col type=\"EMPTY\" startx=\"4\" starty=\"1\" repeatx=\"8\" priority=\"19\" />\n")
+    vpr_file.write("<col type=\"memory\" startx=\"2\" starty=\"1\" repeatx=\"8\" priority=\"20\" />\n")
+    vpr_file.write("<col type=\"EMPTY\" startx=\"2\" starty=\"1\" repeatx=\"8\" priority=\"19\" />\n")
+    vpr_file.write("</auto_layout>\n")
+    vpr_file.write("</layout>\n")
 
-	vpr_file.write("              <pb_type name=\"mult_9x9\" blif_model=\".subckt multiply\" num_pb=\"1\">\n")
-	vpr_file.write("                <input name=\"a\" num_pins=\"9\"/>\n")
-	vpr_file.write("                <input name=\"b\" num_pins=\"9\"/>\n")
-	vpr_file.write("                <output name=\"out\" num_pins=\"18\"/>\n")
-	vpr_file.write("                <delay_constant max=\"1.667e-9\" in_port=\"mult_9x9.a\" out_port=\"mult_9x9.out\"/>\n")
-	vpr_file.write("                <delay_constant max=\"1.667e-9\" in_port=\"mult_9x9.b\" out_port=\"mult_9x9.out\"/>\n")
-	vpr_file.write("              </pb_type>\n")
+    vpr_file.write("  <device>\n")
+    vpr_file.write("    <sizing R_minW_nmos=\"13090.000000\" R_minW_pmos=\"19086.831111\"/> \n") #ipin_mux_trans_size=\"" + str(ipin_mux_trans_size)+ "\"/>\n
+    vpr_file.write("    <area grid_logic_tile_area=\"" + str(grid_logic_tile_area) +"\"/>\n")
+    vpr_file.write("    <chan_width_distr>\n")
+    vpr_file.write("      <x distr=\"uniform\" peak=\"1.000000\"/>\n")
+    vpr_file.write("      <y distr=\"uniform\" peak=\"1.000000\"/>\n")
+    vpr_file.write("    </chan_width_distr>\n")
+    vpr_file.write("    <switch_block type=\"wilton\" fs=\"" + str(Fs) + "\"/>\n")
+    vpr_file.write("    <connection_block input_switch_name=\"ipin_cblock\"/>\n")
+    vpr_file.write("  </device>\n")
 
-	vpr_file.write("              <interconnect>\n")
-	vpr_file.write("                <direct name=\"a2a\" input=\"mult_9x9_slice.A_cfg\" output=\"mult_9x9.a\">\n")
-	vpr_file.write("                </direct>\n")
-	vpr_file.write("                <direct name=\"b2b\" input=\"mult_9x9_slice.B_cfg\" output=\"mult_9x9.b\">\n")
-	vpr_file.write("                </direct>\n")
-	vpr_file.write("                <direct name=\"out2out\" input=\"mult_9x9.out\" output=\"mult_9x9_slice.OUT_cfg\">\n")
-	vpr_file.write("                </direct>\n")
-	vpr_file.write("              </interconnect>\n")
-	vpr_file.write("            </pb_type>\n")
-	vpr_file.write("            <interconnect>\n")
-	vpr_file.write("              <direct name=\"a2a\" input=\"divisible_mult_18x18.a\" output=\"mult_9x9_slice[1:0].A_cfg\">\n")
-	vpr_file.write("              </direct>\n")
-	vpr_file.write("              <direct name=\"b2b\" input=\"divisible_mult_18x18.b\" output=\"mult_9x9_slice[1:0].B_cfg\">\n")
-	vpr_file.write("              </direct>\n")
-	vpr_file.write("              <direct name=\"out2out\" input=\"mult_9x9_slice[1:0].OUT_cfg\" output=\"divisible_mult_18x18.out\">\n")
-	vpr_file.write("              </direct>\n")
-	vpr_file.write("            </interconnect>\n")
-	vpr_file.write("          </mode>\n")
+    
+    vpr_file.write("  <switchlist>\n")
+    vpr_file.write("    <switch type=\"mux\" name=\"0\" R=\"0.000000\" Cin=\"0.000000e+00\" Cout=\"0.000000e+00\" Tdel=\"" + str(Tdel) + "\" mux_trans_size=\"" + str(mux_trans_size) + "\" buf_size=\"" + str(buf_size) + "\"/>\n")
+    vpr_file.write("    <switch type=\"mux\" name=\"ipin_cblock\" R=\"0.000000\" Cin=\"0.000000e+00\" Cout=\"0.000000e+00\" Tdel=\"" + str(T_ipin_cblock) + "\" mux_trans_size=\"" + str(ipin_mux_trans_size) + "\" buf_size=\"" + str(cb_buf_size) + "\"/>\n")
+    vpr_file.write("  </switchlist>\n")
 
-	vpr_file.write("          <mode name=\"mult_18x18\">\n")
-	vpr_file.write("            <pb_type name=\"mult_18x18_slice\" num_pb=\"1\">\n")
-	vpr_file.write("              <input name=\"A_cfg\" num_pins=\"18\"/>\n")
-	vpr_file.write("              <input name=\"B_cfg\" num_pins=\"18\"/>\n")
-	vpr_file.write("              <output name=\"OUT_cfg\" num_pins=\"36\"/>\n")
+    vpr_file.write("  <segmentlist>\n")
+    vpr_file.write("    <segment freq=\"1.000000\" length=\"" + str(L) + "\" type=\"unidir\" Rmetal=\"0.000000\" Cmetal=\"0.000000e+00\">\n")
+    vpr_file.write("    <mux name=\"0\"/>\n")
+    vpr_file.write("    <sb type=\"pattern\">1 1 1 1 1</sb>\n")
+    vpr_file.write("    <cb type=\"pattern\">1 1 1 1</cb>\n")
+    vpr_file.write("    </segment>\n")
+    vpr_file.write("  </segmentlist>\n")
 
-	vpr_file.write("              <pb_type name=\"mult_18x18\" blif_model=\".subckt multiply\" num_pb=\"1\" >\n")
-	vpr_file.write("                <input name=\"a\" num_pins=\"18\"/>\n")
-	vpr_file.write("                <input name=\"b\" num_pins=\"18\"/>\n")
-	vpr_file.write("                <output name=\"out\" num_pins=\"36\"/>\n")
-	vpr_file.write("                <delay_constant max=\"1.667e-9\" in_port=\"mult_18x18.a\" out_port=\"mult_18x18.out\"/>\n")
-	vpr_file.write("                <delay_constant max=\"1.667e-9\" in_port=\"mult_18x18.b\" out_port=\"mult_18x18.out\"/>\n")
-	vpr_file.write("              </pb_type>\n")
+    vpr_file.write("  <complexblocklist>\n")
+    vpr_file.write("      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->\n")
+    vpr_file.write("     <pb_type name=\"io\" capacity=\"8\">\n")
+    vpr_file.write("       <input name=\"outpad\" num_pins=\"1\"/>\n")
+    vpr_file.write("       <output name=\"inpad\" num_pins=\"1\"/>\n")
+    vpr_file.write("       <clock name=\"clock\" num_pins=\"1\"/>\n")
+    vpr_file.write("    <!-- IOs can operate as either inputs or outputs -->\n")
+    vpr_file.write("    <mode name=\"inpad\">\n")
+    vpr_file.write("      <pb_type name=\"inpad\" blif_model=\".input\" num_pb=\"1\">\n")
+    vpr_file.write("        <output name=\"inpad\" num_pins=\"1\"/>\n")
+    vpr_file.write("      </pb_type>\n")
+    vpr_file.write("      <interconnect>\n")
+    vpr_file.write("        <direct name=\"inpad\" input=\"inpad.inpad\" output=\"io.inpad\">\n")
+    vpr_file.write("        <delay_constant max=\"4.243e-11\" in_port=\"inpad.inpad\" out_port=\"io.inpad\"/>\n")
+    vpr_file.write("        </direct>\n")
+    vpr_file.write("      </interconnect>  \n")
+    vpr_file.write("    </mode>\n")
+    vpr_file.write("    <mode name=\"outpad\">\n")
+    vpr_file.write("      <pb_type name=\"outpad\" blif_model=\".output\" num_pb=\"1\">\n")
+    vpr_file.write("        <input name=\"outpad\" num_pins=\"1\"/>\n")
+    vpr_file.write("      </pb_type>\n")
+    vpr_file.write("      <interconnect>\n")
+    vpr_file.write("        <direct name=\"outpad\" input=\"io.outpad\" output=\"outpad.outpad\">\n")
+    vpr_file.write("        <delay_constant max=\"1.394e-11\" in_port=\"io.outpad\" out_port=\"outpad.outpad\"/>\n")
+    vpr_file.write("        </direct>\n")
+    vpr_file.write("      </interconnect>\n")
+    vpr_file.write("    </mode>\n")
+    vpr_file.write("    <fc default_in_type=\"frac\" default_in_val=\"0.15\" default_out_type=\"frac\" default_out_val=\"0.10\"/>\n")
+    vpr_file.write("    <!-- IOs go on the periphery of the FPGA, for consistency, \n")
+    vpr_file.write("      make it physically equivalent on all sides so that only one definition of I/Os is needed.\n")
+    vpr_file.write("      If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA\n")
+    vpr_file.write("    -->\n")
+    vpr_file.write("    <pinlocations pattern=\"custom\">\n")
+    vpr_file.write("      <loc side=\"left\">io.outpad io.inpad io.clock</loc>\n")
+    vpr_file.write("      <loc side=\"top\">io.outpad io.inpad io.clock</loc>\n")
+    vpr_file.write("      <loc side=\"right\">io.outpad io.inpad io.clock</loc>\n")
+    vpr_file.write("      <loc side=\"bottom\">io.outpad io.inpad io.clock</loc>\n")
+    vpr_file.write("    </pinlocations>\n")
 
-	vpr_file.write("              <interconnect>\n")
-	vpr_file.write("                <direct name=\"a2a\" input=\"mult_18x18_slice.A_cfg\" output=\"mult_18x18.a\">\n")
-	vpr_file.write("                </direct>\n")
-	vpr_file.write("                <direct name=\"b2b\" input=\"mult_18x18_slice.B_cfg\" output=\"mult_18x18.b\">\n")
-	vpr_file.write("                </direct>\n")
-	vpr_file.write("                <direct name=\"out2out\" input=\"mult_18x18.out\" output=\"mult_18x18_slice.OUT_cfg\">\n")
-	vpr_file.write("                </direct>\n")
-	vpr_file.write("              </interconnect>\n")
-	vpr_file.write("            </pb_type>\n")
-	vpr_file.write("            <interconnect>\n")
-	vpr_file.write("              <direct name=\"a2a\" input=\"divisible_mult_18x18.a\" output=\"mult_18x18_slice.A_cfg\">\n")
-	vpr_file.write("              </direct>\n")
-	vpr_file.write("              <direct name=\"b2b\" input=\"divisible_mult_18x18.b\" output=\"mult_18x18_slice.B_cfg\">\n")
-	vpr_file.write("              </direct>\n")
-	vpr_file.write("              <direct name=\"out2out\" input=\"mult_18x18_slice.OUT_cfg\" output=\"divisible_mult_18x18.out\">\n")
-	vpr_file.write("              </direct>\n")
-	vpr_file.write("            </interconnect>\n")
-	vpr_file.write("          </mode>\n")
-	vpr_file.write("        </pb_type>\n")
-	vpr_file.write("        <interconnect>\n")
-	vpr_file.write("          <direct name=\"a2a\" input=\"mult_36.a\" output=\"divisible_mult_18x18[1:0].a\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"b2b\" input=\"mult_36.b\" output=\"divisible_mult_18x18[1:0].b\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"out2out\" input=\"divisible_mult_18x18[1:0].out\" output=\"mult_36.out\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("        </interconnect>\n")
-	vpr_file.write("      </mode>\n")
+    vpr_file.write("  </pb_type>\n")
+    vpr_file.write("  <!-- Logic cluster definition -->\n")
+    vpr_file.write("  <pb_type name=\"clb\" area=\""+str(grid_logic_tile_area)+"\">\n")
+    vpr_file.write("    <input name=\"I1\" num_pins=\"" + str(N) + "\" equivalent=\"true\"/>\n")
+    vpr_file.write("    <input name=\"I2\" num_pins=\"" + str(N) + "\" equivalent=\"true\"/>\n")
+    vpr_file.write("    <input name=\"I3\" num_pins=\"" + str(N) + "\" equivalent=\"true\"/>\n")
+    vpr_file.write("    <input name=\"I4\" num_pins=\"" + str(N) + "\" equivalent=\"true\"/>\n")
+    vpr_file.write("    <output name=\"O1\" num_pins=\"2\" equivalent=\"true\"/>\n")
+    vpr_file.write("    <output name=\"O2\" num_pins=\"2\" equivalent=\"true\"/>\n")
+    vpr_file.write("    <output name=\"O3\" num_pins=\"2\" equivalent=\"true\"/>\n")
+    vpr_file.write("    <output name=\"O4\" num_pins=\"2\" equivalent=\"true\"/>\n")
+    vpr_file.write("    <output name=\"O5\" num_pins=\"2\" equivalent=\"true\"/>\n")
+    vpr_file.write("    <output name=\"O6\" num_pins=\"2\" equivalent=\"true\"/>\n")
+    vpr_file.write("    <output name=\"O7\" num_pins=\"2\" equivalent=\"true\"/>\n")
+    vpr_file.write("    <output name=\"O8\" num_pins=\"2\" equivalent=\"true\"/>\n")
+    vpr_file.write("    <output name=\"O9\" num_pins=\"2\" equivalent=\"true\"/>\n")
+    vpr_file.write("    <output name=\"O10\" num_pins=\"2\" equivalent=\"true\"/>\n")
+    vpr_file.write("    <clock name=\"clk\" num_pins=\"1\"/>")
 
-	vpr_file.write("      <mode name=\"mult_36x36\">\n")
-	vpr_file.write("        <pb_type name=\"mult_36x36_slice\" num_pb=\"1\">\n")
-	vpr_file.write("          <input name=\"A_cfg\" num_pins=\"36\"/>\n")
-	vpr_file.write("          <input name=\"B_cfg\" num_pins=\"36\"/>\n")
-	vpr_file.write("          <output name=\"OUT_cfg\" num_pins=\"72\"/>\n")
+    vpr_file.write("  <!-- Basic logic element definition -->\n")
+    vpr_file.write("  <pb_type name=\"ble6\" num_pb=\"" + str(N) + "\">\n")
+    vpr_file.write("  <input name=\"in_A\" num_pins=\"1\" equivalent=\"false\"/>\n")
+    vpr_file.write("  <input name=\"in_B\" num_pins=\"1\" equivalent=\"false\"/>\n")
+    vpr_file.write("  <input name=\"in_C\" num_pins=\"1\" equivalent=\"false\"/>\n")
+    vpr_file.write("  <input name=\"in_D\" num_pins=\"1\" equivalent=\"false\"/>\n")
+    vpr_file.write("  <input name=\"in_E\" num_pins=\"1\" equivalent=\"false\"/>\n")
+    vpr_file.write("  <input name=\"in_F\" num_pins=\"1\" equivalent=\"false\"/>\n")
+    vpr_file.write("  <output name=\"out_local\" num_pins=\"1\" equivalent=\"false\"/>\n")
+    vpr_file.write("  <output name=\"out_routing\" num_pins=\"2\" equivalent=\"true\"/>\n")
+    vpr_file.write("  <clock name=\"clk\" num_pins=\"1\"/> \n")
+    vpr_file.write("  <pb_type name=\"lut6\" blif_model=\".names\" num_pb=\"1\" class=\"lut\">\n")
+    vpr_file.write("  <input name=\"in\" num_pins=\"" + str(K) + "\" port_class=\"lut_in\"/>\n")
+    vpr_file.write("  <output name=\"out\" num_pins=\"1\" port_class=\"lut_out\"/>\n")
+    vpr_file.write("  <!-- We define the LUT delays on the LUT pins instead of through the LUT -->\n")
+    vpr_file.write("  <delay_matrix type=\"max\" in_port=\"lut6.in\" out_port=\"lut6.out\">\n")
+    vpr_file.write("     0\n")
+    vpr_file.write("     0\n")
+    vpr_file.write("     0\n")
+    vpr_file.write("     0\n")
+    vpr_file.write("     0\n")
+    vpr_file.write("     0\n")
+    vpr_file.write("  </delay_matrix>\n")
+    vpr_file.write("  </pb_type>\n")
+    vpr_file.write("  <pb_type name=\"ff\" blif_model=\".latch\" num_pb=\"1\" class=\"flipflop\">\n")
+    vpr_file.write("  <input name=\"D\" num_pins=\"1\" port_class=\"D\"/>\n")
+    vpr_file.write("  <output name=\"Q\" num_pins=\"1\" port_class=\"Q\"/>\n")
+    vpr_file.write("  <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
+    vpr_file.write("  <T_setup value=\"1.891e-11\" port=\"ff.D\" clock=\"clk\"/>\n")
+    vpr_file.write("  <T_clock_to_Q max=\"6.032e-11\" port=\"ff.Q\" clock=\"clk\"/>\n")
+    vpr_file.write("  </pb_type>\n")
 
-	vpr_file.write("          <pb_type name=\"mult_36x36\" blif_model=\".subckt multiply\" num_pb=\"1\">\n")
-	vpr_file.write("            <input name=\"a\" num_pins=\"36\"/>\n")
-	vpr_file.write("            <input name=\"b\" num_pins=\"36\"/>\n")
-	vpr_file.write("            <output name=\"out\" num_pins=\"72\"/>\n")
-	vpr_file.write("            <delay_constant max=\"1.667e-9\" in_port=\"mult_36x36.a\" out_port=\"mult_36x36.out\"/>\n")
-	vpr_file.write("            <delay_constant max=\"1.667e-9\" in_port=\"mult_36x36.b\" out_port=\"mult_36x36.out\"/>\n")
-	vpr_file.write("          </pb_type>\n")
-
-	vpr_file.write("          <interconnect>\n")
-	vpr_file.write("            <direct name=\"a2a\" input=\"mult_36x36_slice.A_cfg\" output=\"mult_36x36.a\">\n")
-	vpr_file.write("            </direct>\n")
-	vpr_file.write("            <direct name=\"b2b\" input=\"mult_36x36_slice.B_cfg\" output=\"mult_36x36.b\">\n")
-	vpr_file.write("            </direct>\n")
-	vpr_file.write("            <direct name=\"out2out\" input=\"mult_36x36.out\" output=\"mult_36x36_slice.OUT_cfg\">\n")
-	vpr_file.write("            </direct>\n")
-	vpr_file.write("          </interconnect>\n")
-	vpr_file.write("        </pb_type>\n")
-	vpr_file.write("        <interconnect>\n")
-	vpr_file.write("          <direct name=\"a2a\" input=\"mult_36.a\" output=\"mult_36x36_slice.A_cfg\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"b2b\" input=\"mult_36.b\" output=\"mult_36x36_slice.B_cfg\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"out2out\" input=\"mult_36x36_slice.OUT_cfg\" output=\"mult_36.out\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("        </interconnect>\n")
-	vpr_file.write("      </mode>\n")
-
-	vpr_file.write("    <fc default_in_type=\"frac\" default_in_val=\"0.15\" default_out_type=\"frac\" default_out_val=\"0.10\"/>\n")
-	vpr_file.write("    <pinlocations pattern=\"spread\"/>\n")
-
-	vpr_file.write("  </pb_type>\n")
-
-
-	vpr_file.write("<!-- This is the Block RAM module  -->\n")
-
-	vpr_file.write("  <pb_type name=\"memory\" height=\""+str(memory_height)+"\" area=\""+str(fpga_inst.area_dict["ram_core"]/fpga_inst.specs.min_width_tran_area)+"\">\n")
-
-	vpr_file.write("      <input name=\"addr1\" num_pins=\""+str(memory_address_bits)+"\"/>\n")
-	vpr_file.write("      <input name=\"addr2\" num_pins=\""+str(memory_address_bits)+"\"/>\n")
-	
-	vpr_file.write("      <input name=\"data\" num_pins=\""+str(memory_max_width)+"\"/>\n")
-	
-	vpr_file.write("      <input name=\"we1\" num_pins=\"1\"/>\n")
-	vpr_file.write("      <input name=\"we2\" num_pins=\"1\"/>\n")
-	
-	vpr_file.write("      <output name=\"out\" num_pins=\""+str(memory_max_width)+"\"/>\n")
-	
-	vpr_file.write("      <clock name=\"clk\" num_pins=\"1\"/>\n")
-
-	# I start with the widest single port mode and increase depth
-	current_width = memory_max_width
-	current_depth = memory_max_depth / current_width
-	current_address_bits = fpga_inst.specs.row_decoder_bits + fpga_inst.specs.col_decoder_bits - 1
-
-	while current_width >= 1:
-		vpr_file.write("      <mode name=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp\">\n")
-		vpr_file.write("        <pb_type name=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp\" blif_model=\".subckt single_port_ram\" class=\"memory\" num_pb=\"1\">\n")
-		vpr_file.write("          <input name=\"addr\" num_pins=\""+str(current_address_bits)+"\" port_class=\"address\"/>\n")
-		vpr_file.write("          <input name=\"data\" num_pins=\""+str(current_width)+"\" port_class=\"data_in\"/>\n")
-		vpr_file.write("          <input name=\"we\" num_pins=\"1\" port_class=\"write_en\"/>\n")
-		vpr_file.write("          <output name=\"out\" num_pins=\""+str(current_width)+"\" port_class=\"data_out\"/>\n")
-		vpr_file.write("          <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
-		vpr_file.write("          <T_setup value=\""+str(memory_setup_time)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp.addr\" clock=\"clk\"/>\n")
-		vpr_file.write("          <T_setup value=\""+str(memory_setup_time)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp.data\" clock=\"clk\"/>\n")
-		vpr_file.write("          <T_setup value=\""+str(memory_setup_time)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp.we\" clock=\"clk\"/>\n")
-		vpr_file.write("          <T_clock_to_Q max=\""+str(memory_clktoq)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp.out\" clock=\"clk\"/>\n")
-		vpr_file.write("        </pb_type>\n")
-		vpr_file.write("        <interconnect>\n")
-		vpr_file.write("          <direct name=\"address1\" input=\"memory.addr1["+str(current_address_bits - 1)+":0]\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp.addr\">\n")
-		vpr_file.write("          </direct>\n")
-		vpr_file.write("          <direct name=\"data1\" input=\"memory.data["+str(current_width - 1)+":0]\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp.data\">\n")
-		vpr_file.write("          </direct>\n")
-		vpr_file.write("          <direct name=\"writeen1\" input=\"memory.we1\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp.we\">\n")
-		vpr_file.write("          </direct>\n")
-		vpr_file.write("          <direct name=\"dataout1\" input=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp.out\" output=\"memory.out["+str(current_width - 1)+":0]\">\n")
-		vpr_file.write("          </direct>\n")
-		vpr_file.write("          <direct name=\"clk\" input=\"memory.clk\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp.clk\">\n")
-		vpr_file.write("          </direct>\n")
-		vpr_file.write("        </interconnect>\n")
-		vpr_file.write("      </mode>\n")
-
-		# Update width, depth, and address bits
-		current_width /= 2
-		current_depth *= 2
-		current_address_bits += 1
-
-	# Generate dual port modes:
-	# In Dual Port mode, maximum width is half of single port mode
-	current_width = memory_max_width / 2
-	current_depth = memory_max_depth / current_width
-	current_address_bits = fpga_inst.specs.row_decoder_bits + fpga_inst.specs.col_decoder_bits
-
-	while current_width >= 1:
-
-		vpr_file.write("      <mode name=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp\">\n")
-		vpr_file.write("        <pb_type name=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp\" blif_model=\".subckt dual_port_ram\" class=\"memory\" num_pb=\"1\">\n")
-		vpr_file.write("          <input name=\"addr1\" num_pins=\""+str(current_address_bits)+"\" port_class=\"address1\"/>\n")
-		vpr_file.write("          <input name=\"addr2\" num_pins=\""+str(current_address_bits)+"\" port_class=\"address2\"/>\n")
-		vpr_file.write("          <input name=\"data1\" num_pins=\""+str(current_width)+"\" port_class=\"data_in1\"/>\n")
-		vpr_file.write("          <input name=\"data2\" num_pins=\""+str(current_width)+"\" port_class=\"data_in2\"/>\n")
-		vpr_file.write("          <input name=\"we1\" num_pins=\"1\" port_class=\"write_en1\"/>\n")
-		vpr_file.write("          <input name=\"we2\" num_pins=\"1\" port_class=\"write_en2\"/>\n")
-		vpr_file.write("          <output name=\"out1\" num_pins=\""+str(current_width)+"\" port_class=\"data_out1\"/>\n")
-		vpr_file.write("          <output name=\"out2\" num_pins=\""+str(current_width)+"\" port_class=\"data_out2\"/>\n")
-		vpr_file.write("          <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
-		vpr_file.write("          <T_setup value=\""+str(memory_setup_time)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.addr1\" clock=\"clk\"/>\n")
-		vpr_file.write("          <T_setup value=\""+str(memory_setup_time)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.data1\" clock=\"clk\"/>\n")
-		vpr_file.write("          <T_setup value=\""+str(memory_setup_time)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.we1\" clock=\"clk\"/>\n")
-		vpr_file.write("          <T_setup value=\""+str(memory_setup_time)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.addr2\" clock=\"clk\"/>\n")
-		vpr_file.write("          <T_setup value=\""+str(memory_setup_time)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.data2\" clock=\"clk\"/>\n")
-		vpr_file.write("          <T_setup value=\""+str(memory_setup_time)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.we2\" clock=\"clk\"/>\n")
-		vpr_file.write("          <T_clock_to_Q max=\""+str(memory_clktoq)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.out1\" clock=\"clk\"/>\n")
-		vpr_file.write("          <T_clock_to_Q max=\""+str(memory_clktoq)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.out2\" clock=\"clk\"/>\n")
-		vpr_file.write("        </pb_type>\n")
-		vpr_file.write("        <interconnect>\n")
-		vpr_file.write("          <direct name=\"address1\" input=\"memory.addr1["+str(current_address_bits -1)+":0]\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.addr1\">\n")
-		vpr_file.write("          </direct>\n")
-		vpr_file.write("          <direct name=\"address2\" input=\"memory.addr2["+str(current_address_bits -1)+":0]\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.addr2\">\n")
-		vpr_file.write("          </direct>\n")
-		vpr_file.write("          <direct name=\"data1\" input=\"memory.data["+str(current_width - 1)+":0]\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.data1\">\n")
-		vpr_file.write("          </direct>\n")
-		vpr_file.write("          <direct name=\"data2\" input=\"memory.data["+str(2*current_width - 1)+":"+str(current_width)+"]\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.data2\">\n")
-		vpr_file.write("          </direct>\n")
-		vpr_file.write("          <direct name=\"writeen1\" input=\"memory.we1\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.we1\">\n")
-		vpr_file.write("          </direct>\n")
-		vpr_file.write("          <direct name=\"writeen2\" input=\"memory.we2\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.we2\">\n")
-		vpr_file.write("          </direct>\n")
-		vpr_file.write("          <direct name=\"dataout1\" input=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.out1\" output=\"memory.out["+str(current_width - 1)+":0]\">\n")
-		vpr_file.write("          </direct>\n")
-		vpr_file.write("          <direct name=\"dataout2\" input=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.out2\" output=\"memory.out["+str(2*current_width - 1)+":"+str(current_width)+"]\">\n")
-		vpr_file.write("          </direct>\n")
-		vpr_file.write("          <direct name=\"clk\" input=\"memory.clk\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.clk\">\n")
-		vpr_file.write("          </direct>\n")
-		vpr_file.write("        </interconnect>\n")
-		vpr_file.write("      </mode>\n")
-
-		current_width /= 2
-		current_depth *= 2
-		current_address_bits += 1
+    vpr_file.write("      <interconnect>\n")
 
 
-	#vpr_file.write("    <fc default_in_type=\"abs\" default_in_val=\""+str(fpga_inst.cb_mux.required_size)+"\" default_out_type=\"abs\" default_out_val=\""+str(fpga_inst.sb_mux.required_size)+"\"/>\n")
-	#vpr_file.write("    <pinlocations pattern=\"spread\"/>\n")
-	vpr_file.write("    <fc default_in_type=\"frac\" default_in_val=\"0.15\" default_out_type=\"frac\" default_out_val=\"0.10\"/>\n")
-	vpr_file.write("    <pinlocations pattern=\"spread\"/>\n")
-	vpr_file.write("  </pb_type>\n")
+    feedback_mux = {}
+    input_num = 0
+    direct_num = 1
+    for input_name in lut_input_names:
+        if Rfb.count(input_name) != 1 :
+            vpr_file.write("    <direct name=\"direct" + str(input_num) + "\" input=\"ble6.in_" + input_name.upper() + "\" output=\"lut6.in[" + str(input_num) + ":" + str(input_num) + "]\">\n")
+            vpr_file.write("      <delay_constant max=\"" + str(lut_delays[input_name]) + "\" in_port=\"ble6.in_" + input_name.upper() + "\" out_port=\"lut6.in[" + str(input_num) + ":" + str(input_num) + "]\" />\n")
+            vpr_file.write("    </direct>\n")
+            direct_num = direct_num + 1
+
+        else:
+            feedback_mux[input_name] = input_num
+
+        input_num = input_num + 1
+
+    vpr_file.write("      <!--Clock -->\n")
+    vpr_file.write("      <direct name=\"direct" + str(direct_num) + "\" input=\"ble6.clk\" output=\"ff.clk\"/>\n")
 
 
-	vpr_file.write("</complexblocklist>\n")
-	vpr_file.write("</architecture>\n")
+    mux_num = 1
+    for name in feedback_mux :
+        vpr_file.write("      <!-- Register feedback mux -->   \n")
+        vpr_file.write("      <mux name=\"mux" + str(mux_num) + "\" input=\"ble6.in_" + name.upper() + " ff.Q\" output=\"lut6.in[" + str(feedback_mux[name]) + ":" + str(feedback_mux[name]) + "]\">\n")
+        vpr_file.write("        <delay_constant max=\"" + str(lut_delays[name]) + "\" in_port=\"ble6.in_" + name.upper() + "\" out_port=\"lut6.in[" + str(feedback_mux[name]) + ":" + str(feedback_mux[name]) + "]\" />\n")
+        vpr_file.write("        <delay_constant max=\"" + str(lut_delays[name]) + "\" in_port=\"ff.Q\" out_port=\"lut6.in[" + str(feedback_mux[name]) + ":" + str(feedback_mux[name]) + "]\" />  \n")
+        vpr_file.write("      </mux>\n")
+        mux_num = mux_num + 1
+        vpr_file.write("      <!-- FF input selection mux -->\n")
+        vpr_file.write("      <mux name=\"" + str(mux_num) + "\" input=\"lut6.out ble6.in_" + name.upper() + "\" output=\"ff.D\">\n")
+        vpr_file.write("        <delay_constant max=\"1.74588e-11\" in_port=\"lut6.out\" out_port=\"ff.D\" />\n")
+        vpr_file.write("        <delay_constant max=\"1.74588e-11\" in_port=\"ble6.in_" + name.upper() + "\" out_port=\"ff.D\" />\n")
+        vpr_file.write("      </mux>\n")
+        mux_num = mux_num + 1
+
+
+    vpr_file.write("      <!-- BLE output (local) -->\n")
+    vpr_file.write("      <mux name=\"mux" + str(mux_num) + "\" input=\"ff.Q lut6.out\" output=\"ble6.out_local\">\n")
+    vpr_file.write("        <delay_constant max=\"" + str(local_feedback) + "\" in_port=\"ff.Q\" out_port=\"ble6.out_local\" />\n")
+    vpr_file.write("        <delay_constant max=\"" + str(local_feedback) + "\" in_port=\"lut6.out\" out_port=\"ble6.out_local\" />\n")
+    vpr_file.write("      </mux>\n")
+    mux_num = mux_num + 1
+
+    vpr_file.write("      <!-- BLE output (routing 1) --> \n")
+    vpr_file.write("      <mux name=\"mux" + str(mux_num) + "\" input=\"ff.Q lut6.out\" output=\"ble6.out_routing[0:0]\">\n")
+    vpr_file.write("        <delay_constant max=\"" + str(logic_block_output)+ "\" in_port=\"ff.Q\" out_port=\"ble6.out_routing[0:0]\" />\n")
+    vpr_file.write("        <delay_constant max=\"" + str(logic_block_output)+ "\" in_port=\"lut6.out\" out_port=\"ble6.out_routing[0:0]\" />\n")
+    vpr_file.write("      </mux>\n")
+    mux_num = mux_num + 1
+
+    vpr_file.write("      <!-- BLE output (routing 2) --> \n")
+    vpr_file.write("      <mux name=\"mux" + str(mux_num) + "\" input=\"ff.Q lut6.out\" output=\"ble6.out_routing[1:1]\">\n")
+    vpr_file.write("        <delay_constant max=\"" + str(logic_block_output)+ "\" in_port=\"ff.Q\" out_port=\"ble6.out_routing[1:1]\" />\n")
+    vpr_file.write("        <delay_constant max=\"" + str(logic_block_output)+ "\" in_port=\"lut6.out\" out_port=\"ble6.out_routing[1:1]\" />\n")
+    vpr_file.write("      </mux>\n")
+    vpr_file.write("      </interconnect>\n")
+    vpr_file.write("    </pb_type>\n")
+        
+    vpr_file.write("    <interconnect>\n")
+    vpr_file.write("    <!-- 50% sparsely populated local routing -->\n")
+    vpr_file.write("    <complete name=\"lutA\" input=\"clb.I4 clb.I3 ble6[1:0].out_local ble6[3:2].out_local ble6[8:8].out_local\" output=\"ble6[9:0].in_A\">\n")
+    vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I4\" out_port=\"ble6.in_A\" />\n")
+    vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I3\" out_port=\"ble6.in_A\" />\n")
+    vpr_file.write("      </complete>\n")
+    vpr_file.write("    <complete name=\"lutB\" input=\"clb.I3 clb.I2 ble6[3:2].out_local ble6[5:4].out_local ble6[9:9].out_local\" output=\"ble6[9:0].in_B\">\n")
+    vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I3\" out_port=\"ble6.in_B\" />\n")
+    vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I2\" out_port=\"ble6.in_B\" />\n")
+    vpr_file.write("      </complete>\n")
+    vpr_file.write("    <complete name=\"lutC\" input=\"clb.I2 clb.I1 ble6[5:4].out_local ble6[7:6].out_local ble6[8:8].out_local\" output=\"ble6[9:0].in_C\">\n")
+    vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I2\" out_port=\"ble6.in_C\" />\n")
+    vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I1\" out_port=\"ble6.in_C\" />\n")
+    vpr_file.write("      </complete>\n")
+    vpr_file.write("    <complete name=\"lutD\" input=\"clb.I4 clb.I2 ble6[1:0].out_local ble6[5:4].out_local ble6[9:9].out_local\" output=\"ble6[9:0].in_D\">\n")
+    vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I4\" out_port=\"ble6.in_D\" />\n")
+    vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I2\" out_port=\"ble6.in_D\" />\n")
+    vpr_file.write("      </complete>\n")
+    vpr_file.write("    <complete name=\"lutE\" input=\"clb.I3 clb.I1 ble6[3:2].out_local ble6[7:6].out_local ble6[8:8].out_local\" output=\"ble6[9:0].in_E\">\n")
+    vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I3\" out_port=\"ble6.in_E\" />\n")
+    vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I1\" out_port=\"ble6.in_E\" />\n")
+    vpr_file.write("      </complete>\n")
+    vpr_file.write("    <complete name=\"lutF\" input=\"clb.I4 clb.I1 ble6[1:0].out_local ble6[7:6].out_local ble6[9:9].out_local\" output=\"ble6[9:0].in_F\">\n")
+    vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I4\" out_port=\"ble6.in_F\" />\n")
+    vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I1\" out_port=\"ble6.in_F\" />\n")
+    vpr_file.write("      </complete>\n")
+    vpr_file.write("      <complete name=\"clks\" input=\"clb.clk\" output=\"ble6[9:0].clk\">\n")
+    vpr_file.write("      </complete>\n")
+              
+    vpr_file.write("      <!-- Direct connections to CLB outputs -->\n")
+    vpr_file.write("      <direct name=\"clbouts1\" input=\"ble6[0:0].out_routing\" output=\"clb.O1\"/>\n")
+    vpr_file.write("      <direct name=\"clbouts2\" input=\"ble6[1:1].out_routing\" output=\"clb.O2\"/>\n")
+    vpr_file.write("      <direct name=\"clbouts3\" input=\"ble6[2:2].out_routing\" output=\"clb.O3\"/>\n")
+    vpr_file.write("      <direct name=\"clbouts4\" input=\"ble6[3:3].out_routing\" output=\"clb.O4\"/>\n")
+    vpr_file.write("      <direct name=\"clbouts5\" input=\"ble6[4:4].out_routing\" output=\"clb.O5\"/>\n")
+    vpr_file.write("      <direct name=\"clbouts6\" input=\"ble6[5:5].out_routing\" output=\"clb.O6\"/>\n")
+    vpr_file.write("      <direct name=\"clbouts7\" input=\"ble6[6:6].out_routing\" output=\"clb.O7\"/>\n")
+    vpr_file.write("      <direct name=\"clbouts8\" input=\"ble6[7:7].out_routing\" output=\"clb.O8\"/>\n")
+    vpr_file.write("      <direct name=\"clbouts9\" input=\"ble6[8:8].out_routing\" output=\"clb.O9\"/>\n")
+    vpr_file.write("      <direct name=\"clbouts10\" input=\"ble6[9:9].out_routing\" output=\"clb.O10\"/>\n")
+
+    vpr_file.write("    </interconnect>\n")
+    vpr_file.write("    <fc default_in_type=\"frac\" default_in_val=\"" + str(Fcin) + "\" default_out_type=\"frac\" default_out_val=\"" + str(Fcout) + "\"/>\n")
+    vpr_file.write("    <!-- Two sided connectivity CLB architecture--> \n")
+    vpr_file.write("    <pinlocations pattern=\"custom\">\n")
+    vpr_file.write("  <loc side=\"right\">clb.O1 clb.O2 clb.O3 clb.O4 clb.O5 clb.I1 clb.I3 clb.clk</loc> \n")
+    vpr_file.write("      <loc side=\"bottom\">clb.O6 clb.O7 clb.O8 clb.O9 clb.O10 clb.I2 clb.I4 clb.clk</loc>      \n")
+    vpr_file.write("    </pinlocations>\n")
+    vpr_file.write("  </pb_type>\n")
+
+    vpr_file.write("  <!-- This is the 36*36 uniform mult -->\n")
+    vpr_file.write("  <pb_type name=\"mult_36\" height=\"4\" area=\"118800\">\n")
+    vpr_file.write("      <input name=\"a\" num_pins=\"36\"/>\n")
+    vpr_file.write("      <input name=\"b\" num_pins=\"36\"/>\n")
+    vpr_file.write("      <output name=\"out\" num_pins=\"72\"/>\n")
+
+    vpr_file.write("      <mode name=\"two_divisible_mult_18x18\">\n")
+    vpr_file.write("        <pb_type name=\"divisible_mult_18x18\" num_pb=\"2\">\n")
+    vpr_file.write("          <input name=\"a\" num_pins=\"18\"/>\n")
+    vpr_file.write("          <input name=\"b\" num_pins=\"18\"/>\n")
+    vpr_file.write("          <output name=\"out\" num_pins=\"36\"/>\n")
+
+    vpr_file.write("          <mode name=\"two_mult_9x9\">\n")
+    vpr_file.write("            <pb_type name=\"mult_9x9_slice\" num_pb=\"2\">\n")
+    vpr_file.write("              <input name=\"A_cfg\" num_pins=\"9\"/>\n")
+    vpr_file.write("              <input name=\"B_cfg\" num_pins=\"9\"/>\n")
+    vpr_file.write("              <output name=\"OUT_cfg\" num_pins=\"18\"/>\n")
+
+    vpr_file.write("              <pb_type name=\"mult_9x9\" blif_model=\".subckt multiply\" num_pb=\"1\">\n")
+    vpr_file.write("                <input name=\"a\" num_pins=\"9\"/>\n")
+    vpr_file.write("                <input name=\"b\" num_pins=\"9\"/>\n")
+    vpr_file.write("                <output name=\"out\" num_pins=\"18\"/>\n")
+    vpr_file.write("                <delay_constant max=\"1.667e-9\" in_port=\"mult_9x9.a\" out_port=\"mult_9x9.out\"/>\n")
+    vpr_file.write("                <delay_constant max=\"1.667e-9\" in_port=\"mult_9x9.b\" out_port=\"mult_9x9.out\"/>\n")
+    vpr_file.write("              </pb_type>\n")
+
+    vpr_file.write("              <interconnect>\n")
+    vpr_file.write("                <direct name=\"a2a\" input=\"mult_9x9_slice.A_cfg\" output=\"mult_9x9.a\">\n")
+    vpr_file.write("                </direct>\n")
+    vpr_file.write("                <direct name=\"b2b\" input=\"mult_9x9_slice.B_cfg\" output=\"mult_9x9.b\">\n")
+    vpr_file.write("                </direct>\n")
+    vpr_file.write("                <direct name=\"out2out\" input=\"mult_9x9.out\" output=\"mult_9x9_slice.OUT_cfg\">\n")
+    vpr_file.write("                </direct>\n")
+    vpr_file.write("              </interconnect>\n")
+    vpr_file.write("            </pb_type>\n")
+    vpr_file.write("            <interconnect>\n")
+    vpr_file.write("              <direct name=\"a2a\" input=\"divisible_mult_18x18.a\" output=\"mult_9x9_slice[1:0].A_cfg\">\n")
+    vpr_file.write("              </direct>\n")
+    vpr_file.write("              <direct name=\"b2b\" input=\"divisible_mult_18x18.b\" output=\"mult_9x9_slice[1:0].B_cfg\">\n")
+    vpr_file.write("              </direct>\n")
+    vpr_file.write("              <direct name=\"out2out\" input=\"mult_9x9_slice[1:0].OUT_cfg\" output=\"divisible_mult_18x18.out\">\n")
+    vpr_file.write("              </direct>\n")
+    vpr_file.write("            </interconnect>\n")
+    vpr_file.write("          </mode>\n")
+
+    vpr_file.write("          <mode name=\"mult_18x18\">\n")
+    vpr_file.write("            <pb_type name=\"mult_18x18_slice\" num_pb=\"1\">\n")
+    vpr_file.write("              <input name=\"A_cfg\" num_pins=\"18\"/>\n")
+    vpr_file.write("              <input name=\"B_cfg\" num_pins=\"18\"/>\n")
+    vpr_file.write("              <output name=\"OUT_cfg\" num_pins=\"36\"/>\n")
+
+    vpr_file.write("              <pb_type name=\"mult_18x18\" blif_model=\".subckt multiply\" num_pb=\"1\" >\n")
+    vpr_file.write("                <input name=\"a\" num_pins=\"18\"/>\n")
+    vpr_file.write("                <input name=\"b\" num_pins=\"18\"/>\n")
+    vpr_file.write("                <output name=\"out\" num_pins=\"36\"/>\n")
+    vpr_file.write("                <delay_constant max=\"1.667e-9\" in_port=\"mult_18x18.a\" out_port=\"mult_18x18.out\"/>\n")
+    vpr_file.write("                <delay_constant max=\"1.667e-9\" in_port=\"mult_18x18.b\" out_port=\"mult_18x18.out\"/>\n")
+    vpr_file.write("              </pb_type>\n")
+
+    vpr_file.write("              <interconnect>\n")
+    vpr_file.write("                <direct name=\"a2a\" input=\"mult_18x18_slice.A_cfg\" output=\"mult_18x18.a\">\n")
+    vpr_file.write("                </direct>\n")
+    vpr_file.write("                <direct name=\"b2b\" input=\"mult_18x18_slice.B_cfg\" output=\"mult_18x18.b\">\n")
+    vpr_file.write("                </direct>\n")
+    vpr_file.write("                <direct name=\"out2out\" input=\"mult_18x18.out\" output=\"mult_18x18_slice.OUT_cfg\">\n")
+    vpr_file.write("                </direct>\n")
+    vpr_file.write("              </interconnect>\n")
+    vpr_file.write("            </pb_type>\n")
+    vpr_file.write("            <interconnect>\n")
+    vpr_file.write("              <direct name=\"a2a\" input=\"divisible_mult_18x18.a\" output=\"mult_18x18_slice.A_cfg\">\n")
+    vpr_file.write("              </direct>\n")
+    vpr_file.write("              <direct name=\"b2b\" input=\"divisible_mult_18x18.b\" output=\"mult_18x18_slice.B_cfg\">\n")
+    vpr_file.write("              </direct>\n")
+    vpr_file.write("              <direct name=\"out2out\" input=\"mult_18x18_slice.OUT_cfg\" output=\"divisible_mult_18x18.out\">\n")
+    vpr_file.write("              </direct>\n")
+    vpr_file.write("            </interconnect>\n")
+    vpr_file.write("          </mode>\n")
+    vpr_file.write("        </pb_type>\n")
+    vpr_file.write("        <interconnect>\n")
+    vpr_file.write("          <direct name=\"a2a\" input=\"mult_36.a\" output=\"divisible_mult_18x18[1:0].a\">\n")
+    vpr_file.write("          </direct>\n")
+    vpr_file.write("          <direct name=\"b2b\" input=\"mult_36.b\" output=\"divisible_mult_18x18[1:0].b\">\n")
+    vpr_file.write("          </direct>\n")
+    vpr_file.write("          <direct name=\"out2out\" input=\"divisible_mult_18x18[1:0].out\" output=\"mult_36.out\">\n")
+    vpr_file.write("          </direct>\n")
+    vpr_file.write("        </interconnect>\n")
+    vpr_file.write("      </mode>\n")
+
+    vpr_file.write("      <mode name=\"mult_36x36\">\n")
+    vpr_file.write("        <pb_type name=\"mult_36x36_slice\" num_pb=\"1\">\n")
+    vpr_file.write("          <input name=\"A_cfg\" num_pins=\"36\"/>\n")
+    vpr_file.write("          <input name=\"B_cfg\" num_pins=\"36\"/>\n")
+    vpr_file.write("          <output name=\"OUT_cfg\" num_pins=\"72\"/>\n")
+
+    vpr_file.write("          <pb_type name=\"mult_36x36\" blif_model=\".subckt multiply\" num_pb=\"1\">\n")
+    vpr_file.write("            <input name=\"a\" num_pins=\"36\"/>\n")
+    vpr_file.write("            <input name=\"b\" num_pins=\"36\"/>\n")
+    vpr_file.write("            <output name=\"out\" num_pins=\"72\"/>\n")
+    vpr_file.write("            <delay_constant max=\"1.667e-9\" in_port=\"mult_36x36.a\" out_port=\"mult_36x36.out\"/>\n")
+    vpr_file.write("            <delay_constant max=\"1.667e-9\" in_port=\"mult_36x36.b\" out_port=\"mult_36x36.out\"/>\n")
+    vpr_file.write("          </pb_type>\n")
+
+    vpr_file.write("          <interconnect>\n")
+    vpr_file.write("            <direct name=\"a2a\" input=\"mult_36x36_slice.A_cfg\" output=\"mult_36x36.a\">\n")
+    vpr_file.write("            </direct>\n")
+    vpr_file.write("            <direct name=\"b2b\" input=\"mult_36x36_slice.B_cfg\" output=\"mult_36x36.b\">\n")
+    vpr_file.write("            </direct>\n")
+    vpr_file.write("            <direct name=\"out2out\" input=\"mult_36x36.out\" output=\"mult_36x36_slice.OUT_cfg\">\n")
+    vpr_file.write("            </direct>\n")
+    vpr_file.write("          </interconnect>\n")
+    vpr_file.write("        </pb_type>\n")
+    vpr_file.write("        <interconnect>\n")
+    vpr_file.write("          <direct name=\"a2a\" input=\"mult_36.a\" output=\"mult_36x36_slice.A_cfg\">\n")
+    vpr_file.write("          </direct>\n")
+    vpr_file.write("          <direct name=\"b2b\" input=\"mult_36.b\" output=\"mult_36x36_slice.B_cfg\">\n")
+    vpr_file.write("          </direct>\n")
+    vpr_file.write("          <direct name=\"out2out\" input=\"mult_36x36_slice.OUT_cfg\" output=\"mult_36.out\">\n")
+    vpr_file.write("          </direct>\n")
+    vpr_file.write("        </interconnect>\n")
+    vpr_file.write("      </mode>\n")
+
+    vpr_file.write("    <fc default_in_type=\"frac\" default_in_val=\"0.15\" default_out_type=\"frac\" default_out_val=\"0.10\"/>\n")
+    vpr_file.write("    <pinlocations pattern=\"spread\"/>\n")
+
+    vpr_file.write("  </pb_type>\n")
+
+
+    vpr_file.write("<!-- This is the Block RAM module  -->\n")
+
+    vpr_file.write("  <pb_type name=\"memory\" height=\""+str(memory_height)+"\" area=\""+str(fpga_inst.area_dict["ram_core"]/fpga_inst.specs.min_width_tran_area)+"\">\n")
+
+    vpr_file.write("      <input name=\"addr1\" num_pins=\""+str(memory_address_bits)+"\"/>\n")
+    vpr_file.write("      <input name=\"addr2\" num_pins=\""+str(memory_address_bits)+"\"/>\n")
+    
+    vpr_file.write("      <input name=\"data\" num_pins=\""+str(memory_max_width)+"\"/>\n")
+    
+    vpr_file.write("      <input name=\"we1\" num_pins=\"1\"/>\n")
+    vpr_file.write("      <input name=\"we2\" num_pins=\"1\"/>\n")
+    
+    vpr_file.write("      <output name=\"out\" num_pins=\""+str(memory_max_width)+"\"/>\n")
+    
+    vpr_file.write("      <clock name=\"clk\" num_pins=\"1\"/>\n")
+
+    # I start with the widest single port mode and increase depth
+    current_width = memory_max_width
+    current_depth = memory_max_depth / current_width
+    current_address_bits = fpga_inst.specs.row_decoder_bits + fpga_inst.specs.col_decoder_bits - 1
+
+    while current_width >= 1:
+        vpr_file.write("      <mode name=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp\">\n")
+        vpr_file.write("        <pb_type name=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp\" blif_model=\".subckt single_port_ram\" class=\"memory\" num_pb=\"1\">\n")
+        vpr_file.write("          <input name=\"addr\" num_pins=\""+str(current_address_bits)+"\" port_class=\"address\"/>\n")
+        vpr_file.write("          <input name=\"data\" num_pins=\""+str(current_width)+"\" port_class=\"data_in\"/>\n")
+        vpr_file.write("          <input name=\"we\" num_pins=\"1\" port_class=\"write_en\"/>\n")
+        vpr_file.write("          <output name=\"out\" num_pins=\""+str(current_width)+"\" port_class=\"data_out\"/>\n")
+        vpr_file.write("          <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
+        vpr_file.write("          <T_setup value=\""+str(memory_setup_time)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp.addr\" clock=\"clk\"/>\n")
+        vpr_file.write("          <T_setup value=\""+str(memory_setup_time)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp.data\" clock=\"clk\"/>\n")
+        vpr_file.write("          <T_setup value=\""+str(memory_setup_time)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp.we\" clock=\"clk\"/>\n")
+        vpr_file.write("          <T_clock_to_Q max=\""+str(memory_clktoq)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp.out\" clock=\"clk\"/>\n")
+        vpr_file.write("        </pb_type>\n")
+        vpr_file.write("        <interconnect>\n")
+        vpr_file.write("          <direct name=\"address1\" input=\"memory.addr1["+str(current_address_bits - 1)+":0]\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp.addr\">\n")
+        vpr_file.write("          </direct>\n")
+        vpr_file.write("          <direct name=\"data1\" input=\"memory.data["+str(current_width - 1)+":0]\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp.data\">\n")
+        vpr_file.write("          </direct>\n")
+        vpr_file.write("          <direct name=\"writeen1\" input=\"memory.we1\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp.we\">\n")
+        vpr_file.write("          </direct>\n")
+        vpr_file.write("          <direct name=\"dataout1\" input=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp.out\" output=\"memory.out["+str(current_width - 1)+":0]\">\n")
+        vpr_file.write("          </direct>\n")
+        vpr_file.write("          <direct name=\"clk\" input=\"memory.clk\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_sp.clk\">\n")
+        vpr_file.write("          </direct>\n")
+        vpr_file.write("        </interconnect>\n")
+        vpr_file.write("      </mode>\n")
+
+        # Update width, depth, and address bits
+        current_width /= 2
+        current_depth *= 2
+        current_address_bits += 1
+
+    # Generate dual port modes:
+    # In Dual Port mode, maximum width is half of single port mode
+    current_width = memory_max_width / 2
+    current_depth = memory_max_depth / current_width
+    current_address_bits = fpga_inst.specs.row_decoder_bits + fpga_inst.specs.col_decoder_bits
+
+    while current_width >= 1:
+
+        vpr_file.write("      <mode name=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp\">\n")
+        vpr_file.write("        <pb_type name=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp\" blif_model=\".subckt dual_port_ram\" class=\"memory\" num_pb=\"1\">\n")
+        vpr_file.write("          <input name=\"addr1\" num_pins=\""+str(current_address_bits)+"\" port_class=\"address1\"/>\n")
+        vpr_file.write("          <input name=\"addr2\" num_pins=\""+str(current_address_bits)+"\" port_class=\"address2\"/>\n")
+        vpr_file.write("          <input name=\"data1\" num_pins=\""+str(current_width)+"\" port_class=\"data_in1\"/>\n")
+        vpr_file.write("          <input name=\"data2\" num_pins=\""+str(current_width)+"\" port_class=\"data_in2\"/>\n")
+        vpr_file.write("          <input name=\"we1\" num_pins=\"1\" port_class=\"write_en1\"/>\n")
+        vpr_file.write("          <input name=\"we2\" num_pins=\"1\" port_class=\"write_en2\"/>\n")
+        vpr_file.write("          <output name=\"out1\" num_pins=\""+str(current_width)+"\" port_class=\"data_out1\"/>\n")
+        vpr_file.write("          <output name=\"out2\" num_pins=\""+str(current_width)+"\" port_class=\"data_out2\"/>\n")
+        vpr_file.write("          <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
+        vpr_file.write("          <T_setup value=\""+str(memory_setup_time)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.addr1\" clock=\"clk\"/>\n")
+        vpr_file.write("          <T_setup value=\""+str(memory_setup_time)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.data1\" clock=\"clk\"/>\n")
+        vpr_file.write("          <T_setup value=\""+str(memory_setup_time)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.we1\" clock=\"clk\"/>\n")
+        vpr_file.write("          <T_setup value=\""+str(memory_setup_time)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.addr2\" clock=\"clk\"/>\n")
+        vpr_file.write("          <T_setup value=\""+str(memory_setup_time)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.data2\" clock=\"clk\"/>\n")
+        vpr_file.write("          <T_setup value=\""+str(memory_setup_time)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.we2\" clock=\"clk\"/>\n")
+        vpr_file.write("          <T_clock_to_Q max=\""+str(memory_clktoq)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.out1\" clock=\"clk\"/>\n")
+        vpr_file.write("          <T_clock_to_Q max=\""+str(memory_clktoq)+"\" port=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.out2\" clock=\"clk\"/>\n")
+        vpr_file.write("        </pb_type>\n")
+        vpr_file.write("        <interconnect>\n")
+        vpr_file.write("          <direct name=\"address1\" input=\"memory.addr1["+str(current_address_bits -1)+":0]\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.addr1\">\n")
+        vpr_file.write("          </direct>\n")
+        vpr_file.write("          <direct name=\"address2\" input=\"memory.addr2["+str(current_address_bits -1)+":0]\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.addr2\">\n")
+        vpr_file.write("          </direct>\n")
+        vpr_file.write("          <direct name=\"data1\" input=\"memory.data["+str(current_width - 1)+":0]\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.data1\">\n")
+        vpr_file.write("          </direct>\n")
+        vpr_file.write("          <direct name=\"data2\" input=\"memory.data["+str(2*current_width - 1)+":"+str(current_width)+"]\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.data2\">\n")
+        vpr_file.write("          </direct>\n")
+        vpr_file.write("          <direct name=\"writeen1\" input=\"memory.we1\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.we1\">\n")
+        vpr_file.write("          </direct>\n")
+        vpr_file.write("          <direct name=\"writeen2\" input=\"memory.we2\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.we2\">\n")
+        vpr_file.write("          </direct>\n")
+        vpr_file.write("          <direct name=\"dataout1\" input=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.out1\" output=\"memory.out["+str(current_width - 1)+":0]\">\n")
+        vpr_file.write("          </direct>\n")
+        vpr_file.write("          <direct name=\"dataout2\" input=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.out2\" output=\"memory.out["+str(2*current_width - 1)+":"+str(current_width)+"]\">\n")
+        vpr_file.write("          </direct>\n")
+        vpr_file.write("          <direct name=\"clk\" input=\"memory.clk\" output=\"mem_"+str(current_depth)+"x"+str(current_width)+"_dp.clk\">\n")
+        vpr_file.write("          </direct>\n")
+        vpr_file.write("        </interconnect>\n")
+        vpr_file.write("      </mode>\n")
+
+        current_width /= 2
+        current_depth *= 2
+        current_address_bits += 1
+
+
+    #vpr_file.write("    <fc default_in_type=\"abs\" default_in_val=\""+str(fpga_inst.cb_mux.required_size)+"\" default_out_type=\"abs\" default_out_val=\""+str(fpga_inst.sb_mux.required_size)+"\"/>\n")
+    #vpr_file.write("    <pinlocations pattern=\"spread\"/>\n")
+    vpr_file.write("    <fc default_in_type=\"frac\" default_in_val=\"0.15\" default_out_type=\"frac\" default_out_val=\"0.10\"/>\n")
+    vpr_file.write("    <pinlocations pattern=\"spread\"/>\n")
+    vpr_file.write("  </pb_type>\n")
+
+
+    vpr_file.write("</complexblocklist>\n")
+    vpr_file.write("</architecture>\n")
 
 
 
 def print_vpr_file_flut_hard(vpr_file, fpga_inst):
 
-	# get delay values
-	Tdel = fpga_inst.sb_mux.delay
-	T_ipin_cblock = fpga_inst.cb_mux.delay
-	local_CLB_routing = fpga_inst.logic_cluster.local_mux.delay
-	local_feedback = fpga_inst.logic_cluster.ble.local_output.delay
-	logic_block_output = fpga_inst.logic_cluster.ble.general_output.delay
-
-	# get lut delays
-	lut_input_names = list(fpga_inst.logic_cluster.ble.lut.input_drivers.keys())
-	lut_input_names.sort()
-	lut_delays = {}
-	for input_name in lut_input_names:
-		lut_input = fpga_inst.logic_cluster.ble.lut.input_drivers[input_name]
-		driver_delay = max(lut_input.driver.delay, lut_input.not_driver.delay)
-		path_delay = lut_input.delay
-		lut_delays[input_name] = driver_delay+path_delay
-		if fpga_inst.specs.use_fluts:
-			lut_delays[input_name] += fpga_inst.logic_cluster.ble.fmux.delay
-	# get archetecture parameters
-	Rfb = fpga_inst.specs.Rfb
-	Fcin = fpga_inst.specs.Fcin
-	Fcout = fpga_inst.specs.Fcout
-	Fs = fpga_inst.specs.Fs
-	N = fpga_inst.specs.N
-	K = fpga_inst.specs.K
-	L = fpga_inst.specs.L
-	independent_inputs = fpga_inst.specs.independent_inputs
-		
-	# get areas
-	grid_logic_tile_area = fpga_inst.area_dict["logic_cluster"]/fpga_inst.specs.min_width_tran_area
-	if grid_logic_tile_area < 1.00 :
-		grid_logic_tile_area = 1.00
-	ipin_mux_trans_size = fpga_inst.area_dict["ipin_mux_trans_size"]/fpga_inst.specs.min_width_tran_area
-	if ipin_mux_trans_size < 1.00 :
-		ipin_mux_trans_size = 1.00
-	mux_trans_size = fpga_inst.area_dict["switch_mux_trans_size"]/fpga_inst.specs.min_width_tran_area
-	if mux_trans_size < 1.00 :
-		mux_trans_size = 1.00
-	buf_size = fpga_inst.area_dict["switch_buf_size"]/fpga_inst.specs.min_width_tran_area
-	if buf_size < 1.00 :
-		buf_size = 1.00
-
-	cb_buf_size = fpga_inst.area_dict["cb_buf_size"]/fpga_inst.specs.min_width_tran_area
-	if cb_buf_size < 1.00:
-		cb_buf_size = 1.00
-
-	vpr_file.write("<architecture>  \n")
-	vpr_file.write("<!-- ODIN II specific config -->\n")
-	vpr_file.write("<models>\n")
-	vpr_file.write("  <model name=\"multiply\">\n")
-	vpr_file.write("    <input_ports>\n")
-	vpr_file.write("    <port name=\"a\" combinational_sink_ports=\"out\"/> \n")
-	vpr_file.write("    <port name=\"b\" combinational_sink_ports=\"out\"/>\n")
-	vpr_file.write("    </input_ports>\n")
-	vpr_file.write("    <output_ports>\n")
-	vpr_file.write("    <port name=\"out\"/>\n")
-	vpr_file.write("    </output_ports>\n")
-	vpr_file.write("  </model>\n")
-	    
-	vpr_file.write("<model name=\"single_port_ram\">\n")
-	vpr_file.write("  <input_ports>\n")
-	vpr_file.write("  <port name=\"we\" clock=\"clk\"/>     <!-- control -->\n")
-	vpr_file.write("  <port name=\"addr\" clock=\"clk\"/>  <!-- address lines -->\n")
-	vpr_file.write("  <port name=\"data\" clock=\"clk\"/>  <!-- data lines can be broken down into smaller bit widths minimum size 1 -->\n")
-	vpr_file.write("  <port name=\"clk\" is_clock=\"1\"/>  <!-- memories are often clocked -->\n")
-	vpr_file.write("  </input_ports>\n")
-	vpr_file.write("  <output_ports>\n")
-	vpr_file.write("  <port name=\"out\" clock=\"clk\"/>   <!-- output can be broken down into smaller bit widths minimum size 1 -->\n")
-	vpr_file.write("  </output_ports>\n")
-	vpr_file.write("</model>\n")
-
-	vpr_file.write("<model name=\"dual_port_ram\">\n")
-	vpr_file.write("  <input_ports>\n")
-	vpr_file.write("  <port name=\"we1\" clock=\"clk\"/>     <!-- write enable -->\n")
-	vpr_file.write("  <port name=\"we2\" clock=\"clk\"/>     <!-- write enable -->\n")
-	vpr_file.write("  <port name=\"addr1\" clock=\"clk\"/>  <!-- address lines -->\n")
-	vpr_file.write("  <port name=\"addr2\" clock=\"clk\"/>  <!-- address lines -->\n")
-	vpr_file.write("  <port name=\"data1\" clock=\"clk\"/>  <!-- data lines can be broken down into smaller bit widths minimum size 1 -->\n")
-	vpr_file.write("  <port name=\"data2\" clock=\"clk\"/>  <!-- data lines can be broken down into smaller bit widths minimum size 1 -->\n")
-	vpr_file.write("  <port name=\"clk\" is_clock=\"1\"/>  <!-- memories are often clocked -->\n")
-	vpr_file.write("  </input_ports>\n")
-	vpr_file.write("  <output_ports>\n")
-	vpr_file.write("  <port name=\"out1\" clock=\"clk\"/>   <!-- output can be broken down into smaller bit widths minimum size 1 -->\n")
-	vpr_file.write("  <port name=\"out2\" clock=\"clk\"/>   <!-- output can be broken down into smaller bit widths minimum size 1 -->\n")
-	vpr_file.write("  </output_ports>\n")
-	vpr_file.write("</model>\n")
-
-	vpr_file.write("</models>\n")
-	vpr_file.write("<!-- ODIN II specific config ends -->\n")
-	vpr_file.write("<!-- Physical descriptions begin -->\n")
-	vpr_file.write("<layout>\n")
-	vpr_file.write("<auto_layout aspect_ratio=\"1.0\">\n")
-	vpr_file.write("<perimeter type=\"io\" priority=\"100\"/>\n")
-	vpr_file.write("<corners type=\"EMPTY\" priority=\"101\"/>\n")
-	vpr_file.write("<fill type=\"clb\" priority=\"10\"/>\n")
-	vpr_file.write("<col type=\"mult_36\" startx=\"4\" starty=\"1\" repeatx=\"8\" priority=\"20\" />\n")
-	vpr_file.write("<col type=\"EMPTY\" startx=\"4\" starty=\"1\" repeatx=\"8\" priority=\"19\" />\n")
-	vpr_file.write("<col type=\"memory\" startx=\"2\" starty=\"1\" repeatx=\"8\" priority=\"20\" />\n")
-	vpr_file.write("<col type=\"EMPTY\" startx=\"2\" starty=\"1\" repeatx=\"8\" priority=\"19\" />\n")
-	vpr_file.write("</auto_layout>\n")
-	vpr_file.write("</layout>\n")
-
-	vpr_file.write("  <device>\n")
-	vpr_file.write("    <sizing R_minW_nmos=\"13090.000000\" R_minW_pmos=\"19086.831111\"/> \n") #ipin_mux_trans_size=\"" + str(ipin_mux_trans_size)+ "\"/>\n
-	vpr_file.write("    <area grid_logic_tile_area=\"" + str(grid_logic_tile_area) +"\"/>\n")
-	vpr_file.write("    <chan_width_distr>\n")
-	vpr_file.write("      <x distr=\"uniform\" peak=\"1.000000\"/>\n")
-	vpr_file.write("      <y distr=\"uniform\" peak=\"1.000000\"/>\n")
-	vpr_file.write("    </chan_width_distr>\n")
-	vpr_file.write("    <switch_block type=\"wilton\" fs=\"" + str(Fs) + "\"/>\n")
-	vpr_file.write("    <connection_block input_switch_name=\"ipin_cblock\"/>\n")
-	vpr_file.write("  </device>\n")
-
-	
-	vpr_file.write("  <switchlist>\n")
-	vpr_file.write("    <switch type=\"mux\" name=\"0\" R=\"0.000000\" Cin=\"0.000000e+00\" Cout=\"0.000000e+00\" Tdel=\"" + str(Tdel) + "\" mux_trans_size=\"" + str(mux_trans_size) + "\" buf_size=\"" + str(buf_size) + "\"/>\n")
-	vpr_file.write("    <switch type=\"mux\" name=\"ipin_cblock\" R=\"0.000000\" Cin=\"0.000000e+00\" Cout=\"0.000000e+00\" Tdel=\"" + str(T_ipin_cblock) + "\" mux_trans_size=\"" + str(ipin_mux_trans_size) + "\" buf_size=\"" + str(cb_buf_size) + "\"/>\n")
-	vpr_file.write("  </switchlist>\n")
-
-	vpr_file.write("  <segmentlist>\n")
-	vpr_file.write("    <segment freq=\"1.000000\" length=\"" + str(L) + "\" type=\"unidir\" Rmetal=\"0.000000\" Cmetal=\"0.000000e+00\">\n")
-	vpr_file.write("    <mux name=\"0\"/>\n")
-	vpr_file.write("    <sb type=\"pattern\">1 1 1 1 1</sb>\n")
-	vpr_file.write("    <cb type=\"pattern\">1 1 1 1</cb>\n")
-	vpr_file.write("    </segment>\n")
-	vpr_file.write("  </segmentlist>\n")
-
-	vpr_file.write("  <complexblocklist>\n")
-	vpr_file.write("      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->\n")
-	vpr_file.write("     <pb_type name=\"io\" capacity=\"8\">\n")
-	vpr_file.write("       <input name=\"outpad\" num_pins=\"1\"/>\n")
-	vpr_file.write("       <output name=\"inpad\" num_pins=\"1\"/>\n")
-	vpr_file.write("       <clock name=\"clock\" num_pins=\"1\"/>\n")
-	vpr_file.write("    <!-- IOs can operate as either inputs or outputs -->\n")
-	vpr_file.write("    <mode name=\"inpad\">\n")
-	vpr_file.write("      <pb_type name=\"inpad\" blif_model=\".input\" num_pb=\"1\">\n")
-	vpr_file.write("        <output name=\"inpad\" num_pins=\"1\"/>\n")
-	vpr_file.write("      </pb_type>\n")
-	vpr_file.write("      <interconnect>\n")
-	vpr_file.write("        <direct name=\"inpad\" input=\"inpad.inpad\" output=\"io.inpad\">\n")
-	vpr_file.write("        <delay_constant max=\"4.243e-11\" in_port=\"inpad.inpad\" out_port=\"io.inpad\"/>\n")
-	vpr_file.write("        </direct>\n")
-	vpr_file.write("      </interconnect>  \n")
-	vpr_file.write("    </mode>\n")
-	vpr_file.write("    <mode name=\"outpad\">\n")
-	vpr_file.write("      <pb_type name=\"outpad\" blif_model=\".output\" num_pb=\"1\">\n")
-	vpr_file.write("        <input name=\"outpad\" num_pins=\"1\"/>\n")
-	vpr_file.write("      </pb_type>\n")
-	vpr_file.write("      <interconnect>\n")
-	vpr_file.write("        <direct name=\"outpad\" input=\"io.outpad\" output=\"outpad.outpad\">\n")
-	vpr_file.write("        <delay_constant max=\"1.394e-11\" in_port=\"io.outpad\" out_port=\"outpad.outpad\"/>\n")
-	vpr_file.write("        </direct>\n")
-	vpr_file.write("      </interconnect>\n")
-	vpr_file.write("    </mode>\n")
-	vpr_file.write("    <fc default_in_type=\"frac\" default_in_val=\"0.15\" default_out_type=\"frac\" default_out_val=\"0.10\"/>\n")
-	vpr_file.write("    <!-- IOs go on the periphery of the FPGA, for consistency, \n")
-	vpr_file.write("      make it physically equivalent on all sides so that only one definition of I/Os is needed.\n")
-	vpr_file.write("      If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA\n")
-	vpr_file.write("    -->\n")
-	vpr_file.write("    <pinlocations pattern=\"custom\">\n")
-	vpr_file.write("      <loc side=\"left\">io.outpad io.inpad io.clock</loc>\n")
-	vpr_file.write("      <loc side=\"top\">io.outpad io.inpad io.clock</loc>\n")
-	vpr_file.write("      <loc side=\"right\">io.outpad io.inpad io.clock</loc>\n")
-	vpr_file.write("      <loc side=\"bottom\">io.outpad io.inpad io.clock</loc>\n")
-	vpr_file.write("    </pinlocations>\n")
-
-
-	vpr_file.write("  </pb_type>\n")
-	vpr_file.write("  <!-- Logic cluster definition -->\n")
-	vpr_file.write("  <pb_type name=\"clb\" area=\""+str(grid_logic_tile_area)+"\">\n")
-	vpr_file.write("    <input name=\"I1\" num_pins=\"" + str(N) + "\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <input name=\"I2\" num_pins=\"" + str(N) + "\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <input name=\"I3\" num_pins=\"" + str(N) + "\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <input name=\"I4\" num_pins=\"" + str(N) + "\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O1\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O2\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O3\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O4\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O5\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O6\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O7\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O8\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O9\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <output name=\"O10\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("    <clock name=\"clk\" num_pins=\"1\"/>")
-
-	vpr_file.write("  <!-- Basic logic element definition -->\n")
-	vpr_file.write("  <pb_type name=\"fle\" num_pb=\""+ str(N) +"\">\n")
-	vpr_file.write("  <input name=\"in_A\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_B\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_C\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_D\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_E\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_F\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	if independent_inputs > 0:
-		vpr_file.write("  <input name=\"in_E2\" num_pins=\"1\" equivalent=\"false\"/>\n")	
-	if independent_inputs > 1:
-		vpr_file.write("  <input name=\"in_D2\" num_pins=\"1\" equivalent=\"false\"/>\n")	
-	if independent_inputs > 2:
-		vpr_file.write("  <input name=\"in_C2\" num_pins=\"1\" equivalent=\"false\"/>\n")	
-	if independent_inputs > 3:
-		vpr_file.write("  <input name=\"in_B2\" num_pins=\"1\" equivalent=\"false\"/>\n")	
-	if independent_inputs > 4:
-		vpr_file.write("  <input name=\"in_A2\" num_pins=\"1\" equivalent=\"false\"/>\n")		
-
-	vpr_file.write("  <output name=\"out_local\" num_pins=\"2\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <output name=\"out_routing\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("  <clock name=\"clk\" num_pins=\"1\"/> \n")
-
-	vpr_file.write("  <mode name=\"n1_lut6\">\n")
-	vpr_file.write("  <pb_type name=\"ble6\" num_pb=\"" + str(1) + "\">\n")
-	vpr_file.write("  <input name=\"in_A\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_B\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_C\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_D\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_E\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_F\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <output name=\"out_local\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <output name=\"out_routing\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("  <clock name=\"clk\" num_pins=\"1\"/> \n")
-	vpr_file.write("  <pb_type name=\"lut6\" blif_model=\".names\" num_pb=\"1\" class=\"lut\">\n")
-	vpr_file.write("  <input name=\"in\" num_pins=\"" + str(K) + "\" port_class=\"lut_in\"/>\n")
-	vpr_file.write("  <output name=\"out\" num_pins=\"1\" port_class=\"lut_out\"/>\n")
-	vpr_file.write("  <!-- We define the LUT delays on the LUT pins instead of through the LUT -->\n")
-	vpr_file.write("  <delay_matrix type=\"max\" in_port=\"lut6.in\" out_port=\"lut6.out\">\n")
-	vpr_file.write("     0\n")
-	vpr_file.write("     0\n")
-	vpr_file.write("     0\n")
-	vpr_file.write("     0\n")
-	vpr_file.write("     0\n")
-	vpr_file.write("     0\n")
-	vpr_file.write("  </delay_matrix>\n")
-	vpr_file.write("  </pb_type>\n")
-	vpr_file.write("  <pb_type name=\"ff\" blif_model=\".latch\" num_pb=\"1\" class=\"flipflop\">\n")
-	vpr_file.write("  <input name=\"D\" num_pins=\"1\" port_class=\"D\"/>\n")
-	vpr_file.write("  <output name=\"Q\" num_pins=\"1\" port_class=\"Q\"/>\n")
-	vpr_file.write("  <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
-	vpr_file.write("  <T_setup value=\"1.891e-11\" port=\"ff.D\" clock=\"clk\"/>\n")
-	vpr_file.write("  <T_clock_to_Q max=\"6.032e-11\" port=\"ff.Q\" clock=\"clk\"/>\n")
-	vpr_file.write("  </pb_type>\n")
-
-	vpr_file.write("      <interconnect>\n")
-
-
-	feedback_mux = {}
-	input_num = 0
-	direct_num = 1
-	for input_name in lut_input_names:
-		if Rfb.count(input_name) != 1 :
-			vpr_file.write("    <direct name=\"direct" + str(input_num) + "\" input=\"ble6.in_" + input_name.upper() + "\" output=\"lut6.in[" + str(input_num) + ":" + str(input_num) + "]\">\n")
-			vpr_file.write("      <delay_constant max=\"" + str(lut_delays[input_name]) + "\" in_port=\"ble6.in_" + input_name.upper() + "\" out_port=\"lut6.in[" + str(input_num) + ":" + str(input_num) + "]\" />\n")
-			vpr_file.write("    </direct>\n")
-
-			direct_num = direct_num + 1
-
-		else:
-			feedback_mux[input_name] = input_num
-
-		input_num = input_num + 1
-
-	vpr_file.write("      <!--Clock -->\n")
-
-	vpr_file.write("      <direct name=\"direct" + str(direct_num) + "\" input=\"ble6.clk\" output=\"ff.clk\"/>\n")
-
-
-	mux_num = 1
-	for name in feedback_mux :
-		vpr_file.write("      <!-- Register feedback mux -->   \n")
-		vpr_file.write("      <mux name=\"mux" + str(mux_num) + "\" input=\"ble6.in_" + name.upper() + " ff.Q\" output=\"lut6.in[" + str(feedback_mux[name]) + ":" + str(feedback_mux[name]) + "]\">\n")
-		vpr_file.write("        <delay_constant max=\"" + str(lut_delays[name]) + "\" in_port=\"ble6.in_" + name.upper() + "\" out_port=\"lut6.in[" + str(feedback_mux[name]) + ":" + str(feedback_mux[name]) + "]\" />\n")
-		vpr_file.write("        <delay_constant max=\"" + str(lut_delays[name]) + "\" in_port=\"ff.Q\" out_port=\"lut6.in[" + str(feedback_mux[name]) + ":" + str(feedback_mux[name]) + "]\" />  \n")
-		vpr_file.write("      </mux>\n")
-		mux_num = mux_num + 1
-		vpr_file.write("      <!-- FF input selection mux -->\n")
-		vpr_file.write("      <mux name=\"" + str(mux_num) + "\" input=\"lut6.out ble6.in_" + name.upper() + "\" output=\"ff.D\">\n")
-		vpr_file.write("        <delay_constant max=\"1.74588e-11\" in_port=\"lut6.out\" out_port=\"ff.D\" />\n")
-		vpr_file.write("        <delay_constant max=\"1.74588e-11\" in_port=\"ble6.in_" + name.upper() + "\" out_port=\"ff.D\" />\n")
-		vpr_file.write("      </mux>\n")
-		mux_num = mux_num + 1
-
-
-	vpr_file.write("      <!-- BLE output (local) -->\n")
-	vpr_file.write("      <mux name=\"mux" + str(mux_num) + "\" input=\"ff.Q lut6.out\" output=\"ble6.out_local\">\n")
-	vpr_file.write("        <delay_constant max=\"" + str(local_feedback) + "\" in_port=\"ff.Q\" out_port=\"ble6.out_local\" />\n")
-	vpr_file.write("        <delay_constant max=\"" + str(local_feedback) + "\" in_port=\"lut6.out\" out_port=\"ble6.out_local\" />\n")
-	vpr_file.write("      </mux>\n")
-	mux_num = mux_num + 1
-
-	vpr_file.write("      <!-- BLE output (routing 1) --> \n")
-	vpr_file.write("      <mux name=\"mux" + str(mux_num) + "\" input=\"ff.Q lut6.out\" output=\"ble6.out_routing[0:0]\">\n")
-	vpr_file.write("        <delay_constant max=\"" + str(logic_block_output)+ "\" in_port=\"ff.Q\" out_port=\"ble6.out_routing[0:0]\" />\n")
-	vpr_file.write("        <delay_constant max=\"" + str(logic_block_output)+ "\" in_port=\"lut6.out\" out_port=\"ble6.out_routing[0:0]\" />\n")
-	vpr_file.write("      </mux>\n")
-	mux_num = mux_num + 1
-
-	vpr_file.write("      <!-- BLE output (routing 2) --> \n")
-	vpr_file.write("      <mux name=\"mux" + str(mux_num) + "\" input=\"ff.Q lut6.out\" output=\"ble6.out_routing[1:1]\">\n")
-	vpr_file.write("        <delay_constant max=\"" + str(logic_block_output)+ "\" in_port=\"ff.Q\" out_port=\"ble6.out_routing[1:1]\" />\n")
-	vpr_file.write("        <delay_constant max=\"" + str(logic_block_output)+ "\" in_port=\"lut6.out\" out_port=\"ble6.out_routing[1:1]\" />\n")
-	vpr_file.write("      </mux>\n")
-	vpr_file.write("      </interconnect>\n")
-	vpr_file.write("    </pb_type>\n")
-	vpr_file.write("  <interconnect>\n")
-	vpr_file.write(" <direct name=\"direct1\" input=\"fle.in_A\" output=\"ble6.in_A\"/>\n")
-	vpr_file.write(" <direct name=\"direct2\" input=\"fle.in_B\" output=\"ble6.in_B\"/>\n")
-	vpr_file.write(" <direct name=\"direct3\" input=\"fle.in_C\" output=\"ble6.in_C\"/>\n")
-	vpr_file.write(" <direct name=\"direct4\" input=\"fle.in_D\" output=\"ble6.in_D\"/>\n")
-	vpr_file.write(" <direct name=\"direct5\" input=\"fle.in_E\" output=\"ble6.in_E\"/>\n")
-	vpr_file.write(" <direct name=\"direct6\" input=\"fle.in_F\" output=\"ble6.in_F\"/>\n")
-	vpr_file.write(" <direct name=\"direct7\" input=\"ble6.out_local\" output=\"fle.out_local[0:0]\"/>\n")
-	vpr_file.write(" <direct name=\"direct8\" input=\"ble6.out_routing\" output=\"fle.out_routing\"/>\n")
-	vpr_file.write(" <direct name=\"direct9\" input=\"fle.clk\" output=\"ble6.clk\"/>\n")
-	vpr_file.write(" </interconnect>\n")
-
-	vpr_file.write("    </mode>  \n")
-	vpr_file.write("    <mode name=\"n2_lut5\">\n")
-	vpr_file.write("      <pb_type name=\"lut5inter\" num_pb=\"1\">\n")
-	vpr_file.write("  <input name=\"in_A\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_B\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_C\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_D\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_E\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	if independent_inputs > 0:
-		vpr_file.write("  <input name=\"in_E2\" num_pins=\"1\" equivalent=\"false\"/>\n")	
-	if independent_inputs > 1:
-		vpr_file.write("  <input name=\"in_D2\" num_pins=\"1\" equivalent=\"false\"/>\n")	
-	if independent_inputs > 2:
-		vpr_file.write("  <input name=\"in_C2\" num_pins=\"1\" equivalent=\"false\"/>\n")	
-	if independent_inputs > 3:
-		vpr_file.write("  <input name=\"in_B2\" num_pins=\"1\" equivalent=\"false\"/>\n")	
-	if independent_inputs > 4:
-		vpr_file.write("  <input name=\"in_A2\" num_pins=\"1\" equivalent=\"false\"/>\n")		
-	vpr_file.write("  <output name=\"out_local\" num_pins=\"2\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <output name=\"out_routing\" num_pins=\"2\" equivalent=\"true\"/>\n")
-	vpr_file.write("  <clock name=\"clk\" num_pins=\"1\"/> \n")
-	vpr_file.write("  <pb_type name=\"ble5\" num_pb=\"2\">\n")
-	vpr_file.write("  <input name=\"in_A\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_B\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_C\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_D\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <input name=\"in_E\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <output name=\"out_local\" num_pins=\"1\" equivalent=\"false\"/>\n")
-	vpr_file.write("  <output name=\"out_routing\" num_pins=\"1\" equivalent=\"true\"/>\n")
-	vpr_file.write("  <clock name=\"clk\" num_pins=\"1\"/> \n")
-	vpr_file.write("          <pb_type name=\"lut5\" blif_model=\".names\" num_pb=\"1\" class=\"lut\">\n")
-	vpr_file.write("            <input name=\"in\" num_pins=\"5\" port_class=\"lut_in\"/>\n")
-	vpr_file.write("            <output name=\"out\" num_pins=\"1\" port_class=\"lut_out\"/>\n")
-	vpr_file.write("  <!-- We define the LUT delays on the LUT pins instead of through the LUT -->\n")
-	vpr_file.write("  <delay_matrix type=\"max\" in_port=\"lut5.in\" out_port=\"lut5.out\">\n")
-	vpr_file.write("     0\n")
-	vpr_file.write("     0\n")
-	vpr_file.write("     0\n")
-	vpr_file.write("     0\n")
-	vpr_file.write("     0\n")
-	vpr_file.write("  </delay_matrix>\n")
-	vpr_file.write("  </pb_type>\n")
-	vpr_file.write("  <pb_type name=\"ff\" blif_model=\".latch\" num_pb=\"1\" class=\"flipflop\">\n")
-	vpr_file.write("  <input name=\"D\" num_pins=\"1\" port_class=\"D\"/>\n")
-	vpr_file.write("  <output name=\"Q\" num_pins=\"1\" port_class=\"Q\"/>\n")
-	vpr_file.write("  <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
-	vpr_file.write("  <T_setup value=\"1.891e-11\" port=\"ff.D\" clock=\"clk\"/>\n")
-	vpr_file.write("  <T_clock_to_Q max=\"6.032e-11\" port=\"ff.Q\" clock=\"clk\"/>\n")
-	vpr_file.write("  </pb_type>\n")
-	vpr_file.write("      <interconnect>\n")
-
-
-
-
-
-	feedback_mux = {}
-	input_num = 0
-	direct_num = 1
-	for input_name in lut_input_names:
-		if Rfb.count(input_name) != 1 and input_num != 5:
-			vpr_file.write("    <direct name=\"direct" + str(input_num) + "\" input=\"ble5.in_" + input_name.upper() + "\" output=\"lut5.in[" + str(input_num) + ":" + str(input_num) + "]\">\n")
-			vpr_file.write("      <delay_constant max=\"" + str(lut_delays[input_name]) + "\" in_port=\"ble5.in_" + input_name.upper() + "\" out_port=\"lut5.in[" + str(input_num) + ":" + str(input_num) + "]\" />\n")
-			vpr_file.write("    </direct>\n")
-
-			direct_num = direct_num + 1
-
-		elif input_num != 5:
-			feedback_mux[input_name] = input_num
-
-		input_num = input_num + 1
-
-	vpr_file.write("      <!--Clock -->\n")
-
-	vpr_file.write("      <direct name=\"direct" + str(direct_num) + "\" input=\"ble5.clk\" output=\"ff.clk\"/>\n")
-
-
-	mux_num = 1
-	for name in feedback_mux :
-		vpr_file.write("      <!-- Register feedback mux -->   \n")
-		vpr_file.write("      <mux name=\"mux" + str(mux_num) + "\" input=\"ble5.in_" + name.upper() + " ff.Q\" output=\"lut5.in[" + str(feedback_mux[name]) + ":" + str(feedback_mux[name]) + "]\">\n")
-		vpr_file.write("        <delay_constant max=\"" + str(lut_delays[name]) + "\" in_port=\"ble5.in_" + name.upper() + "\" out_port=\"lut5.in[" + str(feedback_mux[name]) + ":" + str(feedback_mux[name]) + "]\" />\n")
-		vpr_file.write("        <delay_constant max=\"" + str(lut_delays[name]) + "\" in_port=\"ff.Q\" out_port=\"lut5.in[" + str(feedback_mux[name]) + ":" + str(feedback_mux[name]) + "]\" />  \n")
-		vpr_file.write("      </mux>\n")
-		mux_num = mux_num + 1
-		vpr_file.write("      <!-- FF input selection mux -->\n")
-		vpr_file.write("      <mux name=\"" + str(mux_num) + "\" input=\"lut5.out ble5.in_" + name.upper() + "\" output=\"ff.D\">\n")
-		vpr_file.write("        <delay_constant max=\"1.74588e-11\" in_port=\"lut5.out\" out_port=\"ff.D\" />\n")
-		vpr_file.write("        <delay_constant max=\"1.74588e-11\" in_port=\"ble5.in_" + name.upper() + "\" out_port=\"ff.D\" />\n")
-		vpr_file.write("      </mux>\n")
-		mux_num = mux_num + 1
-
-
-	vpr_file.write("      <!-- BLE output (local) -->\n")
-	vpr_file.write("      <mux name=\"mux" + str(mux_num) + "\" input=\"ff.Q lut5.out\" output=\"ble5.out_local\">\n")
-	vpr_file.write("        <delay_constant max=\"" + str(local_feedback) + "\" in_port=\"ff.Q\" out_port=\"ble5.out_local\" />\n")
-	vpr_file.write("        <delay_constant max=\"" + str(local_feedback) + "\" in_port=\"lut5.out\" out_port=\"ble5.out_local\" />\n")
-	vpr_file.write("      </mux>\n")
-	mux_num = mux_num + 1
-
-	vpr_file.write("      <!-- BLE output (routing 1) --> \n")
-	vpr_file.write("      <mux name=\"mux" + str(mux_num) + "\" input=\"ff.Q lut5.out\" output=\"ble5.out_routing[0:0]\">\n")
-	vpr_file.write("        <delay_constant max=\"" + str(logic_block_output)+ "\" in_port=\"ff.Q\" out_port=\"ble5.out_routing[0:0]\" />\n")
-	vpr_file.write("        <delay_constant max=\"" + str(logic_block_output)+ "\" in_port=\"lut5.out\" out_port=\"ble5.out_routing[0:0]\" />\n")
-	vpr_file.write("      </mux>\n")
-	vpr_file.write(" </interconnect>\n")
-	vpr_file.write("    </pb_type>\n")
-
-	vpr_file.write("  <interconnect>\n")
-	vpr_file.write(" <direct name=\"direct1\" input=\"lut5inter.in_A\" output=\"ble5[0:0].in_A\"/>\n")
-	vpr_file.write(" <direct name=\"direct2\" input=\"lut5inter.in_B\" output=\"ble5[0:0].in_B\"/>\n")
-	vpr_file.write(" <direct name=\"direct3\" input=\"lut5inter.in_C\" output=\"ble5[0:0].in_C\"/>\n")
-	vpr_file.write(" <direct name=\"direct4\" input=\"lut5inter.in_D\" output=\"ble5[0:0].in_D\"/>\n")
-	vpr_file.write(" <direct name=\"direct5\" input=\"lut5inter.in_E\" output=\"ble5[0:0].in_E\"/>\n")
-
-	if independent_inputs > 4:
-		vpr_file.write(" <direct name=\"direct6\" input=\"lut5inter.in_A2\" output=\"ble5[1:1].in_A\"/>\n")
-	else:
-		vpr_file.write(" <direct name=\"direct6\" input=\"lut5inter.in_A\" output=\"ble5[1:1].in_A\"/>\n")
-
-	if independent_inputs > 3:
-		vpr_file.write(" <direct name=\"direct7\" input=\"lut5inter.in_B2\" output=\"ble5[1:1].in_B\"/>\n")
-	else:
-		vpr_file.write(" <direct name=\"direct7\" input=\"lut5inter.in_B\" output=\"ble5[1:1].in_B\"/>\n")
-
-	if independent_inputs > 2:
-		vpr_file.write(" <direct name=\"direct8\" input=\"lut5inter.in_C2\" output=\"ble5[1:1].in_C\"/>\n")
-	else:
-		vpr_file.write(" <direct name=\"direct8\" input=\"lut5inter.in_C\" output=\"ble5[1:1].in_C\"/>\n")
-
-	if independent_inputs > 1:
-		vpr_file.write(" <direct name=\"direct9\" input=\"lut5inter.in_D2\" output=\"ble5[1:1].in_D\"/>\n")
-	else:
-		vpr_file.write(" <direct name=\"direct9\" input=\"lut5inter.in_D\" output=\"ble5[1:1].in_D\"/>\n")
-
-	if independent_inputs > 0:
-		vpr_file.write(" <direct name=\"direct10\" input=\"lut5inter.in_E2\" output=\"ble5[1:1].in_E\"/>\n")
-	else:
-		vpr_file.write(" <direct name=\"direct10\" input=\"lut5inter.in_E\" output=\"ble5[1:1].in_E\"/>\n")
-	vpr_file.write(" <direct name=\"direct11\" input=\"ble5[1:0].out_local\" output=\"lut5inter.out_local\"/>\n")
-	vpr_file.write(" <direct name=\"direct12\" input=\"ble5[1:0].out_routing\" output=\"lut5inter.out_routing\"/>\n") 
-
-	vpr_file.write(" <complete name=\"complete1\" input=\"lut5inter.clk\" output=\"ble5[1:0].clk\"/> \n")                 
-	vpr_file.write("        </interconnect>\n")  
-	vpr_file.write("      </pb_type>\n")  
-
-
-
-
-	vpr_file.write("  <interconnect>\n")
-	vpr_file.write(" <direct name=\"direct1\" input=\"fle.in_A\" output=\"lut5inter.in_A\"/>\n")
-	vpr_file.write(" <direct name=\"direct2\" input=\"fle.in_B\" output=\"lut5inter.in_B\"/>\n")
-	vpr_file.write(" <direct name=\"direct3\" input=\"fle.in_C\" output=\"lut5inter.in_C\"/>\n")
-	vpr_file.write(" <direct name=\"direct4\" input=\"fle.in_D\" output=\"lut5inter.in_D\"/>\n")
-	vpr_file.write(" <direct name=\"direct5\" input=\"fle.in_E\" output=\"lut5inter.in_E\"/>\n")	
-	vpr_file.write(" <direct name=\"direct7\" input=\"lut5inter.out_local\" output=\"fle.out_local\"/>\n")
-	vpr_file.write(" <direct name=\"direct8\" input=\"lut5inter.out_routing\" output=\"fle.out_routing\"/>\n")
-	vpr_file.write(" <direct name=\"direct9\" input=\"fle.clk\" output=\"lut5inter.clk\"/>\n")
-	if independent_inputs > 0:
-		vpr_file.write(" <direct name=\"direct10\" input=\"fle.in_E2\" output=\"lut5inter.in_E2\"/>\n")	
-	if independent_inputs > 1:
-		vpr_file.write(" <direct name=\"direct11\" input=\"fle.in_D2\" output=\"lut5inter.in_D2\"/>\n")	
-	if independent_inputs > 2:
-		vpr_file.write(" <direct name=\"direct12\" input=\"fle.in_C2\" output=\"lut5inter.in_C2\"/>\n")	
-	if independent_inputs > 3:
-		vpr_file.write(" <direct name=\"direct13\" input=\"fle.in_B2\" output=\"lut5inter.in_B2\"/>\n")
-	if independent_inputs > 4:
-		vpr_file.write(" <direct name=\"direct14\" input=\"fle.in_A2\" output=\"lut5inter.in_A2\"/>\n")	
-	vpr_file.write(" </interconnect>\n")
-
-	vpr_file.write("    </mode> \n")
-	vpr_file.write("    </pb_type>\n")
-
-
-
-	vpr_file.write("    <interconnect>\n")
-	vpr_file.write("    <!-- 50% sparsely populated local routing -->\n")
-	vpr_file.write("    <complete name=\"lutA\" input=\"clb.I4 clb.I3 fle[1:0].out_local fle[3:2].out_local fle[8:8].out_local\" output=\"fle[9:0].in_A\">\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I4\" out_port=\"fle.in_A\" />\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I3\" out_port=\"fle.in_A\" />\n")
-	vpr_file.write("      </complete>\n")
-	if independent_inputs > 4:
-		vpr_file.write("    <complete name=\"lutA2\" input=\"clb.I4 clb.I3 fle[1:0].out_local fle[3:2].out_local fle[8:8].out_local\" output=\"fle[9:0].in_A2\">\n")
-		vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I4\" out_port=\"fle.in_A2\" />\n")
-		vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I3\" out_port=\"fle.in_A2\" />\n")
-		vpr_file.write("      </complete>\n")
-	vpr_file.write("    <complete name=\"lutB\" input=\"clb.I3 clb.I2 fle[3:2].out_local fle[5:4].out_local fle[9:9].out_local\" output=\"fle[9:0].in_B\">\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I3\" out_port=\"fle.in_B\" />\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I2\" out_port=\"fle.in_B\" />\n")
-	vpr_file.write("      </complete>\n")
-	if independent_inputs > 3:
-		vpr_file.write("    <complete name=\"lutB2\" input=\"clb.I3 clb.I2 fle[3:2].out_local fle[5:4].out_local fle[9:9].out_local\" output=\"fle[9:0].in_B2\">\n")
-		vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I3\" out_port=\"fle.in_B2\" />\n")
-		vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I2\" out_port=\"fle.in_B2\" />\n")
-		vpr_file.write("      </complete>\n")
-	vpr_file.write("    <complete name=\"lutC\" input=\"clb.I2 clb.I1 fle[5:4].out_local fle[7:6].out_local fle[8:8].out_local\" output=\"fle[9:0].in_C\">\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I2\" out_port=\"fle.in_C\" />\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I1\" out_port=\"fle.in_C\" />\n")
-	vpr_file.write("      </complete>\n")
-	if independent_inputs > 2:
-		vpr_file.write("    <complete name=\"lutC2\" input=\"clb.I2 clb.I1 fle[5:4].out_local fle[7:6].out_local fle[8:8].out_local\" output=\"fle[9:0].in_C2\">\n")
-		vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I2\" out_port=\"fle.in_C2\" />\n")
-		vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I1\" out_port=\"fle.in_C2\" />\n")
-		vpr_file.write("      </complete>\n")
-	vpr_file.write("    <complete name=\"lutD\" input=\"clb.I4 clb.I2 fle[1:0].out_local fle[5:4].out_local fle[9:9].out_local\" output=\"fle[9:0].in_D\">\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I4\" out_port=\"fle.in_D\" />\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I2\" out_port=\"fle.in_D\" />\n")
-	vpr_file.write("      </complete>\n")
-	if independent_inputs > 1:
-		vpr_file.write("    <complete name=\"lutD2\" input=\"clb.I4 clb.I2 fle[1:0].out_local fle[5:4].out_local fle[9:9].out_local\" output=\"fle[9:0].in_D2\">\n")
-		vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I4\" out_port=\"fle.in_D2\" />\n")
-		vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I2\" out_port=\"fle.in_D2\" />\n")
-		vpr_file.write("      </complete>\n")
-	vpr_file.write("    <complete name=\"lutE\" input=\"clb.I3 clb.I1 fle[3:2].out_local fle[7:6].out_local fle[8:8].out_local\" output=\"fle[9:0].in_E\">\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I3\" out_port=\"fle.in_E\" />\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I1\" out_port=\"fle.in_E\" />\n")
-	vpr_file.write("      </complete>\n")
-	if independent_inputs > 0:
-		vpr_file.write("    <complete name=\"lutE2\" input=\"clb.I3 clb.I1 fle[3:2].out_local fle[7:6].out_local fle[8:8].out_local\" output=\"fle[9:0].in_E2\">\n")
-		vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I3\" out_port=\"fle.in_E2\" />\n")
-		vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I1\" out_port=\"fle.in_E2\" />\n")
-		vpr_file.write("      </complete>\n")		
-	vpr_file.write("    <complete name=\"lutF\" input=\"clb.I4 clb.I1 fle[1:0].out_local fle[7:6].out_local fle[9:9].out_local\" output=\"fle[9:0].in_F\">\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I4\" out_port=\"fle.in_F\" />\n")
-	vpr_file.write("      <delay_constant max=\"" + str(local_CLB_routing) + "\" in_port=\"clb.I1\" out_port=\"fle.in_F\" />\n")
-	vpr_file.write("      </complete>\n")
-	vpr_file.write("      <complete name=\"clks\" input=\"clb.clk\" output=\"fle[9:0].clk\">\n")
-	vpr_file.write("      </complete>\n")
-	          
-	vpr_file.write("      <!-- Direct connections to CLB outputs -->\n")
-	vpr_file.write("      <direct name=\"clbouts1\" input=\"fle[0:0].out_routing\" output=\"clb.O1\"/>\n")
-	vpr_file.write("      <direct name=\"clbouts2\" input=\"fle[1:1].out_routing\" output=\"clb.O2\"/>\n")
-	vpr_file.write("      <direct name=\"clbouts3\" input=\"fle[2:2].out_routing\" output=\"clb.O3\"/>\n")
-	vpr_file.write("      <direct name=\"clbouts4\" input=\"fle[3:3].out_routing\" output=\"clb.O4\"/>\n")
-	vpr_file.write("      <direct name=\"clbouts5\" input=\"fle[4:4].out_routing\" output=\"clb.O5\"/>\n")
-	vpr_file.write("      <direct name=\"clbouts6\" input=\"fle[5:5].out_routing\" output=\"clb.O6\"/>\n")
-	vpr_file.write("      <direct name=\"clbouts7\" input=\"fle[6:6].out_routing\" output=\"clb.O7\"/>\n")
-	vpr_file.write("      <direct name=\"clbouts8\" input=\"fle[7:7].out_routing\" output=\"clb.O8\"/>\n")
-	vpr_file.write("      <direct name=\"clbouts9\" input=\"fle[8:8].out_routing\" output=\"clb.O9\"/>\n")
-	vpr_file.write("      <direct name=\"clbouts10\" input=\"fle[9:9].out_routing\" output=\"clb.O10\"/>\n")
-
-	vpr_file.write("    </interconnect>\n")
-	vpr_file.write("    <fc default_in_type=\"frac\" default_in_val=\"" + str(Fcin) + "\" default_out_type=\"frac\" default_out_val=\"" + str(Fcout) + "\"/>\n")
-	vpr_file.write("    <!-- Two sided connectivity CLB architecture--> \n")
-	vpr_file.write("    <pinlocations pattern=\"custom\">\n")
-	vpr_file.write("  <loc side=\"right\">clb.O1 clb.O2 clb.O3 clb.O4 clb.O5 clb.I1 clb.I3 clb.clk</loc> \n")
-	vpr_file.write("      <loc side=\"bottom\">clb.O6 clb.O7 clb.O8 clb.O9 clb.O10 clb.I2 clb.I4 clb.clk</loc>      \n")
-	vpr_file.write("    </pinlocations>\n")
-
-	vpr_file.write("  </pb_type>\n")
-
-	vpr_file.write("  <!-- This is the 36*36 uniform mult -->\n")
-	vpr_file.write("  <pb_type name=\"mult_36\" height=\"4\">\n")
-	vpr_file.write("      <input name=\"a\" num_pins=\"36\"/>\n")
-	vpr_file.write("      <input name=\"b\" num_pins=\"36\"/>\n")
-	vpr_file.write("      <output name=\"out\" num_pins=\"72\"/>\n")
-
-	vpr_file.write("      <mode name=\"two_divisible_mult_18x18\">\n")
-	vpr_file.write("        <pb_type name=\"divisible_mult_18x18\" num_pb=\"2\">\n")
-	vpr_file.write("          <input name=\"a\" num_pins=\"18\"/>\n")
-	vpr_file.write("          <input name=\"b\" num_pins=\"18\"/>\n")
-	vpr_file.write("          <output name=\"out\" num_pins=\"36\"/>\n")
-
-	vpr_file.write("          <mode name=\"two_mult_9x9\">\n")
-	vpr_file.write("            <pb_type name=\"mult_9x9_slice\" num_pb=\"2\">\n")
-	vpr_file.write("              <input name=\"A_cfg\" num_pins=\"9\"/>\n")
-	vpr_file.write("              <input name=\"B_cfg\" num_pins=\"9\"/>\n")
-	vpr_file.write("              <output name=\"OUT_cfg\" num_pins=\"18\"/>\n")
-
-	vpr_file.write("              <pb_type name=\"mult_9x9\" blif_model=\".subckt multiply\" num_pb=\"1\">\n")
-	vpr_file.write("                <input name=\"a\" num_pins=\"9\"/>\n")
-	vpr_file.write("                <input name=\"b\" num_pins=\"9\"/>\n")
-	vpr_file.write("                <output name=\"out\" num_pins=\"18\"/>\n")
-	vpr_file.write("                <delay_constant max=\"1.667e-9\" in_port=\"mult_9x9.a\" out_port=\"mult_9x9.out\"/>\n")
-	vpr_file.write("                <delay_constant max=\"1.667e-9\" in_port=\"mult_9x9.b\" out_port=\"mult_9x9.out\"/>\n")
-	vpr_file.write("              </pb_type>\n")
-
-	vpr_file.write("              <interconnect>\n")
-	vpr_file.write("                <direct name=\"a2a\" input=\"mult_9x9_slice.A_cfg\" output=\"mult_9x9.a\">\n")
-	vpr_file.write("                </direct>\n")
-	vpr_file.write("                <direct name=\"b2b\" input=\"mult_9x9_slice.B_cfg\" output=\"mult_9x9.b\">\n")
-	vpr_file.write("                </direct>\n")
-	vpr_file.write("                <direct name=\"out2out\" input=\"mult_9x9.out\" output=\"mult_9x9_slice.OUT_cfg\">\n")
-	vpr_file.write("                </direct>\n")
-	vpr_file.write("              </interconnect>\n")
-	vpr_file.write("            </pb_type>\n")
-	vpr_file.write("            <interconnect>\n")
-	vpr_file.write("              <direct name=\"a2a\" input=\"divisible_mult_18x18.a\" output=\"mult_9x9_slice[1:0].A_cfg\">\n")
-	vpr_file.write("              </direct>\n")
-	vpr_file.write("              <direct name=\"b2b\" input=\"divisible_mult_18x18.b\" output=\"mult_9x9_slice[1:0].B_cfg\">\n")
-	vpr_file.write("              </direct>\n")
-	vpr_file.write("              <direct name=\"out2out\" input=\"mult_9x9_slice[1:0].OUT_cfg\" output=\"divisible_mult_18x18.out\">\n")
-	vpr_file.write("              </direct>\n")
-	vpr_file.write("            </interconnect>\n")
-	vpr_file.write("          </mode>\n")
-
-	vpr_file.write("          <mode name=\"mult_18x18\">\n")
-	vpr_file.write("            <pb_type name=\"mult_18x18_slice\" num_pb=\"1\">\n")
-	vpr_file.write("              <input name=\"A_cfg\" num_pins=\"18\"/>\n")
-	vpr_file.write("              <input name=\"B_cfg\" num_pins=\"18\"/>\n")
-	vpr_file.write("              <output name=\"OUT_cfg\" num_pins=\"36\"/>\n")
-
-	vpr_file.write("              <pb_type name=\"mult_18x18\" blif_model=\".subckt multiply\" num_pb=\"1\" >\n")
-	vpr_file.write("                <input name=\"a\" num_pins=\"18\"/>\n")
-	vpr_file.write("                <input name=\"b\" num_pins=\"18\"/>\n")
-	vpr_file.write("                <output name=\"out\" num_pins=\"36\"/>\n")
-	vpr_file.write("                <delay_constant max=\"1.667e-9\" in_port=\"mult_18x18.a\" out_port=\"mult_18x18.out\"/>\n")
-	vpr_file.write("                <delay_constant max=\"1.667e-9\" in_port=\"mult_18x18.b\" out_port=\"mult_18x18.out\"/>\n")
-	vpr_file.write("              </pb_type>\n")
-
-	vpr_file.write("              <interconnect>\n")
-	vpr_file.write("                <direct name=\"a2a\" input=\"mult_18x18_slice.A_cfg\" output=\"mult_18x18.a\">\n")
-	vpr_file.write("                </direct>\n")
-	vpr_file.write("                <direct name=\"b2b\" input=\"mult_18x18_slice.B_cfg\" output=\"mult_18x18.b\">\n")
-	vpr_file.write("                </direct>\n")
-	vpr_file.write("                <direct name=\"out2out\" input=\"mult_18x18.out\" output=\"mult_18x18_slice.OUT_cfg\">\n")
-	vpr_file.write("                </direct>\n")
-	vpr_file.write("              </interconnect>\n")
-	vpr_file.write("            </pb_type>\n")
-	vpr_file.write("            <interconnect>\n")
-	vpr_file.write("              <direct name=\"a2a\" input=\"divisible_mult_18x18.a\" output=\"mult_18x18_slice.A_cfg\">\n")
-	vpr_file.write("              </direct>\n")
-	vpr_file.write("              <direct name=\"b2b\" input=\"divisible_mult_18x18.b\" output=\"mult_18x18_slice.B_cfg\">\n")
-	vpr_file.write("              </direct>\n")
-	vpr_file.write("              <direct name=\"out2out\" input=\"mult_18x18_slice.OUT_cfg\" output=\"divisible_mult_18x18.out\">\n")
-	vpr_file.write("              </direct>\n")
-	vpr_file.write("            </interconnect>\n")
-	vpr_file.write("          </mode>\n")
-	vpr_file.write("        </pb_type>\n")
-	vpr_file.write("        <interconnect>\n")
-	vpr_file.write("          <direct name=\"a2a\" input=\"mult_36.a\" output=\"divisible_mult_18x18[1:0].a\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"b2b\" input=\"mult_36.b\" output=\"divisible_mult_18x18[1:0].b\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"out2out\" input=\"divisible_mult_18x18[1:0].out\" output=\"mult_36.out\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("        </interconnect>\n")
-	vpr_file.write("      </mode>\n")
-
-	vpr_file.write("      <mode name=\"mult_36x36\">\n")
-	vpr_file.write("        <pb_type name=\"mult_36x36_slice\" num_pb=\"1\">\n")
-	vpr_file.write("          <input name=\"A_cfg\" num_pins=\"36\"/>\n")
-	vpr_file.write("          <input name=\"B_cfg\" num_pins=\"36\"/>\n")
-	vpr_file.write("          <output name=\"OUT_cfg\" num_pins=\"72\"/>\n")
-
-	vpr_file.write("          <pb_type name=\"mult_36x36\" blif_model=\".subckt multiply\" num_pb=\"1\">\n")
-	vpr_file.write("            <input name=\"a\" num_pins=\"36\"/>\n")
-	vpr_file.write("            <input name=\"b\" num_pins=\"36\"/>\n")
-	vpr_file.write("            <output name=\"out\" num_pins=\"72\"/>\n")
-	vpr_file.write("            <delay_constant max=\"1.667e-9\" in_port=\"mult_36x36.a\" out_port=\"mult_36x36.out\"/>\n")
-	vpr_file.write("            <delay_constant max=\"1.667e-9\" in_port=\"mult_36x36.b\" out_port=\"mult_36x36.out\"/>\n")
-	vpr_file.write("          </pb_type>\n")
-
-	vpr_file.write("          <interconnect>\n")
-	vpr_file.write("            <direct name=\"a2a\" input=\"mult_36x36_slice.A_cfg\" output=\"mult_36x36.a\">\n")
-	vpr_file.write("            </direct>\n")
-	vpr_file.write("            <direct name=\"b2b\" input=\"mult_36x36_slice.B_cfg\" output=\"mult_36x36.b\">\n")
-	vpr_file.write("            </direct>\n")
-	vpr_file.write("            <direct name=\"out2out\" input=\"mult_36x36.out\" output=\"mult_36x36_slice.OUT_cfg\">\n")
-	vpr_file.write("            </direct>\n")
-	vpr_file.write("          </interconnect>\n")
-	vpr_file.write("        </pb_type>\n")
-	vpr_file.write("        <interconnect>\n")
-	vpr_file.write("          <direct name=\"a2a\" input=\"mult_36.a\" output=\"mult_36x36_slice.A_cfg\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"b2b\" input=\"mult_36.b\" output=\"mult_36x36_slice.B_cfg\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"out2out\" input=\"mult_36x36_slice.OUT_cfg\" output=\"mult_36.out\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("        </interconnect>\n")
-	vpr_file.write("      </mode>\n")
-
-	vpr_file.write("    <fc default_in_type=\"frac\" default_in_val=\"0.15\" default_out_type=\"frac\" default_out_val=\"0.10\"/>\n")
-	vpr_file.write("    <pinlocations pattern=\"spread\"/>\n")
-
-
-	vpr_file.write("  </pb_type>\n")
-
-
-	vpr_file.write("<!-- 32 Kb Memory based off Stratix IV 9K memory and Virtex V 36 Kb.  Setup time set to match flip-flop setup time at 40 nm. Clock to q based off Stratix IV 600 max MHz  -->\n")
-	vpr_file.write("  <pb_type name=\"memory\" height=\"6\">\n")
-	vpr_file.write("      <input name=\"addr1\" num_pins=\"15\"/>\n")
-	vpr_file.write("      <input name=\"addr2\" num_pins=\"15\"/>\n")
-	vpr_file.write("      <input name=\"data\" num_pins=\"64\"/>\n")
-	vpr_file.write("      <input name=\"we1\" num_pins=\"1\"/>\n")
-	vpr_file.write("      <input name=\"we2\" num_pins=\"1\"/>\n")
-	vpr_file.write("      <output name=\"out\" num_pins=\"64\"/>\n")
-	vpr_file.write("      <clock name=\"clk\" num_pins=\"1\"/>\n")
-
-	vpr_file.write("      <mode name=\"mem_512x64_sp\">\n")
-	vpr_file.write("        <pb_type name=\"mem_512x64_sp\" blif_model=\".subckt single_port_ram\" class=\"memory\" num_pb=\"1\">\n")
-	vpr_file.write("          <input name=\"addr\" num_pins=\"9\" port_class=\"address\"/>\n")
-	vpr_file.write("          <input name=\"data\" num_pins=\"64\" port_class=\"data_in\"/>\n")
-	vpr_file.write("          <input name=\"we\" num_pins=\"1\" port_class=\"write_en\"/>\n")
-	vpr_file.write("          <output name=\"out\" num_pins=\"64\" port_class=\"data_out\"/>\n")
-	vpr_file.write("          <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_512x64_sp.addr\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_512x64_sp.data\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_512x64_sp.we\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_512x64_sp.out\" clock=\"clk\"/>\n")
-	vpr_file.write("        </pb_type>\n")
-	vpr_file.write("        <interconnect>\n")
-	vpr_file.write("          <direct name=\"address1\" input=\"memory.addr1[8:0]\" output=\"mem_512x64_sp.addr\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data1\" input=\"memory.data[63:0]\" output=\"mem_512x64_sp.data\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen1\" input=\"memory.we1\" output=\"mem_512x64_sp.we\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout1\" input=\"mem_512x64_sp.out\" output=\"memory.out[63:0]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"clk\" input=\"memory.clk\" output=\"mem_512x64_sp.clk\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("        </interconnect>\n")
-	vpr_file.write("      </mode>\n")
-	          
-	vpr_file.write("      <mode name=\"mem_1024x32_sp\">\n")
-	vpr_file.write("        <pb_type name=\"mem_1024x32_sp\" blif_model=\".subckt single_port_ram\" class=\"memory\" num_pb=\"1\">\n")
-	vpr_file.write("          <input name=\"addr\" num_pins=\"" + str(N) + "\" port_class=\"address\"/>\n")
-	vpr_file.write("          <input name=\"data\" num_pins=\"32\" port_class=\"data_in\"/>\n")
-	vpr_file.write("          <input name=\"we\" num_pins=\"1\" port_class=\"write_en\"/>\n")
-	vpr_file.write("          <output name=\"out\" num_pins=\"32\" port_class=\"data_out\"/>\n")
-	vpr_file.write("          <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_1024x32_sp.addr\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_1024x32_sp.data\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_1024x32_sp.we\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_1024x32_sp.out\" clock=\"clk\"/>\n")
-	vpr_file.write("        </pb_type>\n")
-	vpr_file.write("        <interconnect>\n")
-	vpr_file.write("          <direct name=\"address1\" input=\"memory.addr1[9:0]\" output=\"mem_1024x32_sp.addr\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data1\" input=\"memory.data[31:0]\" output=\"mem_1024x32_sp.data\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen1\" input=\"memory.we1\" output=\"mem_1024x32_sp.we\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout1\" input=\"mem_1024x32_sp.out\" output=\"memory.out[31:0]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"clk\" input=\"memory.clk\" output=\"mem_1024x32_sp.clk\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("        </interconnect>\n")
-	vpr_file.write("      </mode>\n")
-
-	          
-	vpr_file.write("      <mode name=\"mem_2048x16_sp\">\n")
-	vpr_file.write("        <pb_type name=\"mem_2048x16_sp\" blif_model=\".subckt single_port_ram\" class=\"memory\" num_pb=\"1\">\n")
-	vpr_file.write("          <input name=\"addr\" num_pins=\"11\" port_class=\"address\"/>\n")
-	vpr_file.write("          <input name=\"data\" num_pins=\"16\" port_class=\"data_in\"/>\n")
-	vpr_file.write("          <input name=\"we\" num_pins=\"1\" port_class=\"write_en\"/>\n")
-	vpr_file.write("          <output name=\"out\" num_pins=\"16\" port_class=\"data_out\"/>\n")
-	vpr_file.write("          <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_2048x16_sp.addr\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_2048x16_sp.data\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_2048x16_sp.we\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_2048x16_sp.out\" clock=\"clk\"/>\n")
-	vpr_file.write("        </pb_type>\n")
-	vpr_file.write("        <interconnect>\n")
-	vpr_file.write("          <direct name=\"address1\" input=\"memory.addr1[10:0]\" output=\"mem_2048x16_sp.addr\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data1\" input=\"memory.data[15:0]\" output=\"mem_2048x16_sp.data\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen1\" input=\"memory.we1\" output=\"mem_2048x16_sp.we\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout1\" input=\"mem_2048x16_sp.out\" output=\"memory.out[15:0]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"clk\" input=\"memory.clk\" output=\"mem_2048x16_sp.clk\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("        </interconnect>\n")
-	vpr_file.write("      </mode>\n")
-
-	vpr_file.write("      <mode name=\"mem_4096x8_sp\">\n")
-	vpr_file.write("        <pb_type name=\"mem_4096x8_sp\" blif_model=\".subckt single_port_ram\" class=\"memory\" num_pb=\"1\">\n")
-	vpr_file.write("          <input name=\"addr\" num_pins=\"12\" port_class=\"address\"/>\n")
-	vpr_file.write("          <input name=\"data\" num_pins=\"8\" port_class=\"data_in\"/>\n")
-	vpr_file.write("          <input name=\"we\" num_pins=\"1\" port_class=\"write_en\"/>\n")
-	vpr_file.write("          <output name=\"out\" num_pins=\"8\" port_class=\"data_out\"/>\n")
-	vpr_file.write("          <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_4096x8_sp.addr\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_4096x8_sp.data\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_4096x8_sp.we\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_4096x8_sp.out\" clock=\"clk\"/>\n")
-	vpr_file.write("        </pb_type>\n")
-	vpr_file.write("        <interconnect>\n")
-	vpr_file.write("          <direct name=\"address1\" input=\"memory.addr1[11:0]\" output=\"mem_4096x8_sp.addr\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data1\" input=\"memory.data[7:0]\" output=\"mem_4096x8_sp.data\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen1\" input=\"memory.we1\" output=\"mem_4096x8_sp.we\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout1\" input=\"mem_4096x8_sp.out\" output=\"memory.out[7:0]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"clk\" input=\"memory.clk\" output=\"mem_4096x8_sp.clk\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("        </interconnect>\n")
-	vpr_file.write("      </mode>\n")
-	 
-	vpr_file.write("      <mode name=\"mem_8192x4_sp\">\n")
-	vpr_file.write("        <pb_type name=\"mem_8192x4_sp\" blif_model=\".subckt single_port_ram\" class=\"memory\" num_pb=\"1\">\n")
-	vpr_file.write("          <input name=\"addr\" num_pins=\"13\" port_class=\"address\"/>\n")
-	vpr_file.write("          <input name=\"data\" num_pins=\"4\" port_class=\"data_in\"/>\n")
-	vpr_file.write("          <input name=\"we\" num_pins=\"1\" port_class=\"write_en\"/>\n")
-	vpr_file.write("          <output name=\"out\" num_pins=\"4\" port_class=\"data_out\"/>\n")
-	vpr_file.write("          <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_8192x4_sp.addr\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_8192x4_sp.data\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_8192x4_sp.we\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_8192x4_sp.out\" clock=\"clk\"/>\n")
-	vpr_file.write("        </pb_type>\n")
-	vpr_file.write("        <interconnect>\n")
-	vpr_file.write("          <direct name=\"address1\" input=\"memory.addr1[12:0]\" output=\"mem_8192x4_sp.addr\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data1\" input=\"memory.data[3:0]\" output=\"mem_8192x4_sp.data\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen1\" input=\"memory.we1\" output=\"mem_8192x4_sp.we\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout1\" input=\"mem_8192x4_sp.out\" output=\"memory.out[3:0]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"clk\" input=\"memory.clk\" output=\"mem_8192x4_sp.clk\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("        </interconnect>\n")
-	vpr_file.write("      </mode>\n")
-
-	vpr_file.write("      <mode name=\"mem_16384x2_sp\">\n")
-	vpr_file.write("        <pb_type name=\"mem_16384x2_sp\" blif_model=\".subckt single_port_ram\" class=\"memory\" num_pb=\"1\">\n")
-	vpr_file.write("          <input name=\"addr\" num_pins=\"14\" port_class=\"address\"/>\n")
-	vpr_file.write("          <input name=\"data\" num_pins=\"2\" port_class=\"data_in\"/>\n")
-	vpr_file.write("          <input name=\"we\" num_pins=\"1\" port_class=\"write_en\"/>\n")
-	vpr_file.write("          <output name=\"out\" num_pins=\"2\" port_class=\"data_out\"/>\n")
-	vpr_file.write("          <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_16384x2_sp.addr\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_16384x2_sp.data\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_16384x2_sp.we\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_16384x2_sp.out\" clock=\"clk\"/>\n")
-	vpr_file.write("        </pb_type>\n")
-	vpr_file.write("        <interconnect>\n")
-	vpr_file.write("          <direct name=\"address1\" input=\"memory.addr1[13:0]\" output=\"mem_16384x2_sp.addr\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data1\" input=\"memory.data[1:0]\" output=\"mem_16384x2_sp.data\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen1\" input=\"memory.we1\" output=\"mem_16384x2_sp.we\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout1\" input=\"mem_16384x2_sp.out\" output=\"memory.out[1:0]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"clk\" input=\"memory.clk\" output=\"mem_16384x2_sp.clk\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("        </interconnect>\n")
-	vpr_file.write("      </mode>  \n")
-	          
-	vpr_file.write("      <mode name=\"mem_32768x1_sp\">\n")
-	vpr_file.write("        <pb_type name=\"mem_32768x1_sp\" blif_model=\".subckt single_port_ram\" class=\"memory\" num_pb=\"1\">\n")
-	vpr_file.write("          <input name=\"addr\" num_pins=\"15\" port_class=\"address\"/>\n")
-	vpr_file.write("          <input name=\"data\" num_pins=\"1\" port_class=\"data_in\"/>\n")
-	vpr_file.write("          <input name=\"we\" num_pins=\"1\" port_class=\"write_en\"/>\n")
-	vpr_file.write("          <output name=\"out\" num_pins=\"1\" port_class=\"data_out\"/>\n")
-	vpr_file.write("          <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_32768x1_sp.addr\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_32768x1_sp.data\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_32768x1_sp.we\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_32768x1_sp.out\" clock=\"clk\"/>\n")
-	vpr_file.write("        </pb_type>\n")
-	vpr_file.write("        <interconnect>\n")
-	vpr_file.write("          <direct name=\"address1\" input=\"memory.addr1[14:0]\" output=\"mem_32768x1_sp.addr\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data1\" input=\"memory.data[0:0]\" output=\"mem_32768x1_sp.data\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen1\" input=\"memory.we1\" output=\"mem_32768x1_sp.we\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout1\" input=\"mem_32768x1_sp.out\" output=\"memory.out[0:0]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"clk\" input=\"memory.clk\" output=\"mem_32768x1_sp.clk\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("        </interconnect>\n")
-	vpr_file.write("      </mode> \n")
-	                   
-	vpr_file.write("      <mode name=\"mem_1024x32_dp\">\n")
-	vpr_file.write("        <pb_type name=\"mem_1024x32_dp\" blif_model=\".subckt dual_port_ram\" class=\"memory\" num_pb=\"1\">\n")
-	vpr_file.write("          <input name=\"addr1\" num_pins=\"" + str(N) + "\" port_class=\"address1\"/>\n")
-	vpr_file.write("          <input name=\"addr2\" num_pins=\"" + str(N) + "\" port_class=\"address2\"/>\n")
-	vpr_file.write("          <input name=\"data1\" num_pins=\"32\" port_class=\"data_in1\"/>\n")
-	vpr_file.write("          <input name=\"data2\" num_pins=\"32\" port_class=\"data_in2\"/>\n")
-	vpr_file.write("          <input name=\"we1\" num_pins=\"1\" port_class=\"write_en1\"/>\n")
-	vpr_file.write("          <input name=\"we2\" num_pins=\"1\" port_class=\"write_en2\"/>\n")
-	vpr_file.write("          <output name=\"out1\" num_pins=\"32\" port_class=\"data_out1\"/>\n")
-	vpr_file.write("          <output name=\"out2\" num_pins=\"32\" port_class=\"data_out2\"/>\n")
-	vpr_file.write("          <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_1024x32_dp.addr1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_1024x32_dp.data1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_1024x32_dp.we1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_1024x32_dp.addr2\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_1024x32_dp.data2\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_1024x32_dp.we2\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_1024x32_dp.out1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_1024x32_dp.out2\" clock=\"clk\"/>\n")
-	vpr_file.write("        </pb_type>\n")
-	vpr_file.write("        <interconnect>\n")
-	vpr_file.write("          <direct name=\"address1\" input=\"memory.addr1[9:0]\" output=\"mem_1024x32_dp.addr1\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"address2\" input=\"memory.addr2[9:0]\" output=\"mem_1024x32_dp.addr2\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data1\" input=\"memory.data[31:0]\" output=\"mem_1024x32_dp.data1\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data2\" input=\"memory.data[63:32]\" output=\"mem_1024x32_dp.data2\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen1\" input=\"memory.we1\" output=\"mem_1024x32_dp.we1\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen2\" input=\"memory.we2\" output=\"mem_1024x32_dp.we2\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout1\" input=\"mem_1024x32_dp.out1\" output=\"memory.out[31:0]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout2\" input=\"mem_1024x32_dp.out2\" output=\"memory.out[63:32]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"clk\" input=\"memory.clk\" output=\"mem_1024x32_dp.clk\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("        </interconnect>\n")
-	vpr_file.write("      </mode>\n")
-	          
-	vpr_file.write("      <mode name=\"mem_2048x16_dp\">\n")
-	vpr_file.write("        <pb_type name=\"mem_2048x16_dp\" blif_model=\".subckt dual_port_ram\" class=\"memory\" num_pb=\"1\">\n")
-	vpr_file.write("          <input name=\"addr1\" num_pins=\"11\" port_class=\"address1\"/>\n")
-	vpr_file.write("          <input name=\"addr2\" num_pins=\"11\" port_class=\"address2\"/>\n")
-	vpr_file.write("          <input name=\"data1\" num_pins=\"16\" port_class=\"data_in1\"/>\n")
-	vpr_file.write("          <input name=\"data2\" num_pins=\"16\" port_class=\"data_in2\"/>\n")
-	vpr_file.write("          <input name=\"we1\" num_pins=\"1\" port_class=\"write_en1\"/>\n")
-	vpr_file.write("          <input name=\"we2\" num_pins=\"1\" port_class=\"write_en2\"/>\n")
-	vpr_file.write("          <output name=\"out1\" num_pins=\"16\" port_class=\"data_out1\"/>\n")
-	vpr_file.write("          <output name=\"out2\" num_pins=\"16\" port_class=\"data_out2\"/>\n")
-	vpr_file.write("          <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_2048x16_dp.addr1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_2048x16_dp.data1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_2048x16_dp.we1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_2048x16_dp.addr2\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_2048x16_dp.data2\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_2048x16_dp.we2\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_2048x16_dp.out1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_2048x16_dp.out2\" clock=\"clk\"/>\n")
-	vpr_file.write("        </pb_type>\n")
-	vpr_file.write("        <interconnect>\n")
-	vpr_file.write("          <direct name=\"address1\" input=\"memory.addr1[10:0]\" output=\"mem_2048x16_dp.addr1\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"address2\" input=\"memory.addr2[10:0]\" output=\"mem_2048x16_dp.addr2\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data1\" input=\"memory.data[15:0]\" output=\"mem_2048x16_dp.data1\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data2\" input=\"memory.data[31:16]\" output=\"mem_2048x16_dp.data2\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen1\" input=\"memory.we1\" output=\"mem_2048x16_dp.we1\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen2\" input=\"memory.we2\" output=\"mem_2048x16_dp.we2\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout1\" input=\"mem_2048x16_dp.out1\" output=\"memory.out[15:0]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout2\" input=\"mem_2048x16_dp.out2\" output=\"memory.out[31:16]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"clk\" input=\"memory.clk\" output=\"mem_2048x16_dp.clk\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("        </interconnect>\n")
-	vpr_file.write("      </mode>\n")
-	          
-	vpr_file.write("      <mode name=\"mem_2048x8_dp\">\n")
-	vpr_file.write("        <pb_type name=\"mem_2048x8_dp\" blif_model=\".subckt dual_port_ram\" class=\"memory\" num_pb=\"1\">\n")
-	vpr_file.write("          <input name=\"addr1\" num_pins=\"12\" port_class=\"address1\"/>\n")
-	vpr_file.write("          <input name=\"addr2\" num_pins=\"12\" port_class=\"address2\"/>\n")
-	vpr_file.write("          <input name=\"data1\" num_pins=\"8\" port_class=\"data_in1\"/>\n")
-	vpr_file.write("          <input name=\"data2\" num_pins=\"8\" port_class=\"data_in2\"/>\n")
-	vpr_file.write("          <input name=\"we1\" num_pins=\"1\" port_class=\"write_en1\"/>\n")
-	vpr_file.write("          <input name=\"we2\" num_pins=\"1\" port_class=\"write_en2\"/>\n")
-	vpr_file.write("          <output name=\"out1\" num_pins=\"8\" port_class=\"data_out1\"/>\n")
-	vpr_file.write("          <output name=\"out2\" num_pins=\"8\" port_class=\"data_out2\"/>\n")
-	vpr_file.write("          <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_2048x8_dp.addr1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_2048x8_dp.data1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_2048x8_dp.we1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_2048x8_dp.addr2\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_2048x8_dp.data2\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_2048x8_dp.we2\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_2048x8_dp.out1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_2048x8_dp.out2\" clock=\"clk\"/>\n")
-	vpr_file.write("        </pb_type>\n")
-	vpr_file.write("        <interconnect>\n")
-	vpr_file.write("          <direct name=\"address1\" input=\"memory.addr1[11:0]\" output=\"mem_2048x8_dp.addr1\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"address2\" input=\"memory.addr2[11:0]\" output=\"mem_2048x8_dp.addr2\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data1\" input=\"memory.data[7:0]\" output=\"mem_2048x8_dp.data1\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data2\" input=\"memory.data[15:8]\" output=\"mem_2048x8_dp.data2\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen1\" input=\"memory.we1\" output=\"mem_2048x8_dp.we1\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen2\" input=\"memory.we2\" output=\"mem_2048x8_dp.we2\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout1\" input=\"mem_2048x8_dp.out1\" output=\"memory.out[7:0]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout2\" input=\"mem_2048x8_dp.out2\" output=\"memory.out[15:8]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"clk\" input=\"memory.clk\" output=\"mem_2048x8_dp.clk\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("        </interconnect>\n")
-	vpr_file.write("      </mode>\n")
-	vpr_file.write("      <mode name=\"mem_8192x4_dp\">\n")
-	vpr_file.write("        <pb_type name=\"mem_8192x4_dp\" blif_model=\".subckt dual_port_ram\" class=\"memory\" num_pb=\"1\">\n")
-	vpr_file.write("          <input name=\"addr1\" num_pins=\"13\" port_class=\"address1\"/>\n")
-	vpr_file.write("          <input name=\"addr2\" num_pins=\"13\" port_class=\"address2\"/>\n")
-	vpr_file.write("          <input name=\"data1\" num_pins=\"4\" port_class=\"data_in1\"/>\n")
-	vpr_file.write("          <input name=\"data2\" num_pins=\"4\" port_class=\"data_in2\"/>\n")
-	vpr_file.write("          <input name=\"we1\" num_pins=\"1\" port_class=\"write_en1\"/>\n")
-	vpr_file.write("          <input name=\"we2\" num_pins=\"1\" port_class=\"write_en2\"/>\n")
-	vpr_file.write("          <output name=\"out1\" num_pins=\"4\" port_class=\"data_out1\"/>\n")
-	vpr_file.write("          <output name=\"out2\" num_pins=\"4\" port_class=\"data_out2\"/>\n")
-	vpr_file.write("          <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_8192x4_dp.addr1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_8192x4_dp.data1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_8192x4_dp.we1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_8192x4_dp.addr2\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_8192x4_dp.data2\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_8192x4_dp.we2\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_8192x4_dp.out1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_8192x4_dp.out2\" clock=\"clk\"/>\n")
-	vpr_file.write("        </pb_type>\n")
-	vpr_file.write("        <interconnect>\n")
-	vpr_file.write("          <direct name=\"address1\" input=\"memory.addr1[12:0]\" output=\"mem_8192x4_dp.addr1\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"address2\" input=\"memory.addr2[12:0]\" output=\"mem_8192x4_dp.addr2\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data1\" input=\"memory.data[3:0]\" output=\"mem_8192x4_dp.data1\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data2\" input=\"memory.data[7:4]\" output=\"mem_8192x4_dp.data2\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen1\" input=\"memory.we1\" output=\"mem_8192x4_dp.we1\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen2\" input=\"memory.we2\" output=\"mem_8192x4_dp.we2\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout1\" input=\"mem_8192x4_dp.out1\" output=\"memory.out[3:0]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout2\" input=\"mem_8192x4_dp.out2\" output=\"memory.out[7:4]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"clk\" input=\"memory.clk\" output=\"mem_8192x4_dp.clk\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("        </interconnect>\n")
-	vpr_file.write("      </mode>\n")
-	vpr_file.write("      <mode name=\"mem_16384x2_dp\">\n")
-	vpr_file.write("        <pb_type name=\"mem_16384x2_dp\" blif_model=\".subckt dual_port_ram\" class=\"memory\" num_pb=\"1\">\n")
-	vpr_file.write("          <input name=\"addr1\" num_pins=\"14\" port_class=\"address1\"/>\n")
-	vpr_file.write("          <input name=\"addr2\" num_pins=\"14\" port_class=\"address2\"/>\n")
-	vpr_file.write("          <input name=\"data1\" num_pins=\"2\" port_class=\"data_in1\"/>\n")
-	vpr_file.write("          <input name=\"data2\" num_pins=\"2\" port_class=\"data_in2\"/>\n")
-	vpr_file.write("          <input name=\"we1\" num_pins=\"1\" port_class=\"write_en1\"/>\n")
-	vpr_file.write("          <input name=\"we2\" num_pins=\"1\" port_class=\"write_en2\"/>\n")
-	vpr_file.write("          <output name=\"out1\" num_pins=\"2\" port_class=\"data_out1\"/>\n")
-	vpr_file.write("          <output name=\"out2\" num_pins=\"2\" port_class=\"data_out2\"/>\n")
-	vpr_file.write("          <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_16384x2_dp.addr1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_16384x2_dp.data1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_16384x2_dp.we1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_16384x2_dp.addr2\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_16384x2_dp.data2\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_16384x2_dp.we2\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_16384x2_dp.out1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_16384x2_dp.out2\" clock=\"clk\"/>\n")
-	vpr_file.write("        </pb_type>\n")
-	vpr_file.write("        <interconnect>\n")
-	vpr_file.write("          <direct name=\"address1\" input=\"memory.addr1[13:0]\" output=\"mem_16384x2_dp.addr1\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"address2\" input=\"memory.addr2[13:0]\" output=\"mem_16384x2_dp.addr2\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data1\" input=\"memory.data[1:0]\" output=\"mem_16384x2_dp.data1\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data2\" input=\"memory.data[3:2]\" output=\"mem_16384x2_dp.data2\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen1\" input=\"memory.we1\" output=\"mem_16384x2_dp.we1\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen2\" input=\"memory.we2\" output=\"mem_16384x2_dp.we2\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout1\" input=\"mem_16384x2_dp.out1\" output=\"memory.out[1:0]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout2\" input=\"mem_16384x2_dp.out2\" output=\"memory.out[3:2]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"clk\" input=\"memory.clk\" output=\"mem_16384x2_dp.clk\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("        </interconnect>\n")
-	vpr_file.write("      </mode>\n")
-	          
-	vpr_file.write("      <mode name=\"mem_32768x1_dp\">\n")
-	vpr_file.write("        <pb_type name=\"mem_32768x1_dp\" blif_model=\".subckt dual_port_ram\" class=\"memory\" num_pb=\"1\">\n")
-	vpr_file.write("          <input name=\"addr1\" num_pins=\"15\" port_class=\"address1\"/>\n")
-	vpr_file.write("          <input name=\"addr2\" num_pins=\"15\" port_class=\"address2\"/>\n")
-	vpr_file.write("          <input name=\"data1\" num_pins=\"1\" port_class=\"data_in1\"/>\n")
-	vpr_file.write("          <input name=\"data2\" num_pins=\"1\" port_class=\"data_in2\"/>\n")
-	vpr_file.write("          <input name=\"we1\" num_pins=\"1\" port_class=\"write_en1\"/>\n")
-	vpr_file.write("          <input name=\"we2\" num_pins=\"1\" port_class=\"write_en2\"/>\n")
-	vpr_file.write("          <output name=\"out1\" num_pins=\"1\" port_class=\"data_out1\"/>\n")
-	vpr_file.write("          <output name=\"out2\" num_pins=\"1\" port_class=\"data_out2\"/>\n")
-	vpr_file.write("          <clock name=\"clk\" num_pins=\"1\" port_class=\"clock\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_32768x1_dp.addr1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_32768x1_dp.data1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_32768x1_dp.we1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_32768x1_dp.addr2\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_32768x1_dp.data2\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_setup value=\"2.448e-10\" port=\"mem_32768x1_dp.we2\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_32768x1_dp.out1\" clock=\"clk\"/>\n")
-	vpr_file.write("          <T_clock_to_Q max=\"1.667e-9\" port=\"mem_32768x1_dp.out2\" clock=\"clk\"/>\n")
-	vpr_file.write("        </pb_type>\n")
-	vpr_file.write("        <interconnect>\n")
-	vpr_file.write("          <direct name=\"address1\" input=\"memory.addr1[14:0]\" output=\"mem_32768x1_dp.addr1\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"address2\" input=\"memory.addr2[14:0]\" output=\"mem_32768x1_dp.addr2\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data1\" input=\"memory.data[0:0]\" output=\"mem_32768x1_dp.data1\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"data2\" input=\"memory.data[1:1]\" output=\"mem_32768x1_dp.data2\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen1\" input=\"memory.we1\" output=\"mem_32768x1_dp.we1\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"writeen2\" input=\"memory.we2\" output=\"mem_32768x1_dp.we2\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout1\" input=\"mem_32768x1_dp.out1\" output=\"memory.out[0:0]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"dataout2\" input=\"mem_32768x1_dp.out2\" output=\"memory.out[1:1]\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("          <direct name=\"clk\" input=\"memory.clk\" output=\"mem_32768x1_dp.clk\">\n")
-	vpr_file.write("          </direct>\n")
-	vpr_file.write("        </interconnect>\n")
-	vpr_file.write("      </mode>\n")
-
-	vpr_file.write("    <fc default_in_type=\"frac\" default_in_val=\"0.15\" default_out_type=\"frac\" default_out_val=\"0.10\"/>\n")
-	vpr_file.write("    <pinlocations pattern=\"spread\"/>\n")
-
-	vpr_file.write("  </pb_type>\n")
-
-
-	vpr_file.write("</complexblocklist>\n")
-	vpr_file.write("</architecture>\n")
-
-
+    # get archetecture parameters
+    Rfb = fpga_inst.specs.Rfb
+    Fcin = fpga_inst.specs.Fcin
+    Fcout = fpga_inst.specs.Fcout
+    Fs = fpga_inst.specs.Fs
+    N = fpga_inst.specs.N
+    K = fpga_inst.specs.K
+    #L = fpga_inst.specs.L
+    #independent_inputs = fpga_inst.specs.independent_inputs
+        
+    # get areas
+    grid_logic_tile_area = fpga_inst.area_dict["logic_cluster"]/fpga_inst.specs.min_width_tran_area
+
+    tree = etree.parse("arch.xml")
+    root = tree.getroot()
+
+    logic_tile = root.xpath("//device/area")[0]
+    boxes = root.xpath("//switchlist/switch")
+
+    logic_tile.set("grid_logic_tile_area", str(grid_logic_tile_area))
+
+    for sb in fpga_inst.sb_muxes:
+        for box in boxes:
+            if sb.vpr_name == box.get("name"):
+                box.set("Tdel", str(sb.delay))
+                box.set("mux_trans_size", str(fpga_inst.area_dict[f"switch_mux_trans_size_{sb.sink_wire.type}"]/fpga_inst.specs.min_width_tran_area))
+                box.set("buf_size", str(fpga_inst.area_dict[f"switch_buf_size_{sb.sink_wire.type}"]/fpga_inst.specs.min_width_tran_area))
+                break
+
+    for cb in fpga_inst.cb_muxes:
+        for box in boxes:
+            if cb.vpr_name == box.get("name"):
+                box.set("Tdel", str(cb.delay))
+                box.set("mux_trans_size", str(fpga_inst.area_dict["ipin_mux_trans_size"]/fpga_inst.specs.min_width_tran_area))
+                box.set("buf_size", str(fpga_inst.area_dict["cb_buf_size"]/fpga_inst.specs.min_width_tran_area))
+                break
+
+    tree.write("patch.xml", pretty_print=True)
 def print_vpr_file(fpga_inst, arch_folder, enable_bram_module):
 
-	vpr_file = open(arch_folder + "/vpr_arch.xml", 'w')
+    vpr_file = open(arch_folder + "/vpr_arch.xml", 'w')
 
-	if enable_bram_module == 1:
-		print_vpr_file_memory(vpr_file, fpga_inst)
-	else:
-		print_vpr_file_flut_hard(vpr_file, fpga_inst)
-		
-	vpr_file.close()
+    if enable_bram_module == 1:
+        print_vpr_file_memory(vpr_file, fpga_inst)
+    else:
+        print_vpr_file_flut_hard(vpr_file, fpga_inst)
+        
+    vpr_file.close()

--- a/src/coffe/vpr.py
+++ b/src/coffe/vpr.py
@@ -606,6 +606,16 @@ def print_vpr_file_flut_hard(vpr_file, fpga_inst):
 
     logic_tile = root.xpath("//device/area")[0]
     boxes = root.xpath("//switchlist/switch")
+    lut_delay_matrices = root.xpath("//delay_matrix") 
+
+    lut_input_names = list(fpga_inst.lut_inputs.keys())
+    lut_input_names.sort()
+    lut_delays = []
+    for input_name in lut_input_names:
+        lut_input = fpga_inst.lut_inputs[input_name][0] #TODO add multi ckt support
+        driver_delay = max(lut_input.driver.delay, lut_input.not_driver.delay)
+        path_delay = lut_input.delay
+        lut_delays.append(driver_delay + path_delay)
 
     logic_tile.set("grid_logic_tile_area", str(grid_logic_tile_area))
 
@@ -624,6 +634,9 @@ def print_vpr_file_flut_hard(vpr_file, fpga_inst):
                 box.set("mux_trans_size", str(fpga_inst.area_dict["ipin_mux_trans_size"]/fpga_inst.specs.min_width_tran_area))
                 box.set("buf_size", str(fpga_inst.area_dict["cb_buf_size"]/fpga_inst.specs.min_width_tran_area))
                 break
+    for delay in lut_delay_matrices:
+        if "lut" in delay.get("in_port"):
+            delay.text = "\n" + "".join(f"{lut}\n" for lut in lut_delays)
 
     tree.write("patch.xml", pretty_print=True)
 def print_vpr_file(fpga_inst, arch_folder, enable_bram_module):

--- a/tests/data/k6n10_template/inputs/arch.xml
+++ b/tests/data/k6n10_template/inputs/arch.xml
@@ -1,0 +1,1783 @@
+<!-- 
+  Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
+
+  - 40 nm technology
+  - General purpose logic block: 
+    K = 6, N = 10, fracturable 6 LUTs (can operate as one 6-LUT or two 5-LUTs with 8 total FLE inputs (2 inputs of which are shared by the 5-LUTs) 
+    with optionally registered outputs
+    Each 5-LUT has an arithemtic mode that converts it to a single-bit adder with both inputs driven by 4-LUTs (both 4-LUTs share all 4 inputs)
+    Carry chain links to vertically adjacent logic blocks
+  - Memory size 32 Kbits, memory aspect ratios vary from a data width of 1 to data width of 64.  
+    Height = 6, found on every (8n+2)th column
+  - Multiplier modes: one 36x36, two 18x18, each 18x18 can also operate as two 9x9.  
+    Height = 4, found on every (8n+6)th column
+  - Routing architecture: L = 4, fc_in = 0.15, Fc_out = 0.1
+
+  Details on Modelling:
+
+  The electrical design of the architecture described here is NOT from an 
+  optimized, SPICED architecture.  Instead, we attempt to create a reasonable 
+  architecture file by using an existing commercial FPGA to approximate the area, 
+  delay, and power of the underlying components. This is combined with a reasonable 40 nm 
+  model of wiring and circuit design for low-level routing components, where available.
+  The resulting architecture has delays that roughly match a commercial 40 nm FPGA, but also 
+  has wiring electrical parameters that allow the wire lengths and switch patterns to be 
+  modified and you will still get reasonable delay results for the new architecture.
+  The following describes, in detail, how we obtained the various electrical values for this 
+  architecture.
+
+  Rmin for nmos and pmos, routing buffer sizes, and I/O pad delays are from the ifar 
+  architecture created by Ian Kuon: K07 N10 45nm fc 0.15 area-delay optimized architecture. 
+  (n10k06l04.fc15.area1delay1.cmos45nm.bptm.cmos45nm.xml)      
+  This routing architecture was optimized for 45 nm, and we have scaled it linearly to 40 nm to 
+  match the overall target (a 40 nm FPGA).
+
+  We obtain delay numbers by measuring delays of routing, soft logic blocks, 
+  memories, and multipliers from test circuits on a Stratix IV GX device 
+  (EP4SGX230DF29C2X, i.e. fastest speed grade). For routing, we took the average delay of H4 and V4 
+  wires.  Rmetal and Cmetal values for the routing wires were obtained from work done by Charles 
+  Chiasson. We use a 96 nm half-pitch (corresponding to mid-level metal stack 40 nm routing) and 
+  take the R and C data from the ITRS roadmap.  
+
+  For the general purpose logic block, we assume that the area and delays of the Stratix IV 
+  crossbar is close enough to the crossbar modelled here.  
+  Stratix IV uses 52 inputs and 20 feedback lines, but only a half-populated crossbar, leading to 
+  36:1 multiplexers.  We match these parameters in this architecture.
+
+  For LUTs, we include LUT 
+  delays measured from Stratix IV which is dependant on the input used (ie. some 
+  LUT inputs are faster than others).  The CAD tools at the time of VTR 7 does 
+  not consider differences in LUT input delays.
+
+  Adder delays obtained as approximate values from a Stratix IV EP4SE230F29C3 device.  
+  Delay obtained by compiling a 256 bit adder (registered inputs and outputs, 
+  all pins except clock virtual) then measuring the delays in chip-planner, 
+  sumout delay = 0.271ns to 0.348 ns, intra-block carry delay = 0.011 ns, 
+  inter-block carry delay = 0.327 ns.  Given this data, I will approximate 
+  sumout 0.3 ns, intra-block carry-delay = 0.01 ns, and 
+  inter-block carry-delay = 0.16 ns (since Altera inter-block carry delay has 
+  overhead that we don't have, I'll approximate the delay of a simpler chain at 
+  one half what they have.  This is very rough, anything from 0.01ns to 0.327ns 
+  can be justified).
+
+  Logic block area numbers obtained by scaling overall tile area of a 65nm 
+  Stratix III device, (as given in Wong, Betz and Rose, FPGA 2011) to 40 nm, then subtracting out 
+  routing area at a channel width of 300. We use a channel width of 300 because it can route 
+  all the VTR 6.0 benchmark circuits with an approximately 20% safety margin, and is also close to the
+  total channel width of Stratix IV. Hence this channel width is close to the commercial practice of
+  choosing a width that provides high routability. The architecture can be routed at different channel
+  widths, but we estimate the tile size and hence the physical length of routing wires assuming
+  a channel width of 300.
+
+  Sanity checks employed:
+    1.  We confirmed the routing buffer delay is ~1/3rd of total routing delay at L = 4. This matches 
+        common electrical design.
+
+
+  Authors: Jason Luu, Jeff Goeders, Vaughn Betz
+-->
+<architecture>
+  <!-- 
+       ODIN II specific config begins 
+       Describes the types of user-specified netlist blocks (in blif, this corresponds to 
+       ".model [type_of_block]") that this architecture supports.
+
+       Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
+       already special structures in blif (.names, .input, .output, and .latch) 
+       that describe them.
+  -->
+  <models>
+    <model name="multiply">
+      <input_ports>
+        <port name="a" combinational_sink_ports="out"/>
+        <port name="b" combinational_sink_ports="out"/>
+      </input_ports>
+      <output_ports>
+        <port name="out"/>
+      </output_ports>
+    </model>
+    <model name="single_port_ram">
+      <input_ports>
+        <port name="we" clock="clk"/>
+        <!-- control -->
+        <port name="addr" clock="clk"/>
+        <!-- address lines -->
+        <port name="data" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="clk" is_clock="1"/>
+        <!-- memories are often clocked -->
+      </input_ports>
+      <output_ports>
+        <port name="out" clock="clk"/>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+      </output_ports>
+    </model>
+    <model name="dual_port_ram">
+      <input_ports>
+        <port name="we1" clock="clk"/>
+        <!-- write enable -->
+        <port name="we2" clock="clk"/>
+        <!-- write enable -->
+        <port name="addr1" clock="clk"/>
+        <!-- address lines -->
+        <port name="addr2" clock="clk"/>
+        <!-- address lines -->
+        <port name="data1" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="data2" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="clk" is_clock="1"/>
+        <!-- memories are often clocked -->
+      </input_ports>
+      <output_ports>
+        <port name="out1" clock="clk"/>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="out2" clock="clk"/>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+      </output_ports>
+    </model>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <clock name="clock" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad io.clock</loc>
+          <loc side="top">io.outpad io.inpad io.clock</loc>
+          <loc side="right">io.outpad io.inpad io.clock</loc>
+          <loc side="bottom">io.outpad io.inpad io.clock</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="I1" num_pins="13" equivalent="full"/>
+        <input name="I2" num_pins="13" equivalent="full"/>
+        <input name="I3" num_pins="13" equivalent="full"/>
+        <input name="I4" num_pins="13" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+    <tile name="mult_36" height="4" area="396000">
+      <sub_tile name="mult_36">
+        <equivalent_sites>
+          <site pb_type="mult_36" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="a" num_pins="36"/>
+        <input name="b" num_pins="36"/>
+        <output name="out" num_pins="72"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="6" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="addr1" num_pins="15"/>
+        <input name="addr2" num_pins="15"/>
+        <input name="data" num_pins="64"/>
+        <input name="we1" num_pins="1"/>
+        <input name="we2" num_pins="1"/>
+        <output name="out" num_pins="64"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout>
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="6" repeatx="8" starty="1" priority="19"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </auto_layout>
+    <!--
+        This architecture is commonly used for the VTR Benchmark Suite. Below
+        are a set of fixed layouts which were found to work well for these
+        benchmarks. They were found by finding the minimum device size for each
+        benchmark and categorizing the benchmarks into the different fixed
+        layouts. Each fixed layout was chosen to be around 1.5x larger than the
+        previous.
+    -->
+    <fixed_layout name="vtr_extra_small" width="20" height="20">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="6" repeatx="8" starty="1" priority="19"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+    <fixed_layout name="vtr_small" width="30" height="30">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="6" repeatx="8" starty="1" priority="19"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+    <fixed_layout name="vtr_medium" width="42" height="42">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="6" repeatx="8" starty="1" priority="19"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+    <fixed_layout name="vtr_large" width="65" height="65">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="6" repeatx="8" starty="1" priority="19"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+    <fixed_layout name="vtr_extra_large" width="105" height="105">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="6" repeatx="8" starty="1" priority="19"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
+			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
+			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
+			     45 nm in general). I'm upping the Rmin_nmos from Ian's just over 6k to nearly 9k, and dropping 
+			     RminW_pmos from 18k to 16k to hit this 1.8x ratio, while keeping the delays of buffers approximately
+			     lined up with Stratix IV. 
+			     We are using Jeff G.'s capacitance data for 45 nm (in tech/ptm_45nm).
+			     Jeff's tables list C in for transistors with widths in multiples of the minimum feature size (45 nm).
+			     The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply drive strength sizes in this file
+	                     by 2.5x when looking up in Jeff's tables.
+			     The delay values are lined up with Stratix IV, which has an architecture similar to this
+			     proposed FPGA, and which is also 40 nm 
+			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+     	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="custom"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+           book area formula. This means the mux transistors are about 5x minimum drive strength.
+           We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
+           mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
+           the n and p transistors in the first stage are equal-sized to lower the buffer trip point, since it's fed
+           by a pass transistor mux. We can then reverse engineer the buffer second stage to hit the specified 
+           buf_size (really buffer area) - 16.2x minimum drive nmos and 1.8*16.2 = 29.2x minimum drive.
+           I then took the data from Jeff G.'s PTM modeling of 45 nm to get the Cin (gate of first stage) and Cout 
+           (diff of second stage) listed below.  Jeff's models are in tech/ptm_45nm, and are in min feature multiples.
+           The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
+           2.5x when looking up in Jeff's tables.
+           Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="L4_driver" R="450" Cin="0.60e-15" Cout="4.82e-15" Tdel="59e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!-- KEM: Since the L16 wires are 4x as long as the L4s, it is not unreasonable to have the L16 drivers be at least 3x as
+         powerful. -->
+    <switch type="mux" name="L16_driver" R="150" Cin="1.80e-15" Cout="14.5e-15" Tdel="87e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+             With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="260" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L4_driver"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+    <segment name="L16" freq="40" length="16" type="unidir" Rmetal="50.42" Cmetal="20.7e-15">
+      <mux name="L16_driver"/>
+      <sb type="pattern">1 0 0 0 1 0 0 0 1 0 0 0 1 0 0 0 1</sb>
+      <!-- For the same reasons, long wires do not connect to block pins in Stratix IV -->
+      <cb type="pattern">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <clock name="clock" num_pins="1"/>
+      <!-- IOs can operate as either inputs or outputs.
+	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
+	     the delays to and from registers in the I/O (and generally I/Os are registered 
+	     today and that is when you timing analyze them.
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
+          make it physically equivalent on all sides so that only one definition of I/Os is needed.
+          If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+	   area is 60 L^2 yields a tile area of 84375 MWTAs.
+	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
+	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
+	   block. Note that the crossbar / local interconnect is considered part of the logic block
+	   area in this analysis. That is a lower proportion of of routing area than most academics
+	   assume, but note that the total routing area really includes the crossbar, which would push
+	   routing area up significantly, we estimate into the ~70% range. 
+	   -->
+    <pb_type name="clb">
+      <input name="I1" num_pins="13" equivalent="full"/>
+      <input name="I2" num_pins="13" equivalent="full"/>
+      <input name="I3" num_pins="13" equivalent="full"/>
+      <input name="I4" num_pins="13" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
+             Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
+             The outputs of the fracturable logic element can be optionally registered
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="8"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <mode name="n2_lut5">
+          <pb_type name="lut5inter" num_pb="1">
+            <input name="in" num_pins="8"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble5" num_pb="2">
+              <input name="in" num_pins="5"/>
+              <input name="cin" num_pins="1"/>
+              <output name="out" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <mode name="blut5">
+                <pb_type name="flut5" num_pb="1">
+                  <input name="in" num_pins="5"/>
+                  <output name="out" num_pins="1"/>
+                  <clock name="clk" num_pins="1"/>
+                  <!-- Regular LUT mode -->
+                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+                    <input name="in" num_pins="5" port_class="lut_in"/>
+                    <output name="out" num_pins="1" port_class="lut_out"/>
+                    <!-- LUT timing using delay matrix -->
+                    <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                           we instead take the average of these numbers to get more stable results
+                        82e-12
+                        173e-12
+                        261e-12
+                        263e-12
+                        398e-12
+                        -->
+                    <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                        235e-12
+                        235e-12
+                        235e-12
+                        235e-12
+                        235e-12
+                      </delay_matrix>
+                  </pb_type>
+                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                    <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="flut5.in" output="lut5.in"/>
+                    <direct name="direct2" input="lut5.out" output="ff.D">
+                      <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+                    </direct>
+                    <direct name="direct3" input="flut5.clk" output="ff.clk"/>
+                    <mux name="mux1" input="ff.Q lut5.out" output="flut5.out">
+                      <delay_constant max="25e-12" in_port="lut5.out" out_port="flut5.out"/>
+                      <delay_constant max="45e-12" in_port="ff.Q" out_port="flut5.out"/>
+                    </mux>
+                  </interconnect>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ble5.in" output="flut5.in"/>
+                  <direct name="direct2" input="ble5.clk" output="flut5.clk"/>
+                  <direct name="direct3" input="flut5.out" output="ble5.out"/>
+                </interconnect>
+              </mode>
+              <mode name="arithmetic">
+                <pb_type name="arithmetic" num_pb="1">
+                  <input name="in" num_pins="4"/>
+                  <input name="cin" num_pins="1"/>
+                  <output name="out" num_pins="1"/>
+                  <output name="cout" num_pins="1"/>
+                  <clock name="clk" num_pins="1"/>
+                  <!-- Special dual-LUT mode that drives adder only -->
+                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+                    <input name="in" num_pins="4" port_class="lut_in"/>
+                    <output name="out" num_pins="1" port_class="lut_out"/>
+                    <!-- LUT timing using delay matrix -->
+                    <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                             we instead take the average of these numbers to get more stable results
+                        82e-12
+                        173e-12
+                        261e-12
+                        263e-12
+                        -->
+                    <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                        195e-12
+                        195e-12
+                        195e-12
+                        195e-12
+                      </delay_matrix>
+                  </pb_type>
+                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+                    <input name="a" num_pins="1"/>
+                    <input name="b" num_pins="1"/>
+                    <input name="cin" num_pins="1"/>
+                    <output name="cout" num_pins="1"/>
+                    <output name="sumout" num_pins="1"/>
+                    <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+                    <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+                  </pb_type>
+                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                    <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+                    <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+                    <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+                    <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                      </direct>
+                    <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                      </direct>
+                    <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                      <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+                    </direct>
+                    <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                      <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+                    </direct>
+                    <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                      <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+                    </direct>
+                    <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                      <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                      <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+                    </mux>
+                  </interconnect>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ble5.in[3:0]" output="arithmetic.in"/>
+                  <direct name="carry_in" input="ble5.cin" output="arithmetic.cin">
+                    <pack_pattern name="chain" in_port="ble5.cin" out_port="arithmetic.cin"/>
+                  </direct>
+                  <direct name="carry_out" input="arithmetic.cout" output="ble5.cout">
+                    <pack_pattern name="chain" in_port="arithmetic.cout" out_port="ble5.cout"/>
+                  </direct>
+                  <direct name="direct2" input="ble5.clk" output="arithmetic.clk"/>
+                  <direct name="direct3" input="arithmetic.out" output="ble5.out"/>
+                </interconnect>
+              </mode>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut5inter.in[4:0]" output="ble5[0:0].in"/>
+              <direct name="direct2" input="lut5inter.in[7:3]" output="ble5[1:1].in"/>
+              <direct name="direct3" input="ble5[1:0].out" output="lut5inter.out"/>
+              <direct name="carry_in" input="lut5inter.cin" output="ble5[0:0].cin">
+                <pack_pattern name="chain" in_port="lut5inter.cin" out_port="ble5[0:0].cin"/>
+              </direct>
+              <direct name="carry_out" input="ble5[1:1].cout" output="lut5inter.cout">
+                <pack_pattern name="chain" in_port="ble5[1:1].cout" out_port="lut5inter.cout"/>
+              </direct>
+              <direct name="carry_link" input="ble5[0:0].cout" output="ble5[1:1].cin">
+                <pack_pattern name="chain" in_port="ble5[0:0].cout" out_port="ble5[1:1].cout"/>
+              </direct>
+              <complete name="complete1" input="lut5inter.clk" output="ble5[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="lut5inter.in"/>
+            <direct name="direct2" input="lut5inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut5inter.clk"/>
+            <direct name="carry_in" input="fle.cin" output="lut5inter.cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="lut5inter.cin"/>
+            </direct>
+            <direct name="carry_out" input="lut5inter.cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="lut5inter.cout" out_port="fle.cout"/>
+            </direct>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                       we instead take the average of these numbers to get more stable results
+                  82e-12
+                  173e-12
+                  261e-12
+                  263e-12
+                  398e-12
+                  397e-12
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  261e-12
+                  261e-12
+                  261e-12
+                  261e-12
+                  261e-12
+                  261e-12
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- n1_lut6 -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
+           The delays below come from Stratix IV. the delay through a connection block
+           input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
+           delay on the connection block input mux (modeled by Ian Kuon), so the remaining
+           delay within the crossbar is 95 ps. 
+           The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
+           Since all our outputs LUT outputs go to a BLE output, and have a delay of 
+           25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
+           to get the part that should be marked on the crossbar.	 -->
+        <!-- 50% sparsely populated local routing -->
+        <complete name="lutA" input="clb.I4 clb.I3 fle[1:0].out fle[3:2].out fle[8:8].out" output="fle[9:0].in[0:0]">
+          <delay_constant max="95e-12" in_port="clb.I4" out_port="fle.in[0:0]"/>
+          <delay_constant max="95e-12" in_port="clb.I3" out_port="fle.in[0:0]"/>
+          <delay_constant max="75e-12" in_port="fle[1:0].out" out_port="fle.in[0:0]"/>
+          <delay_constant max="75e-12" in_port="fle[3:2].out" out_port="fle.in[0:0]"/>
+          <delay_constant max="75e-12" in_port="fle[8:8].out" out_port="fle.in[0:0]"/>
+        </complete>
+        <complete name="lutB" input="clb.I3 clb.I2 fle[3:2].out fle[5:4].out fle[9:9].out" output="fle[9:0].in[1:1]">
+          <delay_constant max="95e-12" in_port="clb.I3" out_port="fle.in[1:1]"/>
+          <delay_constant max="95e-12" in_port="clb.I2" out_port="fle.in[1:1]"/>
+          <delay_constant max="75e-12" in_port="fle[3:2].out" out_port="fle.in[1:1]"/>
+          <delay_constant max="75e-12" in_port="fle[5:4].out" out_port="fle.in[1:1]"/>
+          <delay_constant max="75e-12" in_port="fle[9:9].out" out_port="fle.in[1:1]"/>
+        </complete>
+        <complete name="lutC" input="clb.I2 clb.I1 fle[5:4].out fle[7:6].out fle[8:8].out" output="fle[9:0].in[2:2]">
+          <delay_constant max="95e-12" in_port="clb.I2" out_port="fle.in[2:2]"/>
+          <delay_constant max="95e-12" in_port="clb.I1" out_port="fle.in[2:2]"/>
+          <delay_constant max="75e-12" in_port="fle[5:4].out" out_port="fle.in[2:2]"/>
+          <delay_constant max="75e-12" in_port="fle[7:6].out" out_port="fle.in[2:2]"/>
+          <delay_constant max="75e-12" in_port="fle[8:8].out" out_port="fle.in[2:2]"/>
+        </complete>
+        <complete name="lutD" input="clb.I4 clb.I2 fle[1:0].out fle[5:4].out fle[9:9].out" output="fle[9:0].in[3:3]">
+          <delay_constant max="95e-12" in_port="clb.I4" out_port="fle.in[3:3]"/>
+          <delay_constant max="95e-12" in_port="clb.I2" out_port="fle.in[3:3]"/>
+          <delay_constant max="75e-12" in_port="fle[1:0].out" out_port="fle.in[3:3]"/>
+          <delay_constant max="75e-12" in_port="fle[5:4].out" out_port="fle.in[3:3]"/>
+          <delay_constant max="75e-12" in_port="fle[9:9].out" out_port="fle.in[3:3]"/>
+        </complete>
+        <complete name="lutE" input="clb.I3 clb.I1 fle[3:2].out fle[7:6].out fle[8:8].out" output="fle[9:0].in[4:4]">
+          <delay_constant max="95e-12" in_port="clb.I3" out_port="fle.in[4:4]"/>
+          <delay_constant max="95e-12" in_port="clb.I1" out_port="fle.in[4:4]"/>
+          <delay_constant max="75e-12" in_port="fle[3:2].out" out_port="fle.in[4:4]"/>
+          <delay_constant max="75e-12" in_port="fle[7:6].out" out_port="fle.in[4:4]"/>
+          <delay_constant max="75e-12" in_port="fle[8:8].out" out_port="fle.in[4:4]"/>
+        </complete>
+        <complete name="lutF" input="clb.I4 clb.I1 fle[1:0].out fle[7:6].out fle[9:9].out" output="fle[9:0].in[5:5]">
+          <delay_constant max="95e-12" in_port="clb.I4" out_port="fle.in[5:5]"/>
+          <delay_constant max="95e-12" in_port="clb.I1" out_port="fle.in[5:5]"/>
+          <delay_constant max="75e-12" in_port="fle[1:0].out" out_port="fle.in[5:5]"/>
+          <delay_constant max="75e-12" in_port="fle[7:6].out" out_port="fle.in[5:5]"/>
+          <delay_constant max="75e-12" in_port="fle[9:9].out" out_port="fle.in[5:5]"/>
+        </complete>
+        <complete name="lutG" input="clb.I4 clb.I3 fle[1:0].out fle[3:2].out fle[8:8].out" output="fle[9:0].in[6:6]">
+          <delay_constant max="95e-12" in_port="clb.I4" out_port="fle.in[6:6]"/>
+          <delay_constant max="95e-12" in_port="clb.I3" out_port="fle.in[6:6]"/>
+          <delay_constant max="75e-12" in_port="fle[1:0].out" out_port="fle.in[6:6]"/>
+          <delay_constant max="75e-12" in_port="fle[3:2].out" out_port="fle.in[6:6]"/>
+          <delay_constant max="75e-12" in_port="fle[8:8].out" out_port="fle.in[6:6]"/>
+        </complete>
+        <complete name="lutH" input="clb.I3 clb.I2 fle[3:2].out fle[5:4].out fle[9:9].out" output="fle[9:0].in[7:7]">
+          <delay_constant max="95e-12" in_port="clb.I3" out_port="fle.in[7:7]"/>
+          <delay_constant max="95e-12" in_port="clb.I2" out_port="fle.in[7:7]"/>
+          <delay_constant max="75e-12" in_port="fle[3:2].out" out_port="fle.in[7:7]"/>
+          <delay_constant max="75e-12" in_port="fle[5:4].out" out_port="fle.in[7:7]"/>
+          <delay_constant max="75e-12" in_port="fle[9:9].out" out_port="fle.in[7:7]"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+          </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+                 By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
+                 then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
+                 naive specification).
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define fracturable multiplier begin -->
+    <!-- This multiplier can operate as a 36x36 multiplier that can fracture to two 18x18 multipliers each of which can further fracture to two 9x9 multipliers 
+	   For delay modelling, the 36x36 DSP multiplier in Stratix IV has a delay of 1.523 ns + 1.93 ns
+	    = 3.45 ns. The 18x18 mode doesn't need to sum four 18x18 multipliers, so it is a bit
+	   faster: 1.523 ns for the multiplier, and 1.09 ns for the multiplier output block.
+	    For the input and output interconnect delays, unlike Stratix IV, we don't
+	   have any routing/logic flexibility (crossbars) at the inputs.  There is some output muxing
+	   in Stratix IV and this architecture to select which multiplier outputs should go out (e.g.
+	   9x9 outputs, 18x18 or 36x36) so those are very close between the two architectures. 
+	   We take the conservative (slightly pessimistic)
+           approach modelling the input as the same as the Stratix IV input delay and the output delay the same as the Stratix IV DSP out delay.
+		   
+	   We estimate block area by using the published Stratix III data (which is architecturally identical to Stratix IV)
+	      (H. Wong, V. Betz and J. Rose, "Comparing FPGA vs. Custom CMOS and the Impact on Processor Microarchitecture", FPGA 2011) of 0.2623 
+		  mm^2 and scaling from 65 to 40 nm to obtain 0.0993 mm^2. That area is for a DSP block with approximately 2x the functionality of 
+		  the block we use (can implement two 36x36 multiplies instead of our 1, eight 18x18 multiplies instead of our 4, etc.). Hence we 
+		  divide the area by 2 to obtain 0.0497 mm^2. One minimum-width transistor units = 60 L^2 (where L = 40 nm), so is 518,000 MWTUS. 
+		  That area includes routing and the connection block input muxes.  Our DSP block is four 
+		  rows high, and hence includes four horizontal routing channel segments and four vertical ones, which is 4x the routing of a logic 
+		  block (single tile). It also includes 3.6x the outputs of a logic block, and 1.8x the inputs. Hence a slight overestimate of the routing
+		  area associated with our DSP block is four times that of a logic tile, where the routing area of a logic tile was calculated above (at W = 300)
+		  as 30481 MWTAs. Hence the (core, non-routing) area our DSP block is approximately 518,000 - 4 * 30,481 = 396,000 MWTUs.
+      -->
+    <pb_type name="mult_36">
+      <input name="a" num_pins="36"/>
+      <input name="b" num_pins="36"/>
+      <output name="out" num_pins="72"/>
+      <mode name="two_divisible_mult_18x18">
+        <pb_type name="divisible_mult_18x18" num_pb="2">
+          <input name="a" num_pins="18"/>
+          <input name="b" num_pins="18"/>
+          <output name="out" num_pins="36"/>
+          <!-- Model 9x9 delay and 18x18 delay as the same.  9x9 could be faster, but in Stratix IV
+	          isn't, presumably because the multiplier layout is really optimized for 18x18.
+		-->
+          <mode name="two_mult_9x9">
+            <pb_type name="mult_9x9_slice" num_pb="2">
+              <input name="A_cfg" num_pins="9"/>
+              <input name="B_cfg" num_pins="9"/>
+              <output name="OUT_cfg" num_pins="18"/>
+              <pb_type name="mult_9x9" blif_model=".subckt multiply" num_pb="1">
+                <input name="a" num_pins="9"/>
+                <input name="b" num_pins="9"/>
+                <output name="out" num_pins="18"/>
+                <delay_constant max="1.523e-9" in_port="mult_9x9.a" out_port="mult_9x9.out"/>
+                <delay_constant max="1.523e-9" in_port="mult_9x9.b" out_port="mult_9x9.out"/>
+              </pb_type>
+              <interconnect>
+                <direct name="a2a" input="mult_9x9_slice.A_cfg" output="mult_9x9.a">
+                </direct>
+                <direct name="b2b" input="mult_9x9_slice.B_cfg" output="mult_9x9.b">
+                </direct>
+                <direct name="out2out" input="mult_9x9.out" output="mult_9x9_slice.OUT_cfg">
+                </direct>
+              </interconnect>
+              <power method="pin-toggle">
+                <port name="A_cfg" energy_per_toggle="1.45e-12"/>
+                <port name="B_cfg" energy_per_toggle="1.45e-12"/>
+                <static_power power_per_instance="0.0"/>
+              </power>
+            </pb_type>
+            <interconnect>
+              <direct name="a2a" input="divisible_mult_18x18.a" output="mult_9x9_slice[1:0].A_cfg">
+              </direct>
+              <direct name="b2b" input="divisible_mult_18x18.b" output="mult_9x9_slice[1:0].B_cfg">
+              </direct>
+              <direct name="out2out" input="mult_9x9_slice[1:0].OUT_cfg" output="divisible_mult_18x18.out">
+              </direct>
+            </interconnect>
+          </mode>
+          <mode name="mult_18x18">
+            <pb_type name="mult_18x18_slice" num_pb="1">
+              <input name="A_cfg" num_pins="18"/>
+              <input name="B_cfg" num_pins="18"/>
+              <output name="OUT_cfg" num_pins="36"/>
+              <pb_type name="mult_18x18" blif_model=".subckt multiply" num_pb="1">
+                <input name="a" num_pins="18"/>
+                <input name="b" num_pins="18"/>
+                <output name="out" num_pins="36"/>
+                <delay_constant max="1.523e-9" in_port="mult_18x18.a" out_port="mult_18x18.out"/>
+                <delay_constant max="1.523e-9" in_port="mult_18x18.b" out_port="mult_18x18.out"/>
+              </pb_type>
+              <interconnect>
+                <direct name="a2a" input="mult_18x18_slice.A_cfg" output="mult_18x18.a">
+                </direct>
+                <direct name="b2b" input="mult_18x18_slice.B_cfg" output="mult_18x18.b">
+                </direct>
+                <direct name="out2out" input="mult_18x18.out" output="mult_18x18_slice.OUT_cfg">
+                </direct>
+              </interconnect>
+              <power method="pin-toggle">
+                <port name="A_cfg" energy_per_toggle="1.09e-12"/>
+                <port name="B_cfg" energy_per_toggle="1.09e-12"/>
+                <static_power power_per_instance="0.0"/>
+              </power>
+            </pb_type>
+            <interconnect>
+              <direct name="a2a" input="divisible_mult_18x18.a" output="mult_18x18_slice.A_cfg">
+              </direct>
+              <direct name="b2b" input="divisible_mult_18x18.b" output="mult_18x18_slice.B_cfg">
+              </direct>
+              <direct name="out2out" input="mult_18x18_slice.OUT_cfg" output="divisible_mult_18x18.out">
+              </direct>
+            </interconnect>
+          </mode>
+          <power method="sum-of-children"/>
+        </pb_type>
+        <interconnect>
+          <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
+		   Subtract 72.5 ps delay, which is already in the connection block input mux, leading
+              -->
+          <direct name="a2a" input="mult_36.a" output="divisible_mult_18x18[1:0].a">
+            <delay_constant max="134e-12" in_port="mult_36.a" out_port="divisible_mult_18x18[1:0].a"/>
+          </direct>
+          <direct name="b2b" input="mult_36.b" output="divisible_mult_18x18[1:0].b">
+            <delay_constant max="134e-12" in_port="mult_36.b" out_port="divisible_mult_18x18[1:0].b"/>
+          </direct>
+          <direct name="out2out" input="divisible_mult_18x18[1:0].out" output="mult_36.out">
+            <delay_constant max="1.09e-9" in_port="divisible_mult_18x18[1:0].out" out_port="mult_36.out"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mult_36x36">
+        <pb_type name="mult_36x36_slice" num_pb="1">
+          <input name="A_cfg" num_pins="36"/>
+          <input name="B_cfg" num_pins="36"/>
+          <output name="OUT_cfg" num_pins="72"/>
+          <pb_type name="mult_36x36" blif_model=".subckt multiply" num_pb="1">
+            <input name="a" num_pins="36"/>
+            <input name="b" num_pins="36"/>
+            <output name="out" num_pins="72"/>
+            <delay_constant max="1.523e-9" in_port="mult_36x36.a" out_port="mult_36x36.out"/>
+            <delay_constant max="1.523e-9" in_port="mult_36x36.b" out_port="mult_36x36.out"/>
+          </pb_type>
+          <interconnect>
+            <direct name="a2a" input="mult_36x36_slice.A_cfg" output="mult_36x36.a">
+            </direct>
+            <direct name="b2b" input="mult_36x36_slice.B_cfg" output="mult_36x36.b">
+            </direct>
+            <direct name="out2out" input="mult_36x36.out" output="mult_36x36_slice.OUT_cfg">
+            </direct>
+          </interconnect>
+          <power method="pin-toggle">
+            <port name="A_cfg" energy_per_toggle="2.13e-12"/>
+            <port name="B_cfg" energy_per_toggle="2.13e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
+		   Subtract 72.5 ps delay, which is already in the connection block input mux, leading
+		   to a 134 ps delay.
+              -->
+          <direct name="a2a" input="mult_36.a" output="mult_36x36_slice.A_cfg">
+            <delay_constant max="134e-12" in_port="mult_36.a" out_port="mult_36x36_slice.A_cfg"/>
+          </direct>
+          <direct name="b2b" input="mult_36.b" output="mult_36x36_slice.B_cfg">
+            <delay_constant max="134e-12" in_port="mult_36.b" out_port="mult_36x36_slice.B_cfg"/>
+          </direct>
+          <direct name="out2out" input="mult_36x36_slice.OUT_cfg" output="mult_36.out">
+            <delay_constant max="1.93e-9" in_port="mult_36x36_slice.OUT_cfg" out_port="mult_36.out"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->
+      <power method="sum-of-children"/>
+    </pb_type>
+    <!-- Define fracturable multiplier end -->
+    <!-- Define fracturable memory begin -->
+    <!-- 32 Kb Memory that can operate from 512x64 to 32Kx1 for single-port mode and 1024x32 to 32Kx1 for dual-port mode.  
+           Area and delay based off Stratix IV 9K and 144K memories (delay from linear interpolation, Tsu(483 ps, 636 ps) Tco(1084ps, 1969ps)).  
+           Input delay = 204ps (from Stratix IV LAB line) - 72ps (this architecture does not lump connection box delay in internal delay)
+           Output delay = M9K buffer 50ps
+		   
+		   Area is obtained by appropriately scaling and adjusting the published Stratix III (which is architecturally identical to Stratix IV)
+		   data from H. Wong, V. Betz and J. Rose, "Comparing FPGA vs. Custom CMOS and the Impact on Processor Microarchitecture", FPGA 2011.
+		   Linearly interpolating (by bit count) between the M9k and M144k areas to obtain an M32k (our RAM size) point yields a 65 nm area of
+		   of 0.153 mm^2. Interpolating based on port count between the RAMs would instead yield an area of 0.209 mm^2 for our 32 kB RAM; since 
+		   bit count accounts for more area than ports for a RAM this size we choose the bit count interpolation; however, since the port interpolation
+		   is not radically different this also gives us confidence that interpolating based on bits is OK, but slightly underpredicts area.
+		   Scaling to 40 nm^2 yields .0579 mm^2, and converting to MWTUs at 60 L^2 / MWTU yields 604,000 MWTUs. This includes routing. A Stratix IV
+		   M9K RAM is one row high and hence has one routing tile (one horizonal and one vertical routing segment area). An M144k RAM has 8 such tiles.
+		   Linearly interpolating on
+		   bits to 32 kb yields 2.2 routing tiles incorporated in the area number above. The inter-block routing represents 30% of the area of a logic 
+		   tile according to D. Lewis et al, "Architectural Enhancements in Stratix V," FPGA 2013. Hence we should subtract 0.3 * 2.2 * 84,375 MWTUs to
+		   obtain a RAM core area (not including inter-block routing) of 548,000 MWTU areas for our 32 kb RAM in a 40 nm process.
+      -->
+    <pb_type name="memory">
+      <input name="addr1" num_pins="15"/>
+      <input name="addr2" num_pins="15"/>
+      <input name="data" num_pins="64"/>
+      <input name="we1" num_pins="1"/>
+      <input name="we2" num_pins="1"/>
+      <output name="out" num_pins="64"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify single port mode first -->
+      <mode name="mem_512x64_sp">
+        <pb_type name="mem_512x64_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="9" port_class="address"/>
+          <input name="data" num_pins="64" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="64" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_512x64_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x64_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x64_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_512x64_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[8:0]" output="mem_512x64_sp.addr">
+            <delay_constant max="132e-12" in_port="memory.addr1[8:0]" out_port="mem_512x64_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[63:0]" output="mem_512x64_sp.data">
+            <delay_constant max="132e-12" in_port="memory.data[63:0]" out_port="mem_512x64_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_512x64_sp.we">
+            <delay_constant max="132e-12" in_port="memory.we1" out_port="mem_512x64_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_512x64_sp.out" output="memory.out[63:0]">
+            <delay_constant max="40e-12" in_port="mem_512x64_sp.out" out_port="memory.out[63:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_512x64_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_1024x32_sp">
+        <pb_type name="mem_1024x32_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="10" port_class="address"/>
+          <input name="data" num_pins="32" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="32" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_1024x32_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_1024x32_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[9:0]" output="mem_1024x32_sp.addr">
+            <delay_constant max="132e-12" in_port="memory.addr1[9:0]" out_port="mem_1024x32_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[31:0]" output="mem_1024x32_sp.data">
+            <delay_constant max="132e-12" in_port="memory.data[31:0]" out_port="mem_1024x32_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_1024x32_sp.we">
+            <delay_constant max="132e-12" in_port="memory.we1" out_port="mem_1024x32_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_1024x32_sp.out" output="memory.out[31:0]">
+            <delay_constant max="40e-12" in_port="mem_1024x32_sp.out" out_port="memory.out[31:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_1024x32_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_2048x16_sp">
+        <pb_type name="mem_2048x16_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="11" port_class="address"/>
+          <input name="data" num_pins="16" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="16" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_2048x16_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_2048x16_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[10:0]" output="mem_2048x16_sp.addr">
+            <delay_constant max="132e-12" in_port="memory.addr1[10:0]" out_port="mem_2048x16_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[15:0]" output="mem_2048x16_sp.data">
+            <delay_constant max="132e-12" in_port="memory.data[15:0]" out_port="mem_2048x16_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_2048x16_sp.we">
+            <delay_constant max="132e-12" in_port="memory.we1" out_port="mem_2048x16_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_2048x16_sp.out" output="memory.out[15:0]">
+            <delay_constant max="40e-12" in_port="mem_2048x16_sp.out" out_port="memory.out[15:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_2048x16_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_4096x8_sp">
+        <pb_type name="mem_4096x8_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="12" port_class="address"/>
+          <input name="data" num_pins="8" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="8" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_4096x8_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_4096x8_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_4096x8_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_4096x8_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[11:0]" output="mem_4096x8_sp.addr">
+            <delay_constant max="132e-12" in_port="memory.addr1[11:0]" out_port="mem_4096x8_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[7:0]" output="mem_4096x8_sp.data">
+            <delay_constant max="132e-12" in_port="memory.data[7:0]" out_port="mem_4096x8_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_4096x8_sp.we">
+            <delay_constant max="132e-12" in_port="memory.we1" out_port="mem_4096x8_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_4096x8_sp.out" output="memory.out[7:0]">
+            <delay_constant max="40e-12" in_port="mem_4096x8_sp.out" out_port="memory.out[7:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_4096x8_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_8192x4_sp">
+        <pb_type name="mem_8192x4_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="13" port_class="address"/>
+          <input name="data" num_pins="4" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="4" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_8192x4_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_8192x4_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[12:0]" output="mem_8192x4_sp.addr">
+            <delay_constant max="132e-12" in_port="memory.addr1[12:0]" out_port="mem_8192x4_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[3:0]" output="mem_8192x4_sp.data">
+            <delay_constant max="132e-12" in_port="memory.data[3:0]" out_port="mem_8192x4_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_8192x4_sp.we">
+            <delay_constant max="132e-12" in_port="memory.we1" out_port="mem_8192x4_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_8192x4_sp.out" output="memory.out[3:0]">
+            <delay_constant max="40e-12" in_port="mem_8192x4_sp.out" out_port="memory.out[3:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_8192x4_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_16384x2_sp">
+        <pb_type name="mem_16384x2_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="14" port_class="address"/>
+          <input name="data" num_pins="2" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="2" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_16384x2_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_16384x2_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[13:0]" output="mem_16384x2_sp.addr">
+            <delay_constant max="132e-12" in_port="memory.addr1[13:0]" out_port="mem_16384x2_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[1:0]" output="mem_16384x2_sp.data">
+            <delay_constant max="132e-12" in_port="memory.data[1:0]" out_port="mem_16384x2_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_16384x2_sp.we">
+            <delay_constant max="132e-12" in_port="memory.we1" out_port="mem_16384x2_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_16384x2_sp.out" output="memory.out[1:0]">
+            <delay_constant max="40e-12" in_port="mem_16384x2_sp.out" out_port="memory.out[1:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_16384x2_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_32768x1_sp">
+        <pb_type name="mem_32768x1_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="15" port_class="address"/>
+          <input name="data" num_pins="1" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="1" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_32768x1_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_32768x1_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[14:0]" output="mem_32768x1_sp.addr">
+            <delay_constant max="132e-12" in_port="memory.addr1[14:0]" out_port="mem_32768x1_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[0:0]" output="mem_32768x1_sp.data">
+            <delay_constant max="132e-12" in_port="memory.data[0:0]" out_port="mem_32768x1_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_32768x1_sp.we">
+            <delay_constant max="132e-12" in_port="memory.we1" out_port="mem_32768x1_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_32768x1_sp.out" output="memory.out[0:0]">
+            <delay_constant max="40e-12" in_port="mem_32768x1_sp.out" out_port="memory.out[0:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_32768x1_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Specify true dual port mode next -->
+      <mode name="mem_1024x32_dp">
+        <pb_type name="mem_1024x32_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="10" port_class="address1"/>
+          <input name="addr2" num_pins="10" port_class="address2"/>
+          <input name="data1" num_pins="32" port_class="data_in1"/>
+          <input name="data2" num_pins="32" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="32" port_class="data_out1"/>
+          <output name="out2" num_pins="32" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_1024x32_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_1024x32_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[9:0]" output="mem_1024x32_dp.addr1">
+            <delay_constant max="132e-12" in_port="memory.addr1[9:0]" out_port="mem_1024x32_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[9:0]" output="mem_1024x32_dp.addr2">
+            <delay_constant max="132e-12" in_port="memory.addr2[9:0]" out_port="mem_1024x32_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[31:0]" output="mem_1024x32_dp.data1">
+            <delay_constant max="132e-12" in_port="memory.data[31:0]" out_port="mem_1024x32_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[63:32]" output="mem_1024x32_dp.data2">
+            <delay_constant max="132e-12" in_port="memory.data[63:32]" out_port="mem_1024x32_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_1024x32_dp.we1">
+            <delay_constant max="132e-12" in_port="memory.we1" out_port="mem_1024x32_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_1024x32_dp.we2">
+            <delay_constant max="132e-12" in_port="memory.we2" out_port="mem_1024x32_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_1024x32_dp.out1" output="memory.out[31:0]">
+            <delay_constant max="40e-12" in_port="mem_1024x32_dp.out1" out_port="memory.out[31:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_1024x32_dp.out2" output="memory.out[63:32]">
+            <delay_constant max="40e-12" in_port="mem_1024x32_dp.out2" out_port="memory.out[63:32]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_1024x32_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_2048x16_dp">
+        <pb_type name="mem_2048x16_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="11" port_class="address1"/>
+          <input name="addr2" num_pins="11" port_class="address2"/>
+          <input name="data1" num_pins="16" port_class="data_in1"/>
+          <input name="data2" num_pins="16" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="16" port_class="data_out1"/>
+          <output name="out2" num_pins="16" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_2048x16_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_2048x16_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[10:0]" output="mem_2048x16_dp.addr1">
+            <delay_constant max="132e-12" in_port="memory.addr1[10:0]" out_port="mem_2048x16_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[10:0]" output="mem_2048x16_dp.addr2">
+            <delay_constant max="132e-12" in_port="memory.addr2[10:0]" out_port="mem_2048x16_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[15:0]" output="mem_2048x16_dp.data1">
+            <delay_constant max="132e-12" in_port="memory.data[15:0]" out_port="mem_2048x16_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[31:16]" output="mem_2048x16_dp.data2">
+            <delay_constant max="132e-12" in_port="memory.data[31:16]" out_port="mem_2048x16_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_2048x16_dp.we1">
+            <delay_constant max="132e-12" in_port="memory.we1" out_port="mem_2048x16_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_2048x16_dp.we2">
+            <delay_constant max="132e-12" in_port="memory.we2" out_port="mem_2048x16_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_2048x16_dp.out1" output="memory.out[15:0]">
+            <delay_constant max="40e-12" in_port="mem_2048x16_dp.out1" out_port="memory.out[15:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_2048x16_dp.out2" output="memory.out[31:16]">
+            <delay_constant max="40e-12" in_port="mem_2048x16_dp.out2" out_port="memory.out[31:16]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_2048x16_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_2048x8_dp">
+        <pb_type name="mem_2048x8_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="12" port_class="address1"/>
+          <input name="addr2" num_pins="12" port_class="address2"/>
+          <input name="data1" num_pins="8" port_class="data_in1"/>
+          <input name="data2" num_pins="8" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="8" port_class="data_out1"/>
+          <output name="out2" num_pins="8" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_2048x8_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x8_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x8_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x8_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x8_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x8_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_2048x8_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_2048x8_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[11:0]" output="mem_2048x8_dp.addr1">
+            <delay_constant max="132e-12" in_port="memory.addr1[11:0]" out_port="mem_2048x8_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[11:0]" output="mem_2048x8_dp.addr2">
+            <delay_constant max="132e-12" in_port="memory.addr2[11:0]" out_port="mem_2048x8_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[7:0]" output="mem_2048x8_dp.data1">
+            <delay_constant max="132e-12" in_port="memory.data[7:0]" out_port="mem_2048x8_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[15:8]" output="mem_2048x8_dp.data2">
+            <delay_constant max="132e-12" in_port="memory.data[15:8]" out_port="mem_2048x8_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_2048x8_dp.we1">
+            <delay_constant max="132e-12" in_port="memory.we1" out_port="mem_2048x8_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_2048x8_dp.we2">
+            <delay_constant max="132e-12" in_port="memory.we2" out_port="mem_2048x8_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_2048x8_dp.out1" output="memory.out[7:0]">
+            <delay_constant max="40e-12" in_port="mem_2048x8_dp.out1" out_port="memory.out[7:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_2048x8_dp.out2" output="memory.out[15:8]">
+            <delay_constant max="40e-12" in_port="mem_2048x8_dp.out2" out_port="memory.out[15:8]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_2048x8_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_8192x4_dp">
+        <pb_type name="mem_8192x4_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="13" port_class="address1"/>
+          <input name="addr2" num_pins="13" port_class="address2"/>
+          <input name="data1" num_pins="4" port_class="data_in1"/>
+          <input name="data2" num_pins="4" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="4" port_class="data_out1"/>
+          <output name="out2" num_pins="4" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_8192x4_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_8192x4_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[12:0]" output="mem_8192x4_dp.addr1">
+            <delay_constant max="132e-12" in_port="memory.addr1[12:0]" out_port="mem_8192x4_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[12:0]" output="mem_8192x4_dp.addr2">
+            <delay_constant max="132e-12" in_port="memory.addr2[12:0]" out_port="mem_8192x4_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[3:0]" output="mem_8192x4_dp.data1">
+            <delay_constant max="132e-12" in_port="memory.data[3:0]" out_port="mem_8192x4_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[7:4]" output="mem_8192x4_dp.data2">
+            <delay_constant max="132e-12" in_port="memory.data[7:4]" out_port="mem_8192x4_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_8192x4_dp.we1">
+            <delay_constant max="132e-12" in_port="memory.we1" out_port="mem_8192x4_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_8192x4_dp.we2">
+            <delay_constant max="132e-12" in_port="memory.we2" out_port="mem_8192x4_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_8192x4_dp.out1" output="memory.out[3:0]">
+            <delay_constant max="40e-12" in_port="mem_8192x4_dp.out1" out_port="memory.out[3:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_8192x4_dp.out2" output="memory.out[7:4]">
+            <delay_constant max="40e-12" in_port="mem_8192x4_dp.out2" out_port="memory.out[7:4]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_8192x4_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_16384x2_dp">
+        <pb_type name="mem_16384x2_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="14" port_class="address1"/>
+          <input name="addr2" num_pins="14" port_class="address2"/>
+          <input name="data1" num_pins="2" port_class="data_in1"/>
+          <input name="data2" num_pins="2" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="2" port_class="data_out1"/>
+          <output name="out2" num_pins="2" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_16384x2_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_16384x2_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[13:0]" output="mem_16384x2_dp.addr1">
+            <delay_constant max="132e-12" in_port="memory.addr1[13:0]" out_port="mem_16384x2_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[13:0]" output="mem_16384x2_dp.addr2">
+            <delay_constant max="132e-12" in_port="memory.addr2[13:0]" out_port="mem_16384x2_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[1:0]" output="mem_16384x2_dp.data1">
+            <delay_constant max="132e-12" in_port="memory.data[1:0]" out_port="mem_16384x2_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[3:2]" output="mem_16384x2_dp.data2">
+            <delay_constant max="132e-12" in_port="memory.data[3:2]" out_port="mem_16384x2_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_16384x2_dp.we1">
+            <delay_constant max="132e-12" in_port="memory.we1" out_port="mem_16384x2_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_16384x2_dp.we2">
+            <delay_constant max="132e-12" in_port="memory.we2" out_port="mem_16384x2_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_16384x2_dp.out1" output="memory.out[1:0]">
+            <delay_constant max="40e-12" in_port="mem_16384x2_dp.out1" out_port="memory.out[1:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_16384x2_dp.out2" output="memory.out[3:2]">
+            <delay_constant max="40e-12" in_port="mem_16384x2_dp.out2" out_port="memory.out[3:2]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_16384x2_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_32768x1_dp">
+        <pb_type name="mem_32768x1_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="15" port_class="address1"/>
+          <input name="addr2" num_pins="15" port_class="address2"/>
+          <input name="data1" num_pins="1" port_class="data_in1"/>
+          <input name="data2" num_pins="1" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="1" port_class="data_out1"/>
+          <output name="out2" num_pins="1" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_32768x1_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_32768x1_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[14:0]" output="mem_32768x1_dp.addr1">
+            <delay_constant max="132e-12" in_port="memory.addr1[14:0]" out_port="mem_32768x1_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[14:0]" output="mem_32768x1_dp.addr2">
+            <delay_constant max="132e-12" in_port="memory.addr2[14:0]" out_port="mem_32768x1_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[0:0]" output="mem_32768x1_dp.data1">
+            <delay_constant max="132e-12" in_port="memory.data[0:0]" out_port="mem_32768x1_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[1:1]" output="mem_32768x1_dp.data2">
+            <delay_constant max="132e-12" in_port="memory.data[1:1]" out_port="mem_32768x1_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_32768x1_dp.we1">
+            <delay_constant max="132e-12" in_port="memory.we1" out_port="mem_32768x1_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_32768x1_dp.we2">
+            <delay_constant max="132e-12" in_port="memory.we2" out_port="mem_32768x1_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_32768x1_dp.out1" output="memory.out[0:0]">
+            <delay_constant max="40e-12" in_port="mem_32768x1_dp.out1" out_port="memory.out[0:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_32768x1_dp.out2" output="memory.out[1:1]">
+            <delay_constant max="40e-12" in_port="mem_32768x1_dp.out2" out_port="memory.out[1:1]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_32768x1_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this memory block every 8 columns from (and including) the second column -->
+      <power method="sum-of-children"/>
+    </pb_type>
+    <!-- Define fracturable memory end -->
+  </complexblocklist>
+  <power>
+    <local_interconnect C_wire="2.5e-10"/>
+    <mux_transistor_size mux_transistor_size="3"/>
+    <FF_size FF_size="4"/>
+    <LUT_transistor_size LUT_transistor_size="4"/>
+  </power>
+  <clocks>
+    <clock buffer_size="auto" C_wire="2.5e-10"/>
+  </clocks>
+  <switchblocklist>
+    <!-- Stratix IV uses a uni-directional routing architecture with a Driver Input Mux (DIM) size of 12 (i.e.
+           each wire can be driven by one of 12 block/outputs or wires) for the L4s.
+           
+           In the Stratix IV architecture the long wires (L16 here) are accessible only from the short wires, 
+           and are not connected to the block pins (i.e. connection blocks). Furthermore, they only connect 
+           to switch blocks every 4 LABs (to avoid expensive deep via stacks).
+           We approximate the L16 DIM size as 40:1 (in reality it is a pair of 20:1 (?) muxes with a 2:1 swap mux
+           in front, which has nearly the same connectivity as a full 40:1).
+
+           L4 wires
+           ================
+           At a channel width of 300 there are 260 L4/L4prime wires. At an effective Fc_out of 0.075 
+           and 40 LAB outputs this yeilds:
+
+                40 * 2 = 80 outputs per channel  [2 LABs per-channel]
+
+                80 * 0.075 = 6 outputs drive each L4 wire [output connection block]
+
+           This leaves:
+
+                12 - 6 = 6 inputs to the DIMs from other routing wires [switch block]
+
+           Since L4s connect at every switch block, there are:
+
+                260 L16 wires per channel + direction which can drive wires at a particular switchblock
+                (via switchpoints 0, 1, 2, 3)
+
+           And for each direction (260 wires) only:
+
+               260 / 4 = 65 wires starting/ending per channel + direction at each switch block
+               (i.e. from each direction, north/south/east/west, there are 32 L4s starting, and 32 L4s ending; + 1 wire for the 65th)
+
+           Which we allocate as follows:
+
+                L4
+                =====
+                straight-through connection: 2 (from L4 or L16)
+                clock-wise turn            : 2 (from L4 or L16)
+                counter-clock-wise turn    : 2 (from L4 or L16)
+
+           L16 wires
+           =========
+           At a channel width of 300 there are 40 L16 wires (20 in each direction), which do not connect to the input/output connection blocks.
+           This leaves 40 inputs to the DIM to select from routing wires (long wires use larger DIMs to improve reachability,
+           the area cost is relatively small since they are so rare).
+
+           Since L16s only connect at every 4th switch block there are:
+
+                40 / 4 = 10 L16 wires per channel (5 in each direction) which can drive wires at a particular switchblock
+                (via switchpoints 0, 4, 8, 12)
+
+           And for each direction (20 wires) only:
+
+               40 / 16 = 2.25 => 2 wires starting/ending per channel + direction at each switch block
+               (i.e. from each direction, north/south/east/west, there is one L16 starting, and one L16 ending)
+           
+           We assign the 40 DIM inputs as follows:
+
+                L16
+                =====
+                straight-through connection:  3 (from L16)
+                straight-through connection: 11 (from L4)
+                clock-wise turn            :  3 (from L16)
+                clock-wise turn            : 10 (from L4)
+                counter clock-wise turn    :  3 (from L16)
+                counter clock-wise turn    : 10 (from L4)
+
+           Switch pattern
+           ==============
+           This switch block is based on the Wilton switch block (see Page 103 of Steve Wilton's PhD Thesis 
+           "Architecture and Algorithms for Field-Programmable Gate Arrays with Embedded Memory", 1997):
+
+                left-to-top: W - t
+                top-to-right: t + 1
+                right-to-bottom: 2*W - 2 - t
+                bottom-to-left: t + 1
+                left-to-right: t
+                top-to-bottom: t
+
+           Since Wilton assumed bidirection routing (while we use unidirectional routing),
+           we mirror the clock-wise turns to match the conter-clock-wise specification.
+           -->
+    <switchblock name="wilton_turn_clockwise_core" type="unidir">
+      <switchblock_location type="CORE"/>
+      <switchfuncs>
+        <!-- Clock-wise turns -->
+        <func type="tl" formula="W-t"/>
+        <!-- top to left -->
+        <func type="rt" formula="t+1"/>
+        <!-- right to top -->
+        <func type="br" formula="2*W-2-t"/>
+        <!-- bottom to right -->
+        <func type="lb" formula="t+1"/>
+        <!-- left to bottom -->
+      </switchfuncs>
+      <!-- L16 drivers -->
+      <wireconn num_conns="3*to" from_type="L16" from_switchpoint="0,12,8,4" to_type="L16" to_switchpoint="0"/>
+      <wireconn num_conns="10*to" from_type="L4" from_switchpoint="0" to_type="L16" to_switchpoint="0"/>
+      <!-- L4 drivers 
+
+               Driving from L16 (few) to L4 (many) preferr driving from end-point of L16, although since there are many they will
+               all be multiply connected.
+               
+               Driving from L4 (many) to L4 (many) shuffle the switchpoints so the L4's are driven from a variety of switchpoints.
+               Since the actual number L4s starting/ending are equal, using 'fixed' from_order would mean only switchpoint 0 -> 0
+               connections. A 'shuffled' order will mix-up the from switchpoints for more diversity.
+               -->
+      <wireconn num_conns="2*to" from_order="shuffled">
+        <from type="L16" switchpoint="0,12,8,4"/>
+        <from type="L4" switchpoint="0,1,2,3"/>
+        <to type="L4" switchpoint="0"/>
+      </wireconn>
+    </switchblock>
+    <switchblock name="wilton_turn_counter_clockwise_core" type="unidir">
+      <switchblock_location type="CORE"/>
+      <switchfuncs>
+        <!-- Counter-clock-wise turns -->
+        <func type="lt" formula="W-t"/>
+        <!-- left to top -->
+        <func type="tr" formula="t+1"/>
+        <!-- top to right -->
+        <func type="rb" formula="2*W-2-t"/>
+        <!-- right to bottom -->
+        <func type="bl" formula="t+1"/>
+        <!-- bottom to left -->
+      </switchfuncs>
+      <!-- L16 drivers -->
+      <wireconn num_conns="3*to" from_type="L16" from_switchpoint="0,12,8,4" to_type="L16" to_switchpoint="0"/>
+      <wireconn num_conns="10*to" from_type="L4" from_switchpoint="0" to_type="L16" to_switchpoint="0"/>
+      <!-- L4 drivers 
+
+               Driving from L16 (few) to L4 (many) preferr driving from end-point of L16, although since there are many they will
+               all be multiply connected.
+               
+               Driving from L4 (many) to L4 (many) shuffle the switchpoints so the L4's are driven from a variety of switchpoints.
+               Since the actual number L4s starting/ending are equal, using 'fixed' from_order would mean only switchpoint 0 -> 0
+               connections. A 'shuffled' order will mix-up the from switchpoints for more diversity.
+
+               Note that a different from_switchpoints ordering is used to ensure a different shuffling occurs compared to 
+               wilton_turn_clockwise_core.
+               -->
+      <wireconn num_conns="2*to" from_order="shuffled">
+        <from type="L16" switchpoint="0,12,8,4"/>
+        <from type="L4" switchpoint="0,1,2,3"/>
+        <to type="L4" switchpoint="0"/>
+      </wireconn>
+    </switchblock>
+    <switchblock name="wilton_straight" type="unidir">
+      <switchblock_location type="EVERYWHERE"/>
+      <switchfuncs>
+        <!-- Straight -->
+        <func type="lr" formula="t"/>
+        <!-- left to right -->
+        <func type="tb" formula="t"/>
+        <!-- top to bottom -->
+        <func type="rl" formula="t"/>
+        <!-- right to left -->
+        <func type="bt" formula="t"/>
+        <!-- bottom to top -->
+      </switchfuncs>
+      <!-- L16 Drivers 
+                Note that we order the switchpoints in order of preference, since VPR currently
+                iterates through the source sets in order, such that we connect first to wires
+                ending at the switchblock (switchpoint 0), and then fallback to switchpoints
+                in decreasing distance from the drive point (if we have more to's than from's
+                it then wraps around).
+
+                Note also that we multiply the number of expected connections by 'to', since while usually
+                there is only one 'to' wire, ocasionally there may be more, and we want to ensure they all
+                get the same number of connections.
+
+                For L16->L16:
+                  We allow any valid switchpoint to be used as the 'from' point.
+                  Allow 'low' switchpoints like '4' may seem counter-intuitive (i.e. why not use a cheaper L4)
+                  this makes it easier to bypass once on the L16 network (e.g. to get around congestion).
+           -->
+      <wireconn num_conns="3*to" from_type="L16" from_switchpoint="0,12,8,4" to_type="L16" to_switchpoint="0"/>
+      <wireconn num_conns="11*to" from_type="L4" from_switchpoint="0,3,2,1" to_type="L16" to_switchpoint="0"/>
+      <!-- L4 Drivers -->
+      <wireconn num_conns="2*to" from_order="shuffled">
+        <from type="L16" switchpoint="0,12,8,4"/>
+        <from type="L4" switchpoint="0"/>
+        <to type="L4" switchpoint="0"/>
+      </wireconn>
+      <!--<wireconn num_conns="1*to" from_type="L4" from_switchpoint="0" to_type="L4" to_switchpoint="0"/>-->
+      <!--<wireconn num_conns="1*to" from_type="L16" from_switchpoint="0,12,8,4" to_type="L4" to_switchpoint="0"/>-->
+    </switchblock>
+    <switchblock name="wilton_straight_corner" type="unidir">
+      <!-- Same as wilton straight, but turning around a corner -->
+      <switchblock_location type="CORNER"/>
+      <switchfuncs>
+        <!-- Counter-clock-wise turns -->
+        <func type="lt" formula="t"/>
+        <!-- left to top -->
+        <func type="tr" formula="t"/>
+        <!-- top to right -->
+        <func type="rb" formula="t"/>
+        <!-- right to bottom -->
+        <func type="bl" formula="t"/>
+        <!-- bottom to left -->
+        <!-- Clock-wise turns -->
+        <func type="tl" formula="t"/>
+        <!-- top to left -->
+        <func type="rt" formula="t"/>
+        <!-- right to top -->
+        <func type="br" formula="t"/>
+        <!-- bottom to right -->
+        <func type="lb" formula="t"/>
+        <!-- left to bottom -->
+      </switchfuncs>
+      <!-- L16 Drivers -->
+      <wireconn num_conns="3*to" from_type="L16" from_switchpoint="0,12,8,4" to_type="L16" to_switchpoint="0"/>
+      <wireconn num_conns="11*to" from_type="L4" from_switchpoint="0,3,2,1" to_type="L16" to_switchpoint="0"/>
+      <!-- L4 Drivers -->
+      <wireconn num_conns="2*to" from_order="shuffled">
+        <from type="L16" switchpoint="0,12,8,4"/>
+        <from type="L4" switchpoint="0"/>
+        <to type="L4" switchpoint="0"/>
+      </wireconn>
+      <!--<wireconn num_conns="1*to" from_type="L4" from_switchpoint="0" to_type="L4" to_switchpoint="0"/>-->
+      <!--<wireconn num_conns="1*to" from_type="L16" from_switchpoint="0,12,8,4" to_type="L4" to_switchpoint="0"/>-->
+    </switchblock>
+    <switchblock name="wilton_turn_fringe" type="unidir">
+      <!-- Non-corner perimeter SBs -->
+      <switchblock_location type="FRINGE"/>
+      <switchfuncs>
+        <!-- Counter-clock-wise turns -->
+        <func type="lt" formula="W-t"/>
+        <!-- left to top -->
+        <func type="tr" formula="t+1"/>
+        <!-- top to right -->
+        <func type="rb" formula="2*W-2-t"/>
+        <!-- right to bottom -->
+        <func type="bl" formula="t+1"/>
+        <!-- bottom to left -->
+        <!-- Clock-wise turns -->
+        <func type="tl" formula="W-t"/>
+        <!-- top to left -->
+        <func type="rt" formula="t+1"/>
+        <!-- right to top -->
+        <func type="br" formula="2*W-2-t"/>
+        <!-- bottom to right -->
+        <func type="lb" formula="t+1"/>
+        <!-- left to bottom -->
+      </switchfuncs>
+      <!-- We use 'max' style connections here to ensure there are no dangling wires, otherwise like core turns -->
+      <!-- L16 drivers -->
+      <wireconn num_conns="3*max(from,to)" from_type="L16" from_switchpoint="0,12,8,4" to_type="L16" to_switchpoint="0"/>
+      <wireconn num_conns="21*max(from,to)" from_type="L4" from_switchpoint="0" to_type="L16" to_switchpoint="0"/>
+      <!-- L4 drivers -->
+      <wireconn num_conns="1*max(from,to)" from_type="L16" from_switchpoint="0,12,8,4" from_order="fixed" to_type="L4" to_switchpoint="0"/>
+      <wireconn num_conns="1*max(from,to)" from_type="L4" from_switchpoint="0,1,2,3" from_order="shuffled" to_type="L4" to_switchpoint="0"/>
+    </switchblock>
+  </switchblocklist>
+</architecture>

--- a/tests/data/k6n10_template/inputs/k6n10_template_rrg.yml
+++ b/tests/data/k6n10_template/inputs/k6n10_template_rrg.yml
@@ -1,0 +1,229 @@
+# EXAMPLE COFFE INPUT FILE (FINFET TRANSISTORS)
+#
+# Note: COFFE interprets any line beginning with a '#' as a comment in it's input files.
+#
+# COFFE input parameters can be divided into 2 groups:
+# 1- Parameters describing the FPGA architecture
+# 2- Process technology-related parameters
+# 
+# [1] C. Chiasson and V.Betz. "COFFE: Fully-Automated Transistor Sizing for FPGAs",
+#      IEEE Int. Conf. on Field-Programmable Technology (FPT), 2013
+
+
+#######################################
+##### Architecture Parameters
+#######################################
+fpga_arch_params:
+  # The following parameters are the classic VPR architecture parameters
+  N : 10
+  K : 6 
+  W : 300
+  L : 4
+  I : 80          # Strtx IV Arch File VTR
+  Fs : 3
+  Fcin : 0.15    # Strtx IV Arch File VTR
+  Fcout : 0.1    # Strtx IV Arch File VTR
+
+  # arch_out_folder: ${RAD_GEN_HOME}/tests/data/stratix_iv/outputs/stratix_iv_rrg_debug
+
+  # Running the checkpoint with confirmed results from ${RAD_GEN_HOME}/tests/data/stratix_iv/outputs/stratix_iv_rrg_full_run dir
+  #   (w results): ${RAD_GEN_HOME}/tests/data/stratix_iv/outputs/stratix_iv_checkpointed_it_1
+
+  # Ran with a checkpoint coming from either the original 'part1' and 'part2' dirs or from the 
+  #   ${RAD_GEN_HOME}/tests/data/stratix_iv/outputs/stratix_iv_rrg_full_run dir 
+  #   (w results): ${RAD_GEN_HOME}/tests/data/stratix_iv/outputs/stratix_iv_rrg_mt_8_it_4_from_checkpoint_it_1
+
+  # For full run (currently unused): ${RAD_GEN_HOME}/tests/data/stratix_iv/outputs/stratix_iv_rrg_mt_8_it_4
+  # For debug
+
+
+  # rr_graph_fpath: ${RAD_GEN_HOME}/unit_tests/inputs/coffe/stratix_iv/rr_graph_ep4sgx110.xml
+
+  # Wire types in format [length, percentage of total channel width]
+  # ORIGINAL WIRE TYPE DEFINITION
+  # wire_types:
+  #   - len: 4 # Length of wire type
+  #     freq: 260 # Frequency of wire type
+  #     metal: 1 # metal RC index
+
+  #   - len: 16
+  #     freq: 40
+  #     metal: 1
+  # RRG BASED WIRE TYPE DEFINITION
+  wire_types:
+    - name: "L4"  # Name used to identify this wire, matching name found in the rr_graph
+      len: 4
+      freq: 260
+      metal: 1    # metal RC index
+    - name: "L16" # Name used to identify this wire, matching name found in the rr_graph
+      len: 16
+      freq: 40
+      metal: 2    # metal RC index
+
+
+
+  # Connectivity of each wire type to one another in switch boxes
+  Fs_mtx:
+    # Each element is a dict with:
+    #   src: source wire type index
+    #   dst: destination wire type index
+    #   Fs: routing directions from src to dst wire types
+    # L4 -> L4
+    - src: 0 
+      dst: 0
+      Fs: 3
+    # L4 -> L16
+    - src: 0
+      dst: 1
+      Fs: 0
+    # L16 -> L4
+    - src: 1
+      dst: 0
+      Fs: 3
+    # L16 -> L16
+    - src: 1
+      dst: 1
+      Fs: 3
+    
+
+  # Multi Wire Segment related parameters
+  # options
+  # sb_conn: full -> each wire type can switch to any other wire type in SB
+  # sb_conn: seperate -> each wire type can only connect to wires of the same type in SB
+  # sb_conn: manual -> manually assign connectivity 
+  # sb_conn: 
+  #   mode: full # This just means we have full connectivity between wire lengths
+  # based on the index of wire type we specify how many of each type can connect to other types in each SB
+  # manual_conns:
+  #   - [0.5]
+
+  # The following architecture parameters are new and help COFFE describe
+  # a more flexible BLE. See [1] for more details.
+
+  # Number of BLE outputs to general routing 
+  Or : 2
+
+  # Number of BLE outputs to local routing
+  Ofb : 2
+
+  # Population of local routing MUXes 
+  Fclocal : 0.5
+
+  # Register select:
+  # Defines whether the FF can accept it's input directly from a BLE input or not.
+  # To turn register-select off, Rsel : z
+  # To turn register select on, Rsel : <ble_input_name>
+  # where <ble_input_name>  :  the name of the BLE input from which the FF can
+  # accept its input (e.g. a, b, c, etc...).
+  Rsel : c
+
+  # Register feedback muxes:
+  # Defines which LUT inputs support register feedback.
+  # Set Rfb to a string of LUT input names.
+  # For example: 
+  # Rfb : c tells COFFE to place a register feedback mux on LUT input C.
+  # Rfb : cd tells COFFE to place a register feedback mux on both LUT inputs C and D.
+  # Rfb : z tells COFFE that no LUT input should have register feedback muxes.
+  Rfb : c
+
+  # Do we want to use fracturable Luts?
+  use_fluts : True
+
+  # can be as large as K-1
+  independent_inputs  :  0
+
+  enable_carry_chain  :  1
+  #the carry chain type could be "skip" or "ripple"
+  carry_chain_type  :  skip
+  FAs_per_flut  :  2
+
+  #######################################
+  ##### Process Technology Parameters
+  #######################################
+
+  # Transistor type can be 'bulk' or 'finfet'. 
+  # Make sure your spice model file matches the transistor type you choose.
+  transistor_type : bulk
+
+  # The switch type can be 'pass_transistor' or 'transmission_gate'.
+  switch_type : transmission_gate
+
+  # Supply voltage
+  vdd : 1.0
+
+  # SRAM Vdd
+  # May be unclear but this is also the boost voltage for pass transistor based FPGAs
+  vsram : 1.1 
+
+  # SRAM Vss
+  vsram_n : 0.0
+
+  # Gate length (nm)
+  # From Free45 PDK Layout
+  gate_length : 50
+
+  # This parameter controls the gate length of PMOS level-restorers. For example, setting this paramater 
+  # to 4 sets the gate length to 4x the value of 'gate_legnth'. Increasing the gate length weakens the 
+  # PMOS level-restorer, which is sometimes necessary to ensure proper switching.
+  rest_length_factor  :  5
+
+  # For FinFETs, minimum transistor refers to the contact width of a single-fin transistor (nm).
+  # For Bulk I don't think this parameter is used 
+  # COFFE uses this when it calculates source/drain parasitic capacitances.
+  # ASAP7 has 7nm minimum 
+  min_tran_width  :  90
+
+  # Length of diffusion for a single-finger transistor (nm).
+  # COFFE uses this when it calculates source/drain parasitic capacitances.
+  trans_diffusion_length  :  105
+
+  # Minimum-width transistor area (nm^2)
+  # Look in design rules, make me 1 fin, shortest gate, contact on both sides, no diffusion sharing, 1 space between next transistor
+  # Layout a single transistor pass DRC, look for sample layout
+  min_width_tran_area  :  169175
+
+  # SRAM area (in number of minimum width transistor areas)
+  sram_cell_area  :  6
+
+  # Path to SPICE device models file and library to use
+  model_path : third_party/spice_models/45nm_HP.l
+  model_library : 45NM_FINFET_HP
+
+  #######################################
+  ##### Metal data
+  ##### R in ohms/nm
+  ##### C in fF/nm
+  ##### format: metal : R,C
+  ##### ex: metal : 0.054825,0.000175
+  #######################################
+
+  # Each 'metal' statement defines a new metal layer. 
+  # COFFE uses two metal layers by default. The first metal layer is where COFFE 
+  # implements all wires except for the general routing wires. They are implemented
+  # in the second metal layer. 
+
+  # Mx and My for F7 node in https://dl.acm.org/doi/pdf/10.1145/3431920.3439300
+
+  metal : 
+  # All wires except the general routing wires are implemented in this layer.
+  # Free45 M1
+  - [0.00492, 0.00021]
+  
+  # General routing wires will be implemented in this layer 
+  # Free45 M4-M6
+  - [0.00079, 0.00021]
+
+  # General routing wires will be implemented in this layer 
+  # Free45 M4-M6
+  - [0.00079, 0.00021]
+
+  # If you wanted to, you could define more metal layers by adding more 'metal'
+  # statements but, by default, COFFE would not use them because it only uses 2 layers.
+  # The functionality of being able to add any number of metal layers is here to allow
+  # you to investigate the use of more than 2 metal layers if you wanted to. However,
+  # making use of more metal layers would require changes to the COFFE source code.
+
+  gen_routing_metal_pitch : 280 # From Free45 PDK M4-M6
+  gen_routing_metal_layers : 1
+
+

--- a/tests/data/k6n10_template/inputs/s38584.1.blif
+++ b/tests/data/k6n10_template/inputs/s38584.1.blif
@@ -1,0 +1,19159 @@
+.model top
+.inputs pg115 pg126 pg116 pg125 pg5 pg135 pg127 pg100 pg6751 pg99 pg6750 pg120 \
+pg134 pg113 pg124 pg114 pg92 pg6748 pg91 pg6749 pclk pg6746 pg84 pg6747 pg6744 \
+pg6745 pg6753 pg6752 pg56 pg57 pg64 pg73 pg36 pg54 pg72 pg90 pg35 pg44 pg53
+.outputs pg8342 pg8353 pg8870 pg9048 pg9741 pg13272 pg13906 pg28030 pg28041 \
+pg33533 pg34437 pg8132 pg8783 pg9555 pg12184 pg13068 pg13099 pg31521 pg33435 \
+pg34425 pg7260 pg8344 pg8784 pg14167 pg17320 pg18101 pg30327 pg31793 pg34435 \
+pg8398 pg8785 pg18100 pg20899 pg34436 pg8786 pg14828 pg20557 pg20654 pg21727 \
+pg24171 pg24182 pg26876 pg30329 pg33894 pg34239 pg7243 pg7540 pg8235 pg8787 \
+pg12470 pg17819 pg19334 pg24172 pg24181 pg26877 pg32454 pg34597 pg8403 pg8788 \
+pg9497 pg13926 pg14189 pg14451 pg23190 pg24151 pg24162 pg24180 pg26801 pg33874 \
+pg34237 pg7245 pg8215 pg8789 pg10122 pg12919 pg16924 pg17291 pg20763 pg24161 \
+pg24170 pg28042 pg34238 pg12833 pg14705 pg14738 pg14749 pg16693 pg16718 \
+pg17423 pg18097 pg24164 pg24175 pg29211 pg34235 pg18098 pg20901 pg23652 \
+pg24163 pg24176 pg24185 pg29210 pg34201 pg34236 pg11388 pg17577 pg17674 \
+pg17760 pg18099 pg20652 pg24166 pg24173 pg24184 pg29213 pg29220 pg34233 \
+pg34972 pg14597 pg14694 pg17813 pg21292 pg24165 pg24174 pg24183 pg29212 \
+pg29221 pg32975 pg34234 pg34788 pg11678 pg12923 pg14518 pg14662 pg14673 \
+pg17607 pg17715 pg19357 pg24168 pg24179 pg25219 pg29215 pg30332 pg34956 \
+pg16627 pg23612 pg24167 pg29214 pg34232 pg14635 pg17519 pg17580 pg24177 \
+pg25167 pg29217 pg30330 pg34240 pg12832 pg16722 pg24169 pg24178 pg29216 \
+pg30331 pg34221 pg7916 pg8919 pg11447 pg13881 pg16624 pg17711 pg17722 pg20049 \
+pg25259 pg25583 pg29219 pg33948 pg33959 pg34927 pg8918 pg11770 pg16874 pg17604 \
+pg21245 pg25584 pg29218 pg33949 pg34917 pg25585 pg32185 pg33946 pg34839 pg8839 \
+pg16603 pg16656 pg16744 pg17646 pg17743 pg17778 pg17787 pg18092 pg25586 \
+pg33947 pg34919 pg11418 pg16686 pg17845 pg21176 pg25114 pg25590 pg34383 \
+pg34923 pg12368 pg13895 pg14779 pg17639 pg17688 pg18094 pg18881 pg23683 \
+pg33079 pg33945 pg34913 pg10527 pg13865 pg16659 pg17649 pg17678 pg17685 \
+pg17739 pg17764 pg18095 pg33935 pg34925 pg11349 pg13259 pg16748 pg16775 \
+pg17316 pg17404 pg17871 pg18096 pg21270 pg25582 pg34915 pg8416 pg9617 pg31863 \
+pg33659 pg33950 pg7257 pg8920 pg9251 pg9817 pg13966 pg14217 pg27831 pg31861 \
+pg34921 pg8291 pg12238 pg12300 pg14096 pg14201 pg14421 pg16955 pg17400 pg26875 \
+pg31862 pg32429 pg8283 pg8915 pg9019 pg9682 pg12350 pg12422 pg13049 pg13085 \
+pg14125 pg14147 pg25587 pg31665 pg8279 pg21698 pg25588 pg31860 pg8719 pg8917 \
+pg9615 pg9680 pg9743 pg23002 pg25589 pg28753 pg31656 pg33636 pg7946 pg8178 \
+pg8277 pg8358 pg8475 pg8916 pg9553 pg10306 pg10500 pg13039 pg23759
+.latch    ng33063 ng6215 re pclk 2
+.latch    ng34455 ng4332 re pclk 2
+.latch    ng24264 ng2837 re pclk 2
+.latch    ng26917 ng1135 re pclk 2
+.latch    ng33013 ng2485 re pclk 2
+.latch    ng26951 ng4375 re pclk 2
+.latch    ng24281 pg9251 re pclk 2
+.latch    ng30338 ng1171 re pclk 2
+.latch    ng30403 ng3235 re pclk 2
+.latch    ng34610 ng2852 re pclk 2
+.latch    ng33537 ng222 re pclk 2
+.latch    ng25595 pg8719 re pclk 2
+.latch    ng34446 ng2815 re pclk 2
+.latch    ng34266 ng4888 re pclk 2
+.latch    ng24205 ng433 re pclk 2
+.latch    ng26907 ng246 re pclk 2
+.latch    ng33962 ng102 re pclk 2
+.latch    ng32983 ng1030 re pclk 2
+.latch    ng30286 ng110 re pclk 2
+.latch    pg11418 pg13966 re pclk 2
+.latch    ng34030 ng4801 re pclk 2
+.latch    ng24277 ng4045 re pclk 2
+.latch    ng34605 ng2145 re pclk 2
+.latch    ng29283 ng5138 re pclk 2
+.latch    ng33033 ng3873 re pclk 2
+.latch    ng25678 ng3752 re pclk 2
+.latch    ng34598 ng136 re pclk 2
+.latch    ng33553 ng1772 re pclk 2
+.latch    pg8416 ng990 re pclk 2
+.latch    ng33023 ng3171 re pclk 2
+.latch    ng25600 ng168 re pclk 2
+.latch    ng24207 ng441 re pclk 2
+.latch    ng34249 ng160 re pclk 2
+.latch    pg17519 pg17577 re pclk 2
+.latch    ng30343 ng1361 re pclk 2
+.latch    ng30551 ng6621 re pclk 2
+.latch    ng24341 ng5689 re pclk 2
+.latch    ng30546 ng6593 re pclk 2
+.latch    ng29294 ng5827 re pclk 2
+.latch    pg17291 pg17316 re pclk 2
+.latch    ng26893 ng74 re pclk 2
+.latch    pg7260 ng4443 re pclk 2
+.latch    pg13259 ng979 re pclk 2
+.latch    ng29238 ng1484 re pclk 2
+.latch    ng24347 ng6044 re pclk 2
+.latch    ng29270 ng3817 re pclk 2
+.latch    ng26883 ng316 re pclk 2
+.latch    pg14147 pg14167 re pclk 2
+.latch    ng25609 ng499 re pclk 2
+.latch    pg14738 pg17739 re pclk 2
+.latch    ng25662 pg8279 re pclk 2
+.latch    ng33581 ng2269 re pclk 2
+.latch    ng34803 ng2927 re pclk 2
+.latch    ng30334 ng577 re pclk 2
+.latch    ng33964 ng599 re pclk 2
+.latch    pg8917 pg8870 re pclk 2
+.latch    ng34600 ng781 re pclk 2
+.latch    ng33608 ng2759 re pclk 2
+.latch    ng24263 ng2715 re pclk 2
+.latch    ng33980 ng1870 re pclk 2
+.latch    ng30353 ng1768 re pclk 2
+.latch    pg16748 ng4031 re pclk 2
+.latch    ng29302 ng6181 re pclk 2
+.latch    ng33996 ng2173 re pclk 2
+.latch    ng32992 ng1783 re pclk 2
+.latch    ng26889 ng106 re pclk 2
+.latch    ng34445 ng2803 re pclk 2
+.latch    ng30537 ng6303 re pclk 2
+.latch    ng25670 ng3462 re pclk 2
+.latch    ng28044 ng482 re pclk 2
+.latch    ng29242 ng1811 re pclk 2
+.latch    ng34799 ng2890 re pclk 2
+.latch    ng30346 ng1542 re pclk 2
+.latch    pg33079 ng111 re pclk 2
+.latch    ng33994 ng2161 re pclk 2
+.latch    ng34601 ng947 re pclk 2
+.latch    ng34722 ng546 re pclk 2
+.latch    ng30454 ng3913 re pclk 2
+.latch    ng24258 pg12923 re pclk 2
+.latch    pg11770 pg8915 re pclk 2
+.latch    ng30492 ng5599 re pclk 2
+.latch    ng30437 ng3893 re pclk 2
+.latch    ng25687 ng4141 re pclk 2
+.latch    ng29257 ng3106 re pclk 2
+.latch    ng25682 ng3841 re pclk 2
+.latch    ng33987 ng2004 re pclk 2
+.latch    ng30424 ng3586 re pclk 2
+.latch    ng34727 ng939 re pclk 2
+.latch    ng29303 ng6195 re pclk 2
+.latch    ng32981 ng925 re pclk 2
+.latch    ng30526 ng6255 re pclk 2
+.latch    ng33997 ng2177 re pclk 2
+.latch    ng29296 ng5835 re pclk 2
+.latch    ng33042 ng4543 re pclk 2
+.latch    pg9617 ng5802 re pclk 2
+.latch    ng25697 ng5092 re pclk 2
+.latch    ng30444 ng3933 re pclk 2
+.latch    pg14673 pg17715 re pclk 2
+.latch    ng29230 ng911 re pclk 2
+.latch    ng30438 ng3901 re pclk 2
+.latch    pg10122 ng4297 re pclk 2
+.latch    pg7946 pg8475 re pclk 2
+.latch    ng24278 ng4049 re pclk 2
+.latch    ng25654 ng3139 re pclk 2
+.latch    pg16924 pg13881 re pclk 2
+.latch    ng30558 ng6649 re pclk 2
+.latch    ng33601 ng2599 re pclk 2
+.latch    ng29275 ng4087 re pclk 2
+.latch    ng29237 ng1467 re pclk 2
+.latch    ng29306 ng6519 re pclk 2
+.latch    ng30350 ng1700 re pclk 2
+.latch    ng33985 ng1950 re pclk 2
+.latch    pg11388 pg13926 re pclk 2
+.latch    ng30377 ng2417 re pclk 2
+.latch    ng24208 ng475 re pclk 2
+.latch    ng26884 ng333 re pclk 2
+.latch    ng25701 pg9553 re pclk 2
+.latch    ng24348 pg12422 re pclk 2
+.latch    ng33559 ng1779 re pclk 2
+.latch    ng30392 ng2834 re pclk 2
+.latch    ng25667 ng3470 re pclk 2
+.latch    ng33050 ng5188 re pclk 2
+.latch    pg19334 pg13259 re pclk 2
+.latch    ng25610 ng504 re pclk 2
+.latch    ng29309 ng6541 re pclk 2
+.latch    ng33062 ng6209 re pclk 2
+.latch    pg17678 ng5685 re pclk 2
+.latch    ng24240 pg7916 re pclk 2
+.latch    ng29264 ng3466 re pclk 2
+.latch    ng28063 ng3333 re pclk 2
+.latch    ng34639 ng4922 re pclk 2
+.latch    ng30549 ng6613 re pclk 2
+.latch    ng31783 ng93 re pclk 2
+.latch    ng23280 pg12368 re pclk 2
+.latch    pg13039 pg17787 re pclk 2
+.latch    ng26924 ng1478 re pclk 2
+.latch    ng29730 ng63 re pclk 2
+.latch    ng34020 ng2643 re pclk 2
+.latch    pg8358 ng191 re pclk 2
+.latch    ng33970 ng1620 re pclk 2
+.latch    pg14451 pg16924 re pclk 2
+.latch    ng33594 ng2495 re pclk 2
+.latch    ng30488 ng5583 re pclk 2
+.latch    ng34604 ng2138 re pclk 2
+.latch    ng30469 ng5244 re pclk 2
+.latch    ng26912 ng936 re pclk 2
+.latch    ng24204 ng429 re pclk 2
+.latch    ng34467 ng4854 re pclk 2
+.latch    ng34613 ng37 re pclk 2
+.latch    ng24349 ng6381 re pclk 2
+.latch    pg7540 ng347 re pclk 2
+.latch    ng21898 pg9019 re pclk 2
+.latch    ng26927 ng2767 re pclk 2
+.latch    pg8787 pg8788 re pclk 2
+.latch    ng30507 ng5921 re pclk 2
+.latch    pg17819 pg14673 re pclk 2
+.latch    pg33435 ng85 re pclk 2
+.latch    ng28092 ng5069 re pclk 2
+.latch    ng26914 ng1061 re pclk 2
+.latch    ng26948 ng4401 re pclk 2
+.latch    pg16624 pg14421 re pclk 2
+.latch    ng30430 ng3610 re pclk 2
+.latch    ng34037 ng4975 re pclk 2
+.latch    ng26952 ng4427 re pclk 2
+.latch    ng26939 ng4145 re pclk 2
+.latch    ng30355 ng1834 re pclk 2
+.latch    ng33620 ng5703 re pclk 2
+.latch    ng34024 pg10306 re pclk 2
+.latch    ng29233 ng1141 re pclk 2
+.latch    ng33040 ng4512 re pclk 2
+.latch    ng34630 ng4253 re pclk 2
+.latch    ng33617 ng4570 re pclk 2
+.latch    ng24260 ng1548 re pclk 2
+.latch    ng21897 ng4284 re pclk 2
+.latch    ng25598 ng385 re pclk 2
+.latch    ng32977 ng291 re pclk 2
+.latch    pg14694 pg17711 re pclk 2
+.latch    ng25656 ng3111 re pclk 2
+.latch    ng28051 ng718 re pclk 2
+.latch    ng30528 ng6267 re pclk 2
+.latch    ng33588 ng2399 re pclk 2
+.latch    ng34795 ng2898 re pclk 2
+.latch    ng26946 pg7257 re pclk 2
+.latch    ng28099 ng4831 re pclk 2
+.latch    ng30502 ng5889 re pclk 2
+.latch    ng26899 ng822 re pclk 2
+.latch    ng28140 ng43 re pclk 2
+.latch    pg17760 pg17649 re pclk 2
+.latch    ng33573 ng2112 re pclk 2
+.latch    ng30481 ng5543 re pclk 2
+.latch    ng26955 pg7260 re pclk 2
+.latch    ng34250 ng142 re pclk 2
+.latch    ng25703 ng5022 re pclk 2
+.latch    pg9682 ng6148 re pclk 2
+.latch    ng26922 ng1448 re pclk 2
+.latch    ng30451 ng3961 re pclk 2
+.latch    ng30337 ng1018 re pclk 2
+.latch    ng31902 ng5029 re pclk 2
+.latch    ng25611 ng513 re pclk 2
+.latch    pg9497 ng5109 re pclk 2
+.latch    ng33989 ng2016 re pclk 2
+.latch    ng30486 ng5575 re pclk 2
+.latch    ng31903 ng5052 re pclk 2
+.latch    ng30362 ng1992 re pclk 2
+.latch    ng34801 ng2902 re pclk 2
+.latch    ng29269 ng3808 re pclk 2
+.latch    ng33967 ng1608 re pclk 2
+.latch    ng33055 ng5535 re pclk 2
+.latch    ng24201 ng405 re pclk 2
+.latch    ng25591 pg8291 re pclk 2
+.latch    ng25714 pg9555 re pclk 2
+.latch    ng30411 ng3203 re pclk 2
+.latch    ng28050 ng655 re pclk 2
+.latch    pg10306 ng4423 re pclk 2
+.latch    ng34458 ng4633 re pclk 2
+.latch    ng28072 ng4116 re pclk 2
+.latch    ng33961 ng298 re pclk 2
+.latch    ng24238 pg17291 re pclk 2
+.latch    ng33038 ng4501 re pclk 2
+.latch    ng25761 ng6513 re pclk 2
+.latch    ng30468 ng5240 re pclk 2
+.latch    ng28057 ng1002 re pclk 2
+.latch    ng26910 ng896 re pclk 2
+.latch    pg8279 ng3451 re pclk 2
+.latch    ng24266 ng2712 re pclk 2
+.latch    ng30509 ng5929 re pclk 2
+.latch    ng25756 pg9743 re pclk 2
+.latch    ng24215 ng837 re pclk 2
+.latch    ng34009 ng2437 re pclk 2
+.latch    pg14705 pg17743 re pclk 2
+.latch    pg13926 pg16744 re pclk 2
+.latch    ng34725 ng785 re pclk 2
+.latch    ng34017 ng2575 re pclk 2
+.latch    pg13099 pg17871 re pclk 2
+.latch    ng30442 ng3925 re pclk 2
+.latch    [1421] [1457] re pclk 2
+.latch    ng34264 ng4765 re pclk 2
+.latch    ng25630 ng1266 re pclk 2
+.latch    ng30562 ng6605 re pclk 2
+.latch    ng34616 ng2868 re pclk 2
+.latch    ng33070 ng6573 re pclk 2
+.latch    ng29289 ng5485 re pclk 2
+.latch    ng25628 ng1211 re pclk 2
+.latch    ng33555 ng1821 re pclk 2
+.latch    ng29281 ng5124 re pclk 2
+.latch    ng24352 pg12470 re pclk 2
+.latch    ng34791 ng790 re pclk 2
+.latch    ng29284 ng5142 re pclk 2
+.latch    ng30426 ng3594 re pclk 2
+.latch    ng30515 ng5953 re pclk 2
+.latch    pg17813 pg14635 re pclk 2
+.latch    ng33068 ng6561 re pclk 2
+.latch    ng34443 ng2775 re pclk 2
+.latch    ng26944 ng4366 re pclk 2
+.latch    ng31898 ng5016 re pclk 2
+.latch    pg17604 pg13049 re pclk 2
+.latch    ng25705 ng5128 re pclk 2
+.latch    pg9555 ng5456 re pclk 2
+.latch    ng34026 ng4674 re pclk 2
+.latch    ng30457 ng4153 re pclk 2
+.latch    ng30390 ng117 re pclk 2
+.latch    ng30404 ng3239 re pclk 2
+.latch    ng29236 ng1437 re pclk 2
+.latch    ng24627 [1421] re pclk 2
+.latch    ng21895 ng4269 re pclk 2
+.latch    ng24269 ng3343 re pclk 2
+.latch    ng34448 ng2819 re pclk 2
+.latch    ng25650 ng3050 re pclk 2
+.latch    ng33036 ng4495 re pclk 2
+.latch    ng30341 ng1070 re pclk 2
+.latch    pg13966 pg16775 re pclk 2
+.latch    ng30540 ng6251 re pclk 2
+.latch    ng34730 ng1283 re pclk 2
+.latch    ng25763 ng6537 re pclk 2
+.latch    ng24282 ng2932 re pclk 2
+.latch    ng34451 ng4584 re pclk 2
+.latch    pg14518 pg16955 re pclk 2
+.latch    ng25729 pg9680 re pclk 2
+.latch    pg14096 pg14125 re pclk 2
+.latch    ng34980 ng2984 re pclk 2
+.latch    ng24254 pg17320 re pclk 2
+.latch    ng29235 ng1256 re pclk 2
+.latch    ng2837 ng2841 re pclk 2
+.latch    ng34003 ng2307 re pclk 2
+.latch    ng25715 pg9615 re pclk 2
+.latch    ng33149 ng31 re pclk 2
+.latch    ng4456 ng4455 re pclk 2
+.latch    ng33197 ng9 re pclk 2
+.latch    pg8784 pg8785 re pclk 2
+.latch    ng28089 ng4950 re pclk 2
+.latch    ng30463 ng5216 re pclk 2
+.latch    ng33562 ng1936 re pclk 2
+.latch    ng33546 ng1668 re pclk 2
+.latch    pg12238 pg14662 re pclk 2
+.latch    ng24272 ng3689 re pclk 2
+.latch    ng34628 ng4146 re pclk 2
+.latch    ng34027 ng4681 re pclk 2
+.latch    ng28055 ng827 re pclk 2
+.latch    ng31865 ng287 re pclk 2
+.latch    ng32985 ng1277 re pclk 2
+.latch    ng26931 ng2799 re pclk 2
+.latch    ng29244 ng1945 re pclk 2
+.latch    ng34439 ng776 re pclk 2
+.latch    pg8719 ng358 re pclk 2
+.latch    ng34849 ng626 re pclk 2
+.latch    ng34459 ng4340 re pclk 2
+.latch    ng30363 ng2036 re pclk 2
+.latch    ng24247 ng1249 re pclk 2
+.latch    ng30365 ng2102 re pclk 2
+.latch    ng29300 ng6173 re pclk 2
+.latch    ng33591 ng2338 re pclk 2
+.latch    ng33626 ng6741 re pclk 2
+.latch    ng66 ng65 re pclk 2
+.latch    pg13085 pg17845 re pclk 2
+.latch    ng29305 ng6509 re pclk 2
+.latch    ng33570 ng2070 re pclk 2
+.latch    ng30484 ng5563 re pclk 2
+.latch    ng34256 ng4473 re pclk 2
+.latch    ng34011 ng2445 re pclk 2
+.latch    ng33590 ng2407 re pclk 2
+.latch    ng29240 ng1677 re pclk 2
+.latch    ng25699 ng86 re pclk 2
+.latch    ng26934 ng2827 re pclk 2
+.latch    pg17316 pg17400 re pclk 2
+.latch    ng25636 ng1306 re pclk 2
+.latch    ng30344 ng1514 re pclk 2
+.latch    ng34633 ng4727 re pclk 2
+.latch    ng30399 ng3219 re pclk 2
+.latch    ng30561 ng6597 re pclk 2
+.latch    ng30520 ng5913 re pclk 2
+.latch    ng30409 ng3259 re pclk 2
+.latch    ng34805 ng2999 re pclk 2
+.latch    ng33599 ng2472 re pclk 2
+.latch    ng30410 ng3195 re pclk 2
+.latch    ng31895 ng4417 re pclk 2
+.latch    ng34619 ng2922 re pclk 2
+.latch    ng25664 ng3401 re pclk 2
+.latch    ng25653 ng3119 re pclk 2
+.latch    ng30412 ng3211 re pclk 2
+.latch    ng25681 ng3821 re pclk 2
+.latch    ng30395 ng3191 re pclk 2
+.latch    ng30380 ng2527 re pclk 2
+.latch    ng30405 ng3243 re pclk 2
+.latch    ng30476 ng5204 re pclk 2
+.latch    ng33560 ng1862 re pclk 2
+.latch    ng24236 ng1178 re pclk 2
+.latch    pg12422 pg14779 re pclk 2
+.latch    ng33029 ng3530 re pclk 2
+.latch    ng24280 ng4273 re pclk 2
+.latch    ng28626 ng4572 re pclk 2
+.latch    ng30370 ng2259 re pclk 2
+.latch    ng25749 ng6191 re pclk 2
+.latch    ng30538 ng6307 re pclk 2
+.latch    pg8839 ng4281 re pclk 2
+.latch    ng34025 ng4639 re pclk 2
+.latch    ng31899 ng5037 re pclk 2
+.latch    ng30531 ng6279 re pclk 2
+.latch    ng33619 ng5297 re pclk 2
+.latch    pg8915 pg8916 re pclk 2
+.latch    ng26903 ng232 re pclk 2
+.latch    ng29268 ng3498 re pclk 2
+.latch    ng33067 ng6555 re pclk 2
+.latch    ng26923 ng1472 re pclk 2
+.latch    ng28085 ng4760 re pclk 2
+.latch    ng33583 ng2204 re pclk 2
+.latch    ng26909 ng862 re pclk 2
+.latch    ng24355 ng6736 re pclk 2
+.latch    ng29304 ng6500 re pclk 2
+.latch    ng26926 ng2724 re pclk 2
+.latch    ng34796 ng2882 re pclk 2
+.latch    ng33598 ng2541 re pclk 2
+.latch    ng30559 ng6653 re pclk 2
+.latch    ng28087 ng4894 re pclk 2
+.latch    ng33012 ng2476 re pclk 2
+.latch    ng28060 ng2729 re pclk 2
+.latch    pg14421 pg16874 re pclk 2
+.latch    ng33540 ng930 re pclk 2
+.latch    ng33627 ng6682 re pclk 2
+.latch    ng34615 ng2873 re pclk 2
+.latch    ng34040 ng4899 re pclk 2
+.latch    pg8918 pg8919 re pclk 2
+.latch    ng29267 ng3484 re pclk 2
+.latch    ng34251 ng604 re pclk 2
+.latch    ng29243 ng1825 re pclk 2
+.latch    ng26950 ng4392 re pclk 2
+.latch    ng4519 ng4520 re pclk 2
+.latch    ng25634 ng1395 re pclk 2
+.latch    ng29227 ng714 re pclk 2
+.latch    ng26896 ng79 re pclk 2
+.latch    ng25764 ng6505 re pclk 2
+.latch    ng29286 ng5462 re pclk 2
+.latch    ng28091 ng5073 re pclk 2
+.latch    ng33545 ng1636 re pclk 2
+.latch    ng29297 ng5849 re pclk 2
+.latch    ng33577 ng2197 re pclk 2
+.latch    ng30357 ng1858 re pclk 2
+.latch    ng30544 ng6581 re pclk 2
+.latch    ng30358 ng1902 re pclk 2
+.latch    ng30367 ng2126 re pclk 2
+.latch    pg8785 pg8786 re pclk 2
+.latch    ng31866 ng582 re pclk 2
+.latch    ng25683 ng3845 re pclk 2
+.latch    ng29246 ng2079 re pclk 2
+.latch    ng25734 ng5841 re pclk 2
+.latch    ng21892 ng4239 re pclk 2
+.latch    ng25706 ng5148 re pclk 2
+.latch    pg17580 pg17604 re pclk 2
+.latch    pg17739 pg17607 re pclk 2
+.latch    pg17649 pg17685 re pclk 2
+.latch    ng28093 ng128 re pclk 2
+.latch    ng33016 ng2610 re pclk 2
+.latch    ng24353 ng6727 re pclk 2
+.latch    ng25655 ng3143 re pclk 2
+.latch    ng34642 ng4927 re pclk 2
+.latch    ng25704 ng5077 re pclk 2
+.latch    ng33008 ng2342 re pclk 2
+.latch    ng30421 ng3574 re pclk 2
+.latch    ng33007 ng2319 re pclk 2
+.latch    ng25730 ng5752 re pclk 2
+.latch    ng25624 ng1041 re pclk 2
+.latch    ng34255 ng4467 re pclk 2
+.latch    ng30371 ng2279 re pclk 2
+.latch    ng26900 pg14189 re pclk 2
+.latch    ng33607 ng2606 re pclk 2
+.latch    ng26904 ng262 re pclk 2
+.latch    ng34626 ng3502 re pclk 2
+.latch    ng29293 ng5817 re pclk 2
+.latch    ng34268 ng4944 re pclk 2
+.latch    ng29271 ng3827 re pclk 2
+.latch    ng28083 ng4704 re pclk 2
+.latch    ng26886 ng336 re pclk 2
+.latch    ng33576 ng2153 re pclk 2
+.latch    ng29266 ng3480 re pclk 2
+.latch    pg14635 pg17678 re pclk 2
+.latch    ng34260 ng4646 re pclk 2
+.latch    ng33618 ng5357 re pclk 2
+.latch    ng34640 ng4907 re pclk 2
+.latch    ng30445 ng3937 re pclk 2
+.latch    ng30514 ng5949 re pclk 2
+.latch    ng30356 ng1854 re pclk 2
+.latch    ng25685 ng4064 re pclk 2
+.latch    ng30525 ng6247 re pclk 2
+.latch    ng30342 ng1259 re pclk 2
+.latch    ng30560 ng6589 re pclk 2
+.latch    pg13272 ng1322 re pclk 2
+.latch    ng33567 ng1913 re pclk 2
+.latch    ng29290 ng5489 re pclk 2
+.latch    ng25602 ng182 re pclk 2
+.latch    ng33544 ng1592 re pclk 2
+.latch    ng34606 ng2689 re pclk 2
+.latch    pg14201 pg14217 re pclk 2
+.latch    ng34013 ng2509 re pclk 2
+.latch    ng30441 ng3921 re pclk 2
+.latch    ng33977 ng1756 re pclk 2
+.latch    ng34621 ng2950 re pclk 2
+.latch    ng26908 ng446 re pclk 2
+.latch    ng34257 ng4349 re pclk 2
+.latch    ng29299 ng6163 re pclk 2
+.latch    ng30470 ng5248 re pclk 2
+.latch    ng26954 pg7245 re pclk 2
+.latch    ng21901 pg11447 re pclk 2
+.latch    ng33574 ng2116 re pclk 2
+.latch    ng34607 ng2697 re pclk 2
+.latch    pg13881 pg16722 re pclk 2
+.latch    ng33011 ng2453 re pclk 2
+.latch    ng26965 ng4420 re pclk 2
+.latch    ng30429 ng3606 re pclk 2
+.latch    ng25619 ng843 re pclk 2
+.latch    ng30414 ng3506 re pclk 2
+.latch    ng33541 ng1036 re pclk 2
+.latch    ng33615 ng4104 re pclk 2
+.latch    ng33548 ng1706 re pclk 2
+.latch    ng33053 ng5523 re pclk 2
+.latch    ng25750 ng6159 re pclk 2
+.latch    ng34622 ng2960 re pclk 2
+.latch    ng25720 ng5495 re pclk 2
+.latch    ng34804 ng2975 re pclk 2
+.latch    ng30543 ng6549 re pclk 2
+.latch    ng34005 ng2315 re pclk 2
+.latch    ng30383 ng2595 re pclk 2
+.latch    ng34647 ng6545 re pclk 2
+.latch    ng29255 ng2652 re pclk 2
+.latch    ng30523 ng6235 re pclk 2
+.latch    ng24211 ng542 re pclk 2
+.latch    ng33556 ng1840 re pclk 2
+.latch    ng24214 ng703 re pclk 2
+.latch    ng25700 pg9497 re pclk 2
+.latch    ng25691 ng4072 re pclk 2
+.latch    ng29261 ng3133 re pclk 2
+.latch    ng27511 ng22 re pclk 2
+.latch    ng33561 ng1906 re pclk 2
+.latch    ng34641 ng4912 re pclk 2
+.latch    ng29245 ng1959 re pclk 2
+.latch    ng30435 ng3857 re pclk 2
+.latch    ng34006 ng2375 re pclk 2
+.latch    ng34038 ng4991 re pclk 2
+.latch    ng21899 ng2946 re pclk 2
+.latch    ng30391 ng2831 re pclk 2
+.latch    ng29228 ng739 re pclk 2
+.latch    ng25696 ng5084 re pclk 2
+.latch    ng34029 ng4785 re pclk 2
+.latch    ng26929 ng2791 re pclk 2
+.latch    ng30548 ng6609 re pclk 2
+.latch    ng30364 ng2098 re pclk 2
+.latch    ng30431 ng3546 re pclk 2
+.latch    ng33003 ng2185 re pclk 2
+.latch    ng33014 ng2491 re pclk 2
+.latch    ng25631 ng1312 re pclk 2
+.latch    ng26916 ng1129 re pclk 2
+.latch    ng24246 ng1221 re pclk 2
+.latch    ng32987 ng1624 re pclk 2
+.latch    ng33558 ng1848 re pclk 2
+.latch    ng34468 ng4859 re pclk 2
+.latch    [1457] [1411] re pclk 2
+.latch    ng34732 ng2994 re pclk 2
+.latch    ng25626 ng956 re pclk 2
+.latch    ng33592 ng2421 re pclk 2
+.latch    ng25762 ng6533 re pclk 2
+.latch    ng25597 ng370 re pclk 2
+.latch    ng33986 ng1874 re pclk 2
+.latch    ng25690 ng4125 re pclk 2
+.latch    ng29288 ng5481 re pclk 2
+.latch    ng33212 ng7 re pclk 2
+.latch    ng33586 ng2361 re pclk 2
+.latch    ng30373 ng2327 re pclk 2
+.latch    ng29229 ng723 re pclk 2
+.latch    ng34614 ng94 re pclk 2
+.latch    ng33611 ng3703 re pclk 2
+.latch    ng33041 ng4549 re pclk 2
+.latch    pg8789 ng4180 re pclk 2
+.latch    ng32997 ng1926 re pclk 2
+.latch    ng29226 ng676 re pclk 2
+.latch    ng26966 ng4558 re pclk 2
+.latch    ng34034 ng4864 re pclk 2
+.latch    ng24253 ng1532 re pclk 2
+.latch    ng26920 ng1389 re pclk 2
+.latch    pg16744 pg16627 re pclk 2
+.latch    pg8344 ng3802 re pclk 2
+.latch    ng30369 ng2255 re pclk 2
+.latch    ng25721 ng5499 re pclk 2
+.latch    ng21891 pg11770 re pclk 2
+.latch    ng30506 ng5917 re pclk 2
+.latch    ng25747 ng6167 re pclk 2
+.latch    ng30440 ng3917 re pclk 2
+.latch    ng33597 ng2537 re pclk 2
+.latch    ng30475 ng5268 re pclk 2
+.latch    ng33034 ng3881 re pclk 2
+.latch    ng30472 ng5256 re pclk 2
+.latch    ng34634 ng4732 re pclk 2
+.latch    ng26890 pg7540 re pclk 2
+.latch    pg13049 pg17813 re pclk 2
+.latch    ng34797 ng2878 re pclk 2
+.latch    ng32982 ng933 re pclk 2
+.latch    ng34629 ng4157 re pclk 2
+.latch    ng33031 ng3863 re pclk 2
+.latch    pg16659 pg16693 re pclk 2
+.latch    ng32989 ng1657 re pclk 2
+.latch    pg13068 pg17819 re pclk 2
+.latch    ng28069 ng4035 re pclk 2
+.latch    ng25615 ng667 re pclk 2
+.latch    ng25719 ng5475 re pclk 2
+.latch    ng30493 ng5603 re pclk 2
+.latch    ng25639 ng2719 re pclk 2
+.latch    ng30448 ng3949 re pclk 2
+.latch    ng25593 ng209 re pclk 2
+.latch    ng34254 ng4462 re pclk 2
+.latch    ng34631 ng4249 re pclk 2
+.latch    ng30467 ng5236 re pclk 2
+.latch    pg8916 pg8917 re pclk 2
+.latch    ng34465 ng4849 re pclk 2
+.latch    pg13895 pg16718 re pclk 2
+.latch    ng33578 ng2227 re pclk 2
+.latch    ng25702 ng5062 re pclk 2
+.latch    ng34650 ng34 re pclk 2
+.latch    ng24202 ng424 re pclk 2
+.latch    ng26919 ng1280 re pclk 2
+.latch    ng28049 ng650 re pclk 2
+.latch    ng33998 ng2181 re pclk 2
+.latch    ng26913 ng1046 re pclk 2
+.latch    ng28059 ng1345 re pclk 2
+.latch    ng24342 ng5694 re pclk 2
+.latch    ng34010 ng2441 re pclk 2
+.latch    ng28096 ng4821 re pclk 2
+.latch    ng24273 ng3694 re pclk 2
+.latch    ng26928 ng2779 re pclk 2
+.latch    ng25596 ng376 re pclk 2
+.latch    ng28056 ng907 re pclk 2
+.latch    ng28053 ng699 re pclk 2
+.latch    ng29260 ng3129 re pclk 2
+.latch    ng34261 ng4698 re pclk 2
+.latch    ng24345 ng6035 re pclk 2
+.latch    ng30458 ng4507 re pclk 2
+.latch    ng24276 ng4040 re pclk 2
+.latch    ng30483 ng5555 re pclk 2
+.latch    ng32978 ng590 re pclk 2
+.latch    ng33976 ng1752 re pclk 2
+.latch    ng4474 ng4477 re pclk 2
+.latch    ng34729 ng1296 re pclk 2
+.latch    ng26947 ng4382 re pclk 2
+.latch    ng25625 ng1052 re pclk 2
+.latch    ng33552 ng1728 re pclk 2
+.latch    ng25622 ng969 re pclk 2
+.latch    ng26892 ng355 re pclk 2
+.latch    pg14597 pg17639 re pclk 2
+.latch    ng25757 pg9817 re pclk 2
+.latch    ng26901 ng225 re pclk 2
+.latch    ng33058 ng5869 re pclk 2
+.latch    ng33534 ng153 re pclk 2
+.latch    ng26932 ng2811 re pclk 2
+.latch    pg12923 ng1585 re pclk 2
+.latch    ng33035 ng4108 re pclk 2
+.latch    ng33060 ng5881 re pclk 2
+.latch    ng24233 ng1146 re pclk 2
+.latch    ng25612 ng518 re pclk 2
+.latch    ng24335 ng4531 re pclk 2
+.latch    ng31900 ng5041 re pclk 2
+.latch    ng34624 ng2988 re pclk 2
+.latch    ng30345 ng1526 re pclk 2
+.latch    ng26895 ng568 re pclk 2
+.latch    ng21900 pg10122 re pclk 2
+.latch    ng33045 ng4546 re pclk 2
+.latch    ng25744 ng6098 re pclk 2
+.latch    ng30532 ng6283 re pclk 2
+.latch    ng25708 ng5120 re pclk 2
+.latch    ng24257 pg19357 re pclk 2
+.latch    ng34450 ng4322 re pclk 2
+.latch    ng30471 ng5252 re pclk 2
+.latch    ng33542 ng1274 re pclk 2
+.latch    ng30605 ng112 re pclk 2
+.latch    ng31904 ng5033 re pclk 2
+.latch    ng28088 ng4939 re pclk 2
+.latch    ng25698 ng5097 re pclk 2
+.latch    pg9553 ng5112 re pclk 2
+.latch    pg16686 ng3329 re pclk 2
+.latch    ng34728 ng943 re pclk 2
+.latch    ng30461 ng5200 re pclk 2
+.latch    ng34618 ng2912 re pclk 2
+.latch    ng33609 ng3352 re pclk 2
+.latch    ng29259 ng3125 re pclk 2
+.latch    ng30361 ng1988 re pclk 2
+.latch    ng24338 ng5348 re pclk 2
+.latch    ng26958 pg12832 re pclk 2
+.latch    ng33981 ng1878 re pclk 2
+.latch    ng30381 ng2547 re pclk 2
+.latch    ng24337 ng5343 re pclk 2
+.latch    pg17722 pg13099 re pclk 2
+.latch    ng30499 ng5567 re pclk 2
+.latch    ng24239 pg10500 re pclk 2
+.latch    ng26897 ng753 re pclk 2
+.latch    ng26891 ng351 re pclk 2
+.latch    ng33024 ng3179 re pclk 2
+.latch    ng34447 ng2807 re pclk 2
+.latch    ng33971 ng1682 re pclk 2
+.latch    ng29295 ng5831 re pclk 2
+.latch    ng30402 ng3231 re pclk 2
+.latch    ng26961 ng4486 re pclk 2
+.latch    ng30487 ng5579 re pclk 2
+.latch    ng30552 ng6625 re pclk 2
+.latch    ng25677 pg8398 re pclk 2
+.latch    ng26949 ng4388 re pclk 2
+.latch    ng26967 ng4564 re pclk 2
+.latch    pg9251 ng4308 re pclk 2
+.latch    ng33018 ng2625 re pclk 2
+.latch    ng30452 ng3897 re pclk 2
+.latch    ng34611 ng2860 re pclk 2
+.latch    ng30556 ng6641 re pclk 2
+.latch    ng30415 ng3538 re pclk 2
+.latch    ng29307 ng6523 re pclk 2
+.latch    ng30413 ng3263 re pclk 2
+.latch    ng30433 ng3562 re pclk 2
+.latch    pg12470 pg14828 re pclk 2
+.latch    ng30511 ng5937 re pclk 2
+.latch    pg12919 ng1242 re pclk 2
+.latch    ng28086 ng4771 re pclk 2
+.latch    pg17845 pg14705 re pclk 2
+.latch    ng34039 ng4966 re pclk 2
+.latch    pg14662 pg17674 re pclk 2
+.latch    ng30340 ng1199 re pclk 2
+.latch    ng30512 ng5941 re pclk 2
+.latch    ng24234 ng1152 re pclk 2
+.latch    pg17685 pg13085 re pclk 2
+.latch    ng34793 ng2856 re pclk 2
+.latch    [1411] ng4818 re pclk 2
+.latch    ng24241 pg19334 re pclk 2
+.latch    ng30359 ng1964 re pclk 2
+.latch    ng33176 ng19 re pclk 2
+.latch    ng33047 ng5170 re pclk 2
+.latch    ng25638 ng1559 re pclk 2
+.latch    ng34466 ng4843 re pclk 2
+.latch    pg12300 pg14694 re pclk 2
+.latch    ng30563 ng6657 re pclk 2
+.latch    ng34612 ng2894 re pclk 2
+.latch    ng34449 ng4311 re pclk 2
+.latch    ng30400 ng3223 re pclk 2
+.latch    ng30407 ng3251 re pclk 2
+.latch    ng30500 ng5619 re pclk 2
+.latch    pg9048 ng559 re pclk 2
+.latch    ng34911 ng554 re pclk 2
+.latch    ng32994 ng1798 re pclk 2
+.latch    ng34035 ng4871 re pclk 2
+.latch    pg10527 ng1579 re pclk 2
+.latch    ng34259 ng4643 re pclk 2
+.latch    ng34800 ng2980 re pclk 2
+.latch    ng30504 ng5901 re pclk 2
+.latch    ng24210 ng479 re pclk 2
+.latch    ng34462 ng4653 re pclk 2
+.latch    ng26915 ng1105 re pclk 2
+.latch    ng30436 ng3889 re pclk 2
+.latch    ng31894 ng4098 re pclk 2
+.latch    ng33039 ng4504 re pclk 2
+.latch    ng24261 ng1589 re pclk 2
+.latch    ng33623 ng5990 re pclk 2
+.latch    ng30530 ng6275 re pclk 2
+.latch    ng30524 ng6239 re pclk 2
+.latch    ng4570 ng4571 re pclk 2
+.latch    ng25716 ng5406 re pclk 2
+.latch    ng32976 ng150 re pclk 2
+.latch    ng34719 ng538 re pclk 2
+.latch    ng34262 ng4743 re pclk 2
+.latch    ng30485 ng5571 re pclk 2
+.latch    ng30460 ng5196 re pclk 2
+.latch    ng33009 ng2351 re pclk 2
+.latch    ng26956 ng4434 re pclk 2
+.latch    ng33536 ng301 re pclk 2
+.latch    ng32980 ng854 re pclk 2
+.latch    ng29253 ng2518 re pclk 2
+.latch    pg17607 pg17646 re pclk 2
+.latch    pg14749 pg17764 re pclk 2
+.latch    pg10500 ng1236 re pclk 2
+.latch    ng34456 ng4616 re pclk 2
+.latch    ng30379 ng2523 re pclk 2
+.latch    ng30382 ng2551 re pclk 2
+.latch    pg17871 pg14749 re pclk 2
+.latch    ng34018 ng2579 re pclk 2
+.latch    pg17674 pg17519 re pclk 2
+.latch    ng30443 ng3929 re pclk 2
+.latch    ng33988 ng2012 re pclk 2
+.latch    ng34265 ng4836 re pclk 2
+.latch    ng33572 ng2108 re pclk 2
+.latch    ng34016 ng2571 re pclk 2
+.latch    ng29247 ng2093 re pclk 2
+.latch    ng25637 ng1554 re pclk 2
+.latch    ng30397 ng3207 re pclk 2
+.latch    pg13906 pg16748 re pclk 2
+.latch    ng30351 ng1720 re pclk 2
+.latch    ng26918 ng1193 re pclk 2
+.latch    ng30408 ng3255 re pclk 2
+.latch    ng30503 ng5893 re pclk 2
+.latch    ng24298 ng4456 re pclk 2
+.latch    ng25742 pg9682 re pclk 2
+.latch    ng25635 ng1300 re pclk 2
+.latch    ng33044 ng4552 re pclk 2
+.latch    ng30394 ng3187 re pclk 2
+.latch    ng33568 ng1996 re pclk 2
+.latch    ng24271 pg11388 re pclk 2
+.latch    ng33963 ng496 re pclk 2
+.latch    pg14217 pg14096 re pclk 2
+.latch    ng34636 ng4722 re pclk 2
+.latch    ng29298 ng6154 re pclk 2
+.latch    ng30474 ng5264 re pclk 2
+.latch    ng34625 ng3151 re pclk 2
+.latch    ng34798 ng2886 re pclk 2
+.latch    ng24350 ng6386 re pclk 2
+.latch    ng33613 ng4054 re pclk 2
+.latch    pg17400 ng1087 re pclk 2
+.latch    ng29265 ng3476 re pclk 2
+.latch    ng29276 ng4575 re pclk 2
+.latch    ng33059 ng5873 re pclk 2
+.latch    ng29278 ng4578 re pclk 2
+.latch    ng34253 ng4459 re pclk 2
+.latch    ng30542 ng6311 re pclk 2
+.latch    ng28102 ng4826 re pclk 2
+.latch    pg11349 pg13895 re pclk 2
+.latch    ng24268 ng3338 re pclk 2
+.latch    ng30349 ng1696 re pclk 2
+.latch    ng33219 ng6 re pclk 2
+.latch    ng30422 ng3578 re pclk 2
+.latch    ng33587 ng2380 re pclk 2
+.latch    ng33603 ng2648 re pclk 2
+.latch    ng26888 ng341 re pclk 2
+.latch    ng34453 ng4601 re pclk 2
+.latch    ng34021 ng2567 re pclk 2
+.latch    ng34440 ng890 re pclk 2
+.latch    ng34794 ng2864 re pclk 2
+.latch    ng33164 ng28 re pclk 2
+.latch    ng26968 ng4561 re pclk 2
+.latch    ng29285 ng5156 re pclk 2
+.latch    ng33582 ng2273 re pclk 2
+.latch    ng24231 ng904 re pclk 2
+.latch    ng33065 ng6227 re pclk 2
+.latch    ng30522 ng6203 re pclk 2
+.latch    ng24334 ng66 re pclk 2
+.latch    pg17646 pg13068 re pclk 2
+.latch    ng34000 ng2165 re pclk 2
+.latch    ng28071 ng4112 re pclk 2
+.latch    ng33566 ng1982 re pclk 2
+.latch    ng34635 ng4717 re pclk 2
+.latch    ng4520 ng4483 re pclk 2
+.latch    ng30398 ng3215 re pclk 2
+.latch    ng31871 ng1367 re pclk 2
+.latch    ng33000 ng2051 re pclk 2
+.latch    ng29241 ng1691 re pclk 2
+.latch    ng29234 ng1111 re pclk 2
+.latch    ng25733 ng5821 re pclk 2
+.latch    ng29222 ng411 re pclk 2
+.latch    ng25686 ng4057 re pclk 2
+.latch    pg13865 pg16686 re pclk 2
+.latch    ng30385 ng2661 re pclk 2
+.latch    ng34623 ng2970 re pclk 2
+.latch    ng34457 ng4628 re pclk 2
+.latch    ng34441 ng2771 re pclk 2
+.latch    ng30420 ng3570 re pclk 2
+.latch    ng34790 ng622 re pclk 2
+.latch    ng34627 ng3853 re pclk 2
+.latch    ng34806 ng2941 re pclk 2
+.latch    pg8215 ng3100 re pclk 2
+.latch    ng34637 ng4737 re pclk 2
+.latch    ng34263 ng4754 re pclk 2
+.latch    ng34041 ng4983 re pclk 2
+.latch    ng28090 ng4961 re pclk 2
+.latch    ng25669 ng3494 re pclk 2
+.latch    ng28084 ng4749 re pclk 2
+.latch    ng33593 ng2465 re pclk 2
+.latch    ng34638 ng4917 re pclk 2
+.latch    pg16722 ng3680 re pclk 2
+.latch    ng33975 ng1748 re pclk 2
+.latch    ng25648 pg8215 re pclk 2
+.latch    ng32979 ng758 re pclk 2
+.latch    ng24242 pg12919 re pclk 2
+.latch    ng32990 ng1664 re pclk 2
+.latch    ng26894 ng528 re pclk 2
+.latch    ng34792 ng2848 re pclk 2
+.latch    ng24262 ng1564 re pclk 2
+.latch    ng25627 ng962 re pclk 2
+.latch    ng29272 ng3831 re pclk 2
+.latch    ng34033 ng4793 re pclk 2
+.latch    ng29292 ng5808 re pclk 2
+.latch    pg14779 pg17760 re pclk 2
+.latch    ng33984 ng1890 re pclk 2
+.latch    ng24213 pg12184 re pclk 2
+.latch    ng30518 ng5897 re pclk 2
+.latch    pg17787 pg14597 re pclk 2
+.latch    ng30456 ng4093 re pclk 2
+.latch    ng33017 ng2619 re pclk 2
+.latch    ng28052 ng661 re pclk 2
+.latch    pg9743 ng6494 re pclk 2
+.latch    ng30347 ng1413 re pclk 2
+.latch    ng34004 ng2311 re pclk 2
+.latch    ng34850 ng794 re pclk 2
+.latch    ng33604 ng2667 re pclk 2
+.latch    ng33600 ng2555 re pclk 2
+.latch    ng26969 ng4581 re pclk 2
+.latch    ng33969 ng1616 re pclk 2
+.latch    ng26880 ng305 re pclk 2
+.latch    ng26902 ng255 re pclk 2
+.latch    ng34599 ng613 re pclk 2
+.latch    ng25617 ng817 re pclk 2
+.latch    ng25614 ng686 re pclk 2
+.latch    ng26962 ng4489 re pclk 2
+.latch    ng34269 ng4955 re pclk 2
+.latch    ng33606 ng2675 re pclk 2
+.latch    ng25 ng25 re pclk 2
+.latch    ng319 ng329 re pclk 2
+.latch    pg17688 pg17722 re pclk 2
+.latch    pg14828 pg17778 re pclk 2
+.latch    ng33596 ng2533 re pclk 2
+.latch    ng34620 ng2936 re pclk 2
+.latch    pg16718 pg16603 re pclk 2
+.latch    ng30536 ng6299 re pclk 2
+.latch    ng26882 ng319 re pclk 2
+.latch    ng25632 ng1351 re pclk 2
+.latch    pg16603 pg16624 re pclk 2
+.latch    ng28054 ng728 re pclk 2
+.latch    ng33992 ng2084 re pclk 2
+.latch    ng28048 ng691 re pclk 2
+.latch    ng24343 ng5698 re pclk 2
+.latch    ng26964 ng4515 re pclk 2
+.latch    ng33982 ng1882 re pclk 2
+.latch    pg12368 pg9048 re pclk 2
+.latch    ng33625 ng6336 re pclk 2
+.latch    ng29282 ng5134 re pclk 2
+.latch    ng28070 ng4076 re pclk 2
+.latch    ng24250 ng1495 re pclk 2
+.latch    pg16775 pg16659 re pclk 2
+.latch    ng34643 ng5160 re pclk 2
+.latch    ng24237 ng1189 re pclk 2
+.latch    ng24206 ng437 re pclk 2
+.latch    ng30480 ng5511 re pclk 2
+.latch    ng30455 ng3965 re pclk 2
+.latch    ng25748 ng6187 re pclk 2
+.latch    ng30336 ng914 re pclk 2
+.latch    ng30497 ng5551 re pclk 2
+.latch    ng32986 ng1373 re pclk 2
+.latch    ng34880 ng632 re pclk 2
+.latch    ng24245 ng1246 re pclk 2
+.latch    ng33037 ng4498 re pclk 2
+.latch    ng33999 ng2241 re pclk 2
+.latch    ng29250 ng2370 re pclk 2
+.latch    ng33019 ng2756 re pclk 2
+.latch    ng33595 ng2514 re pclk 2
+.latch    ng34022 ng2763 re pclk 2
+.latch    ng30557 ng6645 re pclk 2
+.latch    ng33032 ng3869 re pclk 2
+.latch    ng33602 ng2629 re pclk 2
+.latch    ng33612 ng3639 re pclk 2
+.latch    ng26906 ng269 re pclk 2
+.latch    ng30450 ng3957 re pclk 2
+.latch    ng30339 ng1183 re pclk 2
+.latch    ng34464 ng4669 re pclk 2
+.latch    pg7257 ng4411 re pclk 2
+.latch    ng30428 ng3602 re pclk 2
+.latch    ng34028 ng4688 re pclk 2
+.latch    ng30401 ng3227 re pclk 2
+.latch    pg16955 pg13906 re pclk 2
+.latch    ng33569 ng2040 re pclk 2
+.latch    ng30501 ng5857 re pclk 2
+.latch    ng33204 ng8 re pclk 2
+.latch    ng34720 ng550 re pclk 2
+.latch    ng28043 ng283 re pclk 2
+.latch    ng26930 ng2795 re pclk 2
+.latch    ng25592 pg8358 re pclk 2
+.latch    ng33622 ng6049 re pclk 2
+.latch    ng26938 ng4082 re pclk 2
+.latch    ng28058 ng1252 re pclk 2
+.latch    ng33054 ng5527 re pclk 2
+.latch    ng30464 ng5224 re pclk 2
+.latch    ng34731 ng1287 re pclk 2
+.latch    ng33551 ng1644 re pclk 2
+.latch    ng33048 ng5176 re pclk 2
+.latch    ng26925 ng1536 re pclk 2
+.latch    ng30465 ng5228 re pclk 2
+.latch    ng29274 ng3849 re pclk 2
+.latch    ng34002 ng2303 re pclk 2
+.latch    ng25649 pg8277 re pclk 2
+.latch    ng26887 ng324 re pclk 2
+.latch    ng29308 ng6527 re pclk 2
+.latch    ng33621 ng5644 re pclk 2
+.latch    pg7916 pg8416 re pclk 2
+.latch    ng30449 ng3953 re pclk 2
+.latch    ng31864 ng164 re pclk 2
+.latch    ng32988 ng1648 re pclk 2
+.latch    ng30535 ng6295 re pclk 2
+.latch    ng32993 ng1792 re pclk 2
+.latch    ng34019 ng2583 re pclk 2
+.latch    ng25663 pg8342 re pclk 2
+.latch    ng25594 ng278 re pclk 2
+.latch    ng33624 ng6395 re pclk 2
+.latch    pg17320 pg17404 re pclk 2
+.latch    ng33539 ng763 re pclk 2
+.latch    ng30348 ng1632 re pclk 2
+.latch    ng30335 ng744 re pclk 2
+.latch    ng24251 ng1442 re pclk 2
+.latch    ng29239 ng1454 re pclk 2
+.latch    ng33584 ng2287 re pclk 2
+.latch    ng30419 ng3566 re pclk 2
+.latch    ng28047 ng681 re pclk 2
+.latch    ng33027 ng3518 re pclk 2
+.latch    pg11678 ng736 re pclk 2
+.latch    pg17711 pg17580 re pclk 2
+.latch    ng29273 ng3835 re pclk 2
+.latch    pg17639 ng5339 re pclk 2
+.latch    ng25601 ng174 re pclk 2
+.latch    ng34442 ng2783 re pclk 2
+.latch    pg12350 pg14738 re pclk 2
+.latch    ng30539 ng6243 re pclk 2
+.latch    ng33187 ng16 re pclk 2
+.latch    ng26905 ng239 re pclk 2
+.latch    pg7245 ng4452 re pclk 2
+.latch    pg14125 pg14147 re pclk 2
+.latch    ng30459 ng5164 re pclk 2
+.latch    pg8870 pg8918 re pclk 2
+.latch    ng30378 ng2461 re pclk 2
+.latch    ng26970 ng4369 re pclk 2
+.latch    ng33610 ng3288 re pclk 2
+.latch    ng31870 ng1263 re pclk 2
+.latch    ng34463 ng4664 re pclk 2
+.latch    ng33575 ng2047 re pclk 2
+.latch    ng26957 ng4430 re pclk 2
+.latch    ng28045 ng572 re pclk 2
+.latch    ng33614 ng3990 re pclk 2
+.latch    ng26898 ng812 re pclk 2
+.latch    ng28066 ng3684 re pclk 2
+.latch    ng24203 ng401 re pclk 2
+.latch    ng29224 ng586 re pclk 2
+.latch    ng30375 ng2393 re pclk 2
+.latch    pg17577 pg13039 re pclk 2
+.latch    ng33015 ng2587 re pclk 2
+.latch    ng30529 ng6271 re pclk 2
+.latch    ng33990 ng2020 re pclk 2
+.latch    ng25605 ng460 re pclk 2
+.latch    ng30406 ng3247 re pclk 2
+.latch    pg8788 pg8789 re pclk 2
+.latch    ng34721 ng199 re pclk 2
+.latch    ng25695 ng5080 re pclk 2
+.latch    ng34808 ng2965 re pclk 2
+.latch    ng26921 ng1404 re pclk 2
+.latch    ng34724 ng617 re pclk 2
+.latch    ng33021 ng3161 re pclk 2
+.latch    ng33557 ng1844 re pclk 2
+.latch    ng33563 ng1955 re pclk 2
+.latch    ng29225 ng671 re pclk 2
+.latch    ng32984 ng1270 re pclk 2
+.latch    ng30508 ng5925 re pclk 2
+.latch    ng34444 ng2787 re pclk 2
+.latch    ng30547 ng6601 re pclk 2
+.latch    ng28073 ng4119 re pclk 2
+.latch    ng25735 ng5845 re pclk 2
+.latch    pg17778 pg17688 re pclk 2
+.latch    ng30417 ng3550 re pclk 2
+.latch    ng33547 ng1687 re pclk 2
+.latch    ng33549 ng1710 re pclk 2
+.latch    ng25707 ng5152 re pclk 2
+.latch    ng33001 ng2060 re pclk 2
+.latch    ng31901 ng5046 re pclk 2
+.latch    pg8919 pg8920 re pclk 2
+.latch    ng33616 ng4519 re pclk 2
+.latch    ng30434 ng3614 re pclk 2
+.latch    ng30479 ng5272 re pclk 2
+.latch    ng34258 ng4358 re pclk 2
+.latch    ng18597 ng3003 re pclk 2
+.latch    ng30473 ng5260 re pclk 2
+.latch    ng34735 ng4300 re pclk 2
+.latch    ng16696 ng71 re pclk 2
+.latch    ng34007 ng2299 re pclk 2
+.latch    ng26963 ng4492 re pclk 2
+.latch    ng25676 pg8344 re pclk 2
+.latch    ng30453 ng3905 re pclk 2
+.latch    ng24336 pg12238 re pclk 2
+.latch    ng32996 ng1917 re pclk 2
+.latch    ng30521 ng5965 re pclk 2
+.latch    ng30510 ng5933 re pclk 2
+.latch    ng30495 ng5611 re pclk 2
+.latch    ng34023 ng4534 re pclk 2
+.latch    ng24209 ng417 re pclk 2
+.latch    ng33972 ng1604 re pclk 2
+.latch    ng33993 ng2008 re pclk 2
+.latch    ng30366 ng2122 re pclk 2
+.latch    ng34014 ng2433 re pclk 2
+.latch    ng26940 ng4164 re pclk 2
+.latch    ng30555 ng6637 re pclk 2
+.latch    ng30418 ng3558 re pclk 2
+.latch    ng33960 ng157 re pclk 2
+.latch    pg19357 pg13272 re pclk 2
+.latch    ng30517 ng5961 re pclk 2
+.latch    ng30553 ng6629 re pclk 2
+.latch    ng25629 ng1216 re pclk 2
+.latch    pg17423 ng1430 re pclk 2
+.latch    ng30462 ng5208 re pclk 2
+.latch    pg8475 ng1333 re pclk 2
+.latch    ng16663 ng101 re pclk 2
+.latch    ng33978 ng1816 re pclk 2
+.latch    ng33589 ng2403 re pclk 2
+.latch    ng34726 ng952 re pclk 2
+.latch    ng33006 ng2223 re pclk 2
+.latch    ng30516 ng5957 re pclk 2
+.latch    pg11447 pg8783 re pclk 2
+.latch    ng34603 ng2130 re pclk 2
+.latch    ng25618 ng832 re pclk 2
+.latch    ng26933 ng2823 re pclk 2
+.latch    ng24346 ng6040 re pclk 2
+.latch    ng32991 ng1760 re pclk 2
+.latch    pg14189 pg14201 re pclk 2
+.latch    ng30368 ng2193 re pclk 2
+.latch    ng24243 ng996 re pclk 2
+.latch    ng4467 ng4474 re pclk 2
+.latch    ng31896 ng4480 re pclk 2
+.latch    ng30423 ng3582 re pclk 2
+.latch    pg16693 pg14518 re pclk 2
+.latch    ng25722 ng5467 re pclk 2
+.latch    ng34454 ng4608 re pclk 2
+.latch    ng32995 ng1894 re pclk 2
+.latch    ng28105 ng5011 re pclk 2
+.latch    ng33057 ng5863 re pclk 2
+.latch    ng25758 ng6444 re pclk 2
+.latch    ng30478 ng5220 re pclk 2
+.latch    ng29251 ng2384 re pclk 2
+.latch    ng28082 ng4527 re pclk 2
+.latch    ng24249 ng1489 re pclk 2
+.latch    ng21896 pg8839 re pclk 2
+.latch    ng24270 ng3347 re pclk 2
+.latch    ng33580 ng2265 re pclk 2
+.latch    ng33564 ng1974 re pclk 2
+.latch    ng29232 ng1124 re pclk 2
+.latch    ng34008 ng2429 re pclk 2
+.latch    ng33565 ng1978 re pclk 2
+.latch    ng24351 ng6390 re pclk 2
+.latch    ng30396 ng3199 re pclk 2
+.latch    ng33979 ng1740 re pclk 2
+.latch    ng30386 ng2681 re pclk 2
+.latch    ng30376 ng2413 re pclk 2
+.latch    ng24339 ng5352 re pclk 2
+.latch    ng30550 ng6617 re pclk 2
+.latch    ng34608 ng2704 re pclk 2
+.latch    ng29249 ng2250 re pclk 2
+.latch    ng33010 ng2357 re pclk 2
+.latch    ng29280 ng5115 re pclk 2
+.latch    ng30491 ng5595 re pclk 2
+.latch    ng29256 ng2735 re pclk 2
+.latch    ng34461 ng4659 re pclk 2
+.latch    ng29231 ng1094 re pclk 2
+.latch    ng34723 ng534 re pclk 2
+.latch    ng24252 ng1521 re pclk 2
+.latch    pg8786 pg8787 re pclk 2
+.latch    ng28440 ng59 re pclk 2
+.latch    ng34252 ng772 re pclk 2
+.latch    ng34015 ng2563 re pclk 2
+.latch    ng30427 ng3598 re pclk 2
+.latch    ng33535 ng294 re pclk 2
+.latch    ng25621 ng921 re pclk 2
+.latch    ng33028 ng3522 re pclk 2
+.latch    ng33543 ng1379 re pclk 2
+.latch    ng30489 ng5587 re pclk 2
+.latch    ng24256 pg7946 re pclk 2
+.latch    ng21894 ng4264 re pclk 2
+.latch    ng30534 ng6291 re pclk 2
+.latch    ng34807 ng2955 re pclk 2
+.latch    ng29258 ng3115 re pclk 2
+.latch    ng30352 ng1724 re pclk 2
+.latch    ng29301 ng6177 re pclk 2
+.latch    ng34452 ng4593 re pclk 2
+.latch    ng31869 ng1024 re pclk 2
+.latch    pg16627 pg16656 re pclk 2
+.latch    ng25599 ng203 re pclk 2
+.latch    ng33046 ng5057 re pclk 2
+.latch    pg17743 ng6377 re pclk 2
+.latch    ng34031 ng4776 re pclk 2
+.latch    ng30490 ng5591 re pclk 2
+.latch    ng34644 ng5507 re pclk 2
+.latch    ng25604 ng452 re pclk 2
+.latch    ng34881 ng807 re pclk 2
+.latch    ng33966 ng1600 re pclk 2
+.latch    ng34460 ng4621 re pclk 2
+.latch    ng24235 ng1099 re pclk 2
+.latch    ng33991 ng2024 re pclk 2
+.latch    ng24279 ng4242 re pclk 2
+.latch    ng30388 ng2741 re pclk 2
+.latch    ng33005 ng2217 re pclk 2
+.latch    ng33064 ng6219 re pclk 2
+.latch    ng33550 ng1714 re pclk 2
+.latch    ng30360 ng1968 re pclk 2
+.latch    ng34036 ng4878 re pclk 2
+.latch    ng24267 pg11349 re pclk 2
+.latch    pg8783 pg8784 re pclk 2
+.latch    ng29291 ng5503 re pclk 2
+.latch    pg12184 pg11678 re pclk 2
+.latch    ng33538 ng595 re pclk 2
+.latch    ng30416 ng3542 re pclk 2
+.latch    ng24216 ng847 re pclk 2
+.latch    ng24344 pg12350 re pclk 2
+.latch    ng33973 ng1736 re pclk 2
+.latch    ng30374 ng2389 re pclk 2
+.latch    ng29254 ng2638 re pclk 2
+.latch    ng33002 ng2066 re pclk 2
+.latch    ng21893 ng4258 re pclk 2
+.latch    ng30466 ng5232 re pclk 2
+.latch    pg17715 ng6031 re pclk 2
+.latch    pg8920 ng4235 re pclk 2
+.latch    ng29262 ng3147 re pclk 2
+.latch    ng26390 ng4438 re pclk 2
+.latch    ng30482 ng5547 re pclk 2
+.latch    ng28074 ng4122 re pclk 2
+.latch    ng24248 ng1319 re pclk 2
+.latch    ng33968 ng1612 re pclk 2
+.latch    ng25736 ng5813 re pclk 2
+.latch    ng34733 ng4172 re pclk 2
+.latch    ng29223 ng490 re pclk 2
+.latch    ng29263 ng3457 re pclk 2
+.latch    ng34609 ng2844 re pclk 2
+.latch    ng34032 ng4709 re pclk 2
+.latch    ng34602 ng1291 re pclk 2
+.latch    ng34012 ng2449 re pclk 2
+.latch    ng30477 ng5212 re pclk 2
+.latch    ng30354 ng1830 re pclk 2
+.latch    ng26945 pg7243 re pclk 2
+.latch    ng34617 ng2907 re pclk 2
+.latch    ng24232 ng976 re pclk 2
+.latch    ng29248 ng2236 re pclk 2
+.latch    ng24340 pg12300 re pclk 2
+.latch    ng30533 ng6287 re pclk 2
+.latch    ng33049 ng5180 re pclk 2
+.latch    ng31868 ng918 re pclk 2
+.latch    ng30513 ng5945 re pclk 2
+.latch    ng33052 ng5517 re pclk 2
+.latch    ng34632 ng4245 re pclk 2
+.latch    ng33579 ng2246 re pclk 2
+.latch    ng32998 ng1932 re pclk 2
+.latch    ng24255 pg10527 re pclk 2
+.latch    ng30446 ng3941 re pclk 2
+.latch    ng33974 ng1744 re pclk 2
+.latch    ng33026 ng3512 re pclk 2
+.latch    pg16656 pg14451 re pclk 2
+.latch    ng30384 ng2657 re pclk 2
+.latch    ng34267 ng4933 re pclk 2
+.latch    ng34438 ng608 re pclk 2
+.latch    ng33983 ng1886 re pclk 2
+.latch    ng25623 ng1008 re pclk 2
+.latch    ng28046 ng645 re pclk 2
+.latch    ng24200 ng392 re pclk 2
+.latch    ng30333 ng146 re pclk 2
+.latch    ng33605 ng2671 re pclk 2
+.latch    ng33069 ng6565 re pclk 2
+.latch    ng30505 ng5909 re pclk 2
+.latch    ng34882 ng4372 re pclk 2
+.latch    ng30393 ng3155 re pclk 2
+.latch    ng30494 ng5607 re pclk 2
+.latch    ng26971 ng4521 re pclk 2
+.latch    ng25613 ng562 re pclk 2
+.latch    pg9019 ng4291 re pclk 2
+.latch    ng30425 ng3590 re pclk 2
+.latch    pg8291 ng218 re pclk 2
+.latch    ng32999 ng2028 re pclk 2
+.latch    ng30387 ng2685 re pclk 2
+.latch    ng33554 ng1802 re pclk 2
+.latch    ng25668 ng3490 re pclk 2
+.latch    ng33022 ng3167 re pclk 2
+.latch    ng34001 ng2295 re pclk 2
+.latch    pg16874 pg13865 re pclk 2
+.latch    ng25684 ng3813 re pclk 2
+.latch    ng24244 ng1205 re pclk 2
+.latch    ng33004 ng2208 re pclk 2
+.latch    ng25616 ng732 re pclk 2
+.latch    ng34734 ng4176 re pclk 2
+.latch    ng30527 ng6263 re pclk 2
+.latch    ng31897 ng4540 re pclk 2
+.latch    ng30389 ng121 re pclk 2
+.latch    ng24354 ng6732 re pclk 2
+.latch    ng30432 ng3554 re pclk 2
+.latch    ng31867 ng749 re pclk 2
+.latch    ng30496 ng5615 re pclk 2
+.latch    ng34646 ng6199 re pclk 2
+.latch    ng33571 ng2089 re pclk 2
+.latch    ng25743 pg9741 re pclk 2
+.latch    ng30439 ng3909 re pclk 2
+.latch    ng34802 ng2917 re pclk 2
+.latch    ng29252 ng2504 re pclk 2
+.latch    ng24275 pg11418 re pclk 2
+.latch    ng33585 ng2331 re pclk 2
+.latch    pg17764 ng6723 re pclk 2
+.latch    ng30545 ng6585 re pclk 2
+.latch    ng30554 ng6633 re pclk 2
+.latch    ng4571 ng4555 re pclk 2
+.latch    ng33043 ng4567 re pclk 2
+.latch    ng24259 ng1339 re pclk 2
+.latch    ng33965 ng767 re pclk 2
+.latch    ng25728 pg9617 re pclk 2
+.latch    ng30541 ng6259 re pclk 2
+.latch    pg7243 ng4405 re pclk 2
+.latch    ng30447 ng3945 re pclk 2
+.latch    ng31872 ng2748 re pclk 2
+.latch    ng30372 ng2283 re pclk 2
+.latch    pg17404 pg17423 re pclk 2
+.latch    ng24274 ng3698 re pclk 2
+.latch    ng26881 ng311 re pclk 2
+.latch    ng25633 ng1384 re pclk 2
+.latch    ng34645 ng5853 re pclk 2
+.latch    ng30498 ng5559 re pclk 2
+.latch    ng30519 ng5905 re pclk 2
+.latch    pg14167 ng872 re pclk 2
+.latch    ng29287 ng5471 re pclk 2
+.latch    ng33995 ng2169 re pclk 2
+.names [34052] [34053] [34057] pg28030
+1-- 1
+-1- 1
+--1 1
+.names ng19422 ng19402 pg28041
+0- 1
+-0 1
+.names ng2729 ng23554 [29308] [29309] pg33435
+00-- 1
+-01- 1
+-0-1 1
+.names [3190] [3191] [29245] [29246] pg34425
+--1- 1
+---1 1
+00-- 1
+.names ng37 pg30327
+0 1
+.names [3189] [34096] [34099] [34101] pg31793
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng3003 pg21727
+01 1
+.names ng17657 ng17700 pg26876
+0- 1
+-0 1
+.names ng136 pg30329
+0 1
+.names [3176] [3177] [34166] [34167] pg34239
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng17694 ng17727 pg26877
+0- 1
+-0 1
+.names pg32454
+ 1
+.names pg34597
+.names ng22 ng25 pg23190
+00 1
+.names pg24151
+ 1
+.names ng66 ng29186 pg33874
+1- 1
+-1 1
+.names pg35 ng1306 ng962 pg28042
+0-- 1
+-1- 1
+--1 1
+.names pg5 pg12833
+0 1
+.names ng2834 pg23652
+0 1
+.names ng25357 [28637] [28638] [34256] pg34201
+0--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ni31843 [3140] [3141] [34275] pg34236
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng22 ng34650 pg34972
+0- 1
+-1 1
+.names pg72 ng4322 ng4369 [34278] pg34956
+--10 1
+011- 1
+101- 1
+.names ng136 pg23612
+0 1
+.names pg34232
+ 1
+.names ng2834 pg30330
+0 1
+.names ng2831 pg30331
+0 1
+.names ng29730 [3190] [3191] pg34221
+1-- 1
+-00 1
+.names pg33948
+ 1
+.names ng22 ng33164 pg34927
+0- 1
+-1 1
+.names pg33949
+ 1
+.names ng22 ng33212 pg34917
+0- 1
+-1 1
+.names [3134] [34279] [34280] [34281] pg32185
+0000 1
+.names pg33946
+ 1
+.names pg72 ng4322 ng4369 [34278] pg34839
+--10 1
+011- 1
+101- 1
+.names pg33947
+ 1
+.names ng22 ni30751 [30180] [30181] pg34919
+0--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng26314 [31726] [31727] [34290] pg34383
+0--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng22 ng33187 pg34923
+0- 1
+-1 1
+.names [7186] [7187] [28915] [28916] pg33079
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg33945
+ 1
+.names ng22 ng33219 pg34913
+0- 1
+-1 1
+.names ng24374 [30515] [30516] [34292] pg33935
+0--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng22 ng33176 pg34925
+0- 1
+-1 1
+.names ng33149 ng22 pg34915
+1- 1
+-0 1
+.names ng24688 [29507] [29508] [34294] pg33659
+0--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg33950
+ 1
+.names ng22 [30135] [30136] [30150] pg34921
+0--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [32542] [32543] [32544] [32545] pg26875
+00-- 1
+--00 1
+.names pg32429
+ 1
+.names ng37 pg23002
+0 1
+.names ng24374 [32269] [32270] [34296] pg33636
+0--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng2831 pg23759
+0 1
+.names pg35 ng6209 ng26977 [28473] ng33063
+01-- 1
+--01 1
+.names pg35 ng4322 [7734] [7735] ng34455
+--1- 1
+---1 1
+01-- 1
+.names pg125 pg35 ng24264
+11 1
+.names ng10929 ng13846 [28483] [28485] ng26917
+---1 1
+1-1- 1
+-11- 1
+.names pg35 ng2491 [7720] [28507] ng33013
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng4427 ng4423 ng26951
+01- 1
+1-1 1
+.names pg35 pg9251 ng4308 ng24281
+110 1
+100 1
+.names pg35 pg7916 ng1171 ng24591 ng30338
+1--1 1
+101- 1
+110- 1
+.names ng13977 [7703] [28521] [28522] ng30403
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng2852 ng2844 ng34610
+11- 1
+0-1 1
+.names pg35 ng301 [7686] ng33537
+--1 1
+01- 1
+.names pg35 pg8719 ng358 ng25595
+100 1
+.names pg35 ng29503 [28571] [28574] ng34446
+---1 1
+111- 1
+.names ng29676 [7681] [28577] [28581] ng34266
+-1-- 1
+---1 1
+1-1- 1
+.names ng8806 [7677] [28583] [28584] ng24205
+-1-- 1
+0-1- 1
+1--1 1
+.names ng10632 [7671] [28587] [28588] ng26907
+-1-- 1
+0-1- 1
+1--1 1
+.names [7662] [7667] [7668] [28606] ng33962
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [7647] [28612] ng32983
+1- 1
+-1 1
+.names ng28336 ng13464 [28645] [28646] ng34030
+---1 1
+111- 1
+.names pg35 ng4049 ng4040 ng8751 ng24277
+0-1- 1
+100- 1
+10-1 1
+.names pg35 ng2145 ng2138 ng34605
+11- 1
+0-1 1
+.names ng23590 [7623] [28655] [28659] ng29283
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 ng3873 ng3869 ng27635 ng33033
+0-1- 1
+-010 1
+1100 1
+.names pg35 pg8398 ng3752 [28670] ng25678
+---1 1
+101- 1
+.names pg35 ng136 ng550 ng34598
+11- 1
+0-1 1
+.names pg35 ng1779 [7595] [7596] ng33553
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng3171 ng3167 ng27602 ng33023
+0-1- 1
+-010 1
+1100 1
+.names pg35 ng168 ng174 ng11676 ng25600
+0-1- 1
+--10 1
+11-1 1
+.names pg35 ng441 ng475 ng8806 ng24207
+0-1- 1
+--10 1
+11-1 1
+.names pg35 ng160 ng31134 [28715] ng34249
+---1 1
+101- 1
+.names ng25917 [7567] [7568] [28719] ng30343
+-1-- 1
+--1- 1
+1--1 1
+.names ng14868 [7565] [28722] [28723] ng30551
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng5689 ng5685 ng10160 ng24341
+0-1- 1
+11-1 1
+10-0 1
+.names ng12632 ng12716 [28732] [28733] ng30546
+---1 1
+0-1- 1
+-01- 1
+.names pg35 ng5827 ng5821 ng23666 ng29294
+0-1- 1
+--10 1
+11-1 1
+.names [7346] [28741] ng26893
+1- 1
+-1 1
+.names [7331] [7332] [28757] [28758] ng29238
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng6035 ng6040 ng10185 ng24347
+0-1- 1
+-01- 1
+--11 1
+.names [7321] [7322] [7323] [7324] ng29270
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng305 ng324 ng311 ng26883
+0-1- 1
+111- 1
+1-01 1
+.names ng11607 [7310] [28775] [28779] ng25609
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 ng3530 ng25662
+11 1
+.names [7298] [7299] [7300] [7301] ng33581
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng2932 ng2917 [28792] ng34803
+---1 1
+11-- 1
+0-1- 1
+.names ng23978 [28796] [28799] [28800] ng30334
+---1 1
+011- 1
+.names pg35 ng595 [7286] [7287] ng33964
+--1- 1
+---1 1
+01-- 1
+.names ng32212 [28816] [28819] [28820] ng34600
+---1 1
+101- 1
+.names ng2756 ng25317 [28822] [28824] ng33608
+---1 1
+0-1- 1
+-01- 1
+.names pg35 ng2715 ng2712 ng2841 ng24263
+10-- 1
+0-1- 1
+1--0 1
+.names ng30304 [7259] [7260] [28830] ng33980
+-1-- 1
+--1- 1
+1--1 1
+.names ng25385 [7255] [28837] [28841] ng30353
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 ng6181 ng6177 ng23699 ng29302
+0-1- 1
+11-1 1
+10-0 1
+.names ng30300 [7236] [7237] [28849] ng33996
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng1760 [7232] [28856] ng32992
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng74 ng13385 [28858] ng26889
+01-- 1
+--01 1
+.names pg35 ng29503 [28860] [28865] ng34445
+---1 1
+111- 1
+.names ng15036 [7221] [28866] [28867] ng30537
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng3462 ng3498 ng12692 ng25670
+0-1- 1
+--11 1
+11-0 1
+.names pg35 ng482 ng20000 [28874] ng28044
+---1 1
+101- 1
+110- 1
+.names [7202] [7204] [28891] [28892] ng29242
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 pg44 ng2890 ng2873 ng34799
+10-- 1
+1-1- 1
+0--1 1
+.names ng24609 [7190] [28905] [28907] ng30346
+-1-- 1
+0-1- 1
+0--1 1
+.names ng30300 [7180] [7181] [28920] ng33994
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng947 ng34601
+11 1
+.names pg35 ng546 ng538 ng691 ng34722
+11-- 1
+0-1- 1
+1--0 1
+.names ng14058 [7175] [28924] [28925] ng30454
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng1554 ng496 ng24258
+01- 1
+1-1 1
+.names ng14885 [7170] [28927] [28928] ng30492
+-1-- 1
+0-1- 1
+1--1 1
+.names ng11626 ng11763 [28932] [28933] ng30437
+---1 1
+0-1- 1
+-01- 1
+.names pg35 ng2841 [28937] [28938] ng25687
+---1 1
+111- 1
+.names [7131] [7132] [7133] [7134] ng29257
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng3841 ng3835 ng12735 ng25682
+0-1- 1
+--11 1
+11-0 1
+.names ng30311 [7116] [7117] [29012] ng33987
+-1-- 1
+--1- 1
+1--1 1
+.names ng14015 [7114] [29015] [29016] ng30424
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng939 ng933 ng952 ng34727
+11-- 1
+1-1- 1
+0--1 1
+.names pg35 ng4284 ng4180 ng14271 ng29303
+11-0 1
+1-00 1
+1011 1
+.names [7102] [29023] ng32981
+1- 1
+-1 1
+.names ng12622 ng12667 [29026] [29027] ng30526
+---1 1
+0-1- 1
+-01- 1
+.names ng30300 [7096] [7097] [29029] ng33997
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng5835 ng5831 ng23666 ng29296
+0-1- 1
+11-1 1
+10-0 1
+.names [29039] [29040] ng33042
+1- 1
+-1 1
+.names pg35 ng5092 ng5084 ng25697
+0-1 1
+-01 1
+110 1
+.names ng14021 [7083] [29043] [29044] ng30444
+-1-- 1
+0-1- 1
+1--1 1
+.names [7078] [29048] ng29230
+1- 1
+-1 1
+.names ng11626 ng11537 [29050] [29051] ng30438
+---1 1
+0-1- 1
+-01- 1
+.names pg35 ng4045 ng4040 ng8751 ng24278
+01-- 1
+-10- 1
+-1-1 1
+.names pg35 ng3139 ng3133 ng12641 ng25654
+0-1- 1
+--11 1
+11-0 1
+.names ng12915 [7069] [29054] [29055] ng30558
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng2606 [7058] [7059] ng33601
+--1- 1
+---1 1
+01-- 1
+.names ng4076 ng13217 [29070] [29071] ng29275
+---1 1
+101- 1
+.names [7049] [7050] [29087] [29088] ng29237
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng6519 ng6513 ng23733 ng29306
+0-1- 1
+--10 1
+11-1 1
+.names pg35 ng1700 ng1696 ng25275 ng30350
+0-1- 1
+11-1 1
+10-0 1
+.names ng29488 [29104] [29106] [29108] ng33985
+---1 1
+11-- 1
+0-1- 1
+.names ng25349 [7028] [29115] [29119] ng30377
+-1-- 1
+---1 1
+0-1- 1
+.names ng8806 [7024] [29120] [29121] ng24208
+-1-- 1
+0-1- 1
+1--1 1
+.names ng13385 [29129] [29130] [29131] ng26884
+--1- 1
+---1 1
+11-- 1
+.names pg35 ng5062 ng5343 ng25701
+01- 1
+1-1 1
+.names [7008] [7009] [7010] [7011] ng24348
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [7004] [7005] [7006] [7007] ng33559
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [6992] [29184] [29185] [29186] ng30392
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng3470 ng3466 ng12692 ng25667
+0-1- 1
+10-1 1
+11-0 1
+.names ng27999 [6988] [29195] [29196] ng33050
+-1-- 1
+0-1- 1
+0--1 1
+.names ng11607 [6985] [29198] [29202] ng25610
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 ng4284 ng4180 ng14306 ng29309
+11-0 1
+1-00 1
+1011 1
+.names pg35 ng6209 ng6203 ng26977 ng33062
+0-1- 1
+-010 1
+1100 1
+.names pg35 ng996 ng8417 ng16246 ng24240
+01-- 1
+1-11 1
+1-00 1
+.names ng23112 [6965] [29220] [29223] ng29264
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 ng3263 [6959] [6960] ng28063
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng4922 ng4917 ng34639
+11- 1
+0-1 1
+.names ng14782 [6956] [29227] [29228] ng30549
+-1-- 1
+0-1- 1
+1--1 1
+.names ng10961 ng13861 [29248] [29251] ng26924
+---1 1
+001- 1
+.names ng29501 [29256] [29258] [29260] ng34020
+---1 1
+01-- 1
+1-1- 1
+.names ng30293 [6915] [6916] [29265] ng33970
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng2465 [6905] [6906] ng33594
+--1- 1
+---1 1
+01-- 1
+.names ng14727 [6904] [29277] [29278] ng30488
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng2138 ng2130 ng34604
+11- 1
+0-1 1
+.names ng14755 [6899] [29280] [29281] ng30469
+-1-- 1
+0-1- 1
+1--1 1
+.names ng19063 [29283] [29285] ng26912
+--1 1
+01- 1
+.names pg35 ng433 ng429 ng8806 ng24204
+01-- 1
+-1-0 1
+1-11 1
+.names ng31009 ng10862 [29292] [29293] ng34467
+---1 1
+101- 1
+.names pg35 ng37 ng2894 ng34613
+11- 1
+0-1 1
+.names pg35 ng6381 ng6377 ng10207 ng24349
+0-1- 1
+11-1 1
+10-0 1
+.names pg35 pg9019 ng4284 ng4291 ng21898
+0-1- 1
+11-0 1
+10-0 1
+.names ng17625 ng12377 [29300] [29303] ng26927
+---1 1
+101- 1
+.names ng14697 [6872] [29304] [29305] ng30507
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng5057 ng25290 [29317] ng28092
+01-- 1
+--01 1
+.names ng1052 ng13121 [29322] [29323] ng26914
+---1 1
+101- 1
+.names ng4405 [29324] [29325] [29328] ng26948
+1--- 1
+0111 1
+.names ng13923 [6852] [29329] [29330] ng30430
+-1-- 1
+0-1- 1
+1--1 1
+.names [6847] [29336] ng34037
+1- 1
+-1 1
+.names [6842] [6843] [6844] [29340] ng26952
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng4104 [6838] ng26939
+--1 1
+01- 1
+.names pg35 ng1834 ng1830 ng25300 ng30355
+0-1- 1
+11-1 1
+10-0 1
+.names pg35 ng5698 [6828] [6829] ng33620
+--1- 1
+---1 1
+01-- 1
+.names [6826] [6827] [29355] [29361] ng34024
+---1 1
+001- 1
+.names [6816] [6817] [29377] [29378] ng29233
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [6808] [6809] [29383] ng33040
+1-- 1
+-1- 1
+--1 1
+.names pg35 ng4253 ng4300 ng34630
+11- 1
+0-1 1
+.names pg35 ng4552 ng4581 [6804] ng33617
+01-- 1
+11-0 1
+1-10 1
+.names pg35 ng1548 ng1430 ng24260
+0-1 1
+-01 1
+110 1
+.names pg35 pg8839 ng4281 ng21897
+0-1 1
+101 1
+110 1
+.names pg35 ng385 ng358 ng376 ng25598
+0--1 1
+110- 1
+11-0 1
+1011 1
+.names pg35 ng287 [6789] [6790] ng32977
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng3111 ng3147 ng12641 ng25656
+0-1- 1
+--11 1
+11-0 1
+.names pg35 ng718 ng655 ng20248 ng28051
+0-1- 1
+--10 1
+11-1 1
+.names ng14741 [6777] [29402] [29403] ng30528
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng2393 [6763] [6764] ng33588
+--1- 1
+---1 1
+01-- 1
+.names pg35 ni24685 [29414] [29415] ng34795
+---1 1
+10-- 1
+1-1- 1
+.names [29325] [29326] [29417] [29418] ng26946
+---1 1
+0-1- 1
+-01- 1
+.names pg35 ng5965 [6715] [6716] ng28099
+--1- 1
+---1 1
+01-- 1
+.names ng10312 ng12609 [29481] [29482] ng30502
+---1 1
+0-1- 1
+-01- 1
+.names ng17264 [6709] [29484] [29486] ng26899
+-1-- 1
+0-1- 1
+1--1 1
+.names [6695] [6696] [6697] [6698] ng33573
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng10281 ng12558 [29517] [29518] ng30481
+---1 1
+0-1- 1
+-01- 1
+.names [29520] [29521] [29523] [29524] ng26955
+---1 1
+111- 1
+.names pg35 ng298 [6686] [6687] ng34250
+--1- 1
+---1 1
+01-- 1
+.names pg35 pg9497 ng5022 [29532] ng25703
+---1 1
+101- 1
+.names ng13273 ng10961 [29535] [29537] ng26922
+---1 1
+1-1- 1
+-11- 1
+.names ng13963 [6678] [29538] [29539] ng30451
+-1-- 1
+0-1- 1
+1--1 1
+.names ng25911 [6674] [6675] [29541] ng30337
+-1-- 1
+--1- 1
+1--1 1
+.names [29550] [29551] [29553] [29555] ng31902
+---1 1
+001- 1
+.names ng11607 [6669] [29556] [29557] ng25611
+-1-- 1
+0-1- 1
+1--1 1
+.names ng30311 [6665] [6666] [29560] ng33989
+-1-- 1
+--1- 1
+1--1 1
+.names ng14665 [6663] [29563] [29564] ng30486
+-1-- 1
+0-1- 1
+1--1 1
+.names ng26625 [6660] [29567] [29568] ng31903
+-1-- 1
+1-1- 1
+0--1 1
+.names ng25341 [6653] [29575] [29579] ng30362
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 ng301 ng2970 [29581] ng34801
+---1 1
+11-- 1
+0-1- 1
+.names [6619] [6620] [29644] ng29269
+1-- 1
+-1- 1
+--1 1
+.names ng30293 [6614] [6615] [29647] ng33967
+-1-- 1
+--1- 1
+1--1 1
+.names ng28010 [6612] [29652] [29653] ng33055
+-1-- 1
+0-1- 1
+0--1 1
+.names pg35 ng405 ng392 ng8806 ng24201
+0-1- 1
+--10 1
+11-1 1
+.names pg35 ng209 ng218 ng25591
+01- 1
+1-0 1
+.names pg35 ng5535 ng25714
+11 1
+.names ng13951 [6604] [29657] [29658] ng30411
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng655 ng650 ng20248 ng28050
+0-1- 1
+--10 1
+11-1 1
+.names ng31950 [6598] [29663] [29665] ng34458
+-1-- 1
+0-1- 1
+0--1 1
+.names ng13806 [29669] [29671] [29672] ng28072
+---1 1
+0-1- 1
+-11- 1
+.names ng28444 [28561] [29675] [29676] ng33961
+---1 1
+101- 1
+.names ng11148 [6588] [29683] ng24238
+-1- 1
+0-1 1
+.names [29688] [29689] ng33038
+1- 1
+-1 1
+.names pg35 ng6513 ng6509 ng10887 ng25761
+0-1- 1
+10-1 1
+11-0 1
+.names ng14720 [6576] [29693] [29694] ng30468
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng1008 [6571] [6572] ng28057
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng862 ng890 ng26910
+01- 1
+-11 1
+100 1
+.names pg35 ng2837 ng2712 ng2841 ng24266
+0--1 1
+110- 1
+.names ng14768 [6565] [29702] [29703] ng30509
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng6573 ng25756
+11 1
+.names [6561] [29711] [29712] ng24215
+1-- 1
+-1- 1
+--1 1
+.names ng30314 [6552] [6553] [29715] ng34009
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng781 [6548] [6549] ng34725
+--1- 1
+---1 1
+01-- 1
+.names ng29313 [6544] [6545] [29724] ng34017
+-1-- 1
+--1- 1
+1--1 1
+.names ng13960 [6542] [29727] [29728] ng30442
+-1-- 1
+0-1- 1
+1--1 1
+.names ng29719 [6539] [29731] [29735] ng34264
+-1-- 1
+---1 1
+1-1- 1
+.names pg35 pg12923 ng1266 ng1249 ng25630
+0--1 1
+-101 1
+1110 1
+.names ng14950 [6532] [29737] [29738] ng30562
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng2868 ng2988 ng34616
+11- 1
+0-1 1
+.names ng26994 [6527] [29742] [29743] ng33070
+-1-- 1
+0-1- 1
+0--1 1
+.names ng23630 [6524] [29747] [29752] ng29289
+-1-- 1
+---1 1
+0-1- 1
+.names ng11148 ng13570 [29755] [29757] ng25628
+---1 1
+011- 1
+.names pg35 ng1816 [6515] [6516] ng33555
+--1- 1
+---1 1
+01-- 1
+.names ng23590 [6514] [29761] [29764] ng29281
+-1-- 1
+---1 1
+0-1- 1
+.names [6503] [6504] [29787] ng24352
+1-- 1
+-1- 1
+--1 1
+.names ng34162 [6500] [29791] [29792] ng34791
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 ng5138 ng5142 ng23590 ng29284
+01-- 1
+1-11 1
+1-00 1
+.names ng14075 [6494] [29797] [29798] ng30426
+-1-- 1
+0-1- 1
+1--1 1
+.names ng14999 [6491] [29800] [29801] ng30515
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng6555 ng26994 [29804] ng33068
+01-- 1
+--01 1
+.names pg35 ng29503 [29809] [29812] ng34443
+---1 1
+111- 1
+.names [6474] [6475] [6476] ng26944
+1-- 1
+-1- 1
+--1 1
+.names [29550] [29551] [29841] [29843] ng31898
+---1 1
+001- 1
+.names pg35 ng5124 ng5128 ng10823 ng25705
+01-- 1
+1-01 1
+1-10 1
+.names pg35 ng4646 ng31003 ng34026
+01- 1
+-11 1
+.names ng26256 [29851] [29852] [29853] ng30457
+--1- 1
+---1 1
+11-- 1
+.names [6451] [29184] [29185] [29186] ng30390
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng14008 [6450] [29855] [29856] ng30404
+-1-- 1
+0-1- 1
+1--1 1
+.names [6442] [6443] [29873] [29874] ng29236
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng4269 ng4264 ng4258 ng21895
+0-1- 1
+110- 1
+11-0 1
+1011 1
+.names pg35 ng3338 ng3347 ng8691 ng24269
+01-- 1
+100- 1
+1-01 1
+.names pg35 ng29503 [29887] [29890] ng34448
+---1 1
+111- 1
+.names pg35 pg8277 ng3050 [29894] ng25650
+---1 1
+101- 1
+.names [29899] [29900] ng33036
+1- 1
+-1 1
+.names ng24591 [6424] [29903] [29905] ng30341
+-1-- 1
+0-1- 1
+0--1 1
+.names ng14864 [6421] [29907] [29908] ng30540
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng1283 ng1277 ng1296 ng34730
+11-- 1
+1-1- 1
+0--1 1
+.names ng10887 [6415] [29912] [29917] ng25763
+-1-- 1
+---1 1
+1-1- 1
+.names pg35 pg9251 ng4308 ng24282
+0-1 1
+101 1
+110 1
+.names ng30583 [6408] [29922] [29923] ng34451
+---1 1
+001- 1
+.names pg35 ng5752 ng6035 ng25729
+01- 1
+1-1 1
+.names ng34650 [30236] [30237] ng34980
+--1 1
+11- 1
+.names ng11171 [6398] [30245] ng24254
+-1- 1
+0-1 1
+.names pg35 ng1252 [6395] [6396] ng29235
+--1- 1
+---1 1
+01-- 1
+.names ng30307 [6389] [6390] [30250] ng34003
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng5689 ng5406 ng25715
+11- 1
+0-1 1
+.names [30061] [30062] [30081] [30082] ng33149
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [30131] [30132] [30136] [30150] ng33197
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [30267] [30268] [30269] ng28089
+1-- 1
+-1- 1
+--1 1
+.names ng12443 ng12492 [30273] [30274] ng30463
+---1 1
+0-1- 1
+-01- 1
+.names pg35 ng1906 [6363] [6364] ng33562
+--1- 1
+---1 1
+01-- 1
+.names [6361] [30286] ng33546
+1- 1
+-1 1
+.names pg35 ng3689 ng3680 ng8728 ng24272
+0-1- 1
+11-1 1
+10-0 1
+.names pg35 ng4146 ng4176 ng34628
+11- 1
+0-1 1
+.names pg35 ng4674 ng31003 ng34027
+01- 1
+-11 1
+.names ng20905 [6348] [30293] [30295] ng28055
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng287 ng283 ng23204 ng31865
+0-1- 1
+-011 1
+1101 1
+.names pg35 ng1274 [6341] ng32985
+--1 1
+01- 1
+.names ng17625 ng12377 [30301] [30304] ng26931
+---1 1
+101- 1
+.names [6333] [6335] [30320] [30321] ng29244
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng32212 [6329] [30324] [30325] ng34439
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng622 [6324] [6325] ng34849
+--1- 1
+---1 1
+01-- 1
+.names ng31971 [6323] [30337] [30341] ng34459
+-1-- 1
+---1 1
+1-1- 1
+.names ng25470 [6317] [30344] [30348] ng30363
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 pg12923 ng1249 ng24247
+110 1
+.names pg35 ng2102 ng2098 ng25389 ng30365
+0-1- 1
+11-1 1
+10-0 1
+.names pg35 ng6173 ng6167 ng23699 ng29300
+0-1- 1
+--10 1
+11-1 1
+.names [6304] [6305] [6306] [6307] ng33591
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng6736 [6301] [6302] ng33626
+--1- 1
+---1 1
+01-- 1
+.names ng23733 [6300] [30372] [30375] ng29305
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 ng2040 [6294] [6295] ng33570
+--1- 1
+---1 1
+01-- 1
+.names ng12505 ng12558 [30383] [30384] ng30484
+---1 1
+0-1- 1
+-01- 1
+.names pg35 ng33394 [6283] [30388] ng34256
+--1- 1
+---1 1
+10-- 1
+.names ng30314 [6281] [6282] [30391] ng34011
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng2403 [6277] [6278] ng33590
+--1- 1
+---1 1
+01-- 1
+.names [6273] [6274] [30411] [30412] ng29240
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng86 ng5097 ng9724 ng25699
+0-1- 1
+110- 1
+11-1 1
+1010 1
+.names ng17625 ng12377 [30417] [30420] ng26934
+---1 1
+101- 1
+.names ng13291 [6260] [30421] [30422] ng25636
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 pg7946 ng1514 ng24609 ng30344
+1--1 1
+101- 1
+110- 1
+.names pg35 ng4727 ng34633
+11 1
+.names ng13873 [6254] [30427] [30428] ng30399
+-1-- 1
+0-1- 1
+1--1 1
+.names ng14908 [6251] [30430] [30431] ng30561
+-1-- 1
+0-1- 1
+1--1 1
+.names ng14858 [6248] [30433] [30434] ng30520
+-1-- 1
+0-1- 1
+1--1 1
+.names ng13892 [6245] [30436] [30437] ng30409
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng2932 ng2999 ng34805
+11- 1
+1-1 1
+.names [6237] [6238] [6239] [6240] ng33599
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng11432 [6236] [30447] [30448] ng30410
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng4382 ng29503 ng31895
+01- 1
+1-1 1
+.names pg35 ng2922 ng2912 ng34619
+11- 1
+0-1 1
+.names pg35 pg8342 ng3401 [30453] ng25664
+---1 1
+101- 1
+.names pg35 ng3119 ng3115 ng12641 ng25653
+0-1- 1
+10-1 1
+11-0 1
+.names ng13980 [6223] [30457] [30458] ng30412
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng3817 ng3821 ng12735 ng25681
+01-- 1
+1-01 1
+1-10 1
+.names ng11514 ng11729 [30465] [30466] ng30395
+---1 1
+0-1- 1
+-01- 1
+.names pg35 ng2527 ng2523 ng25400 ng30380
+0-1- 1
+11-1 1
+10-0 1
+.names ng14041 [6211] [30471] [30472] ng30405
+-1-- 1
+0-1- 1
+1--1 1
+.names ng12402 [6208] [30474] [30475] ng30476
+-1-- 1
+0-1- 1
+1--1 1
+.names ng28927 [6205] [30480] ng33560
+-1- 1
+1-1 1
+.names pg35 pg7916 ng996 [30484] ng24236
+---1 1
+111- 1
+.names ng27617 [6197] [30487] [30488] ng33029
+-1-- 1
+0-1- 1
+0--1 1
+.names pg35 ng4269 ng4273 ng8967 ng24280
+01-- 1
+101- 1
+1-11 1
+1100 1
+.names pg35 ng2259 ng2255 ng25309 ng30370
+0-1- 1
+11-1 1
+10-0 1
+.names ng10874 [6167] [30562] [30566] ng25749
+-1-- 1
+---1 1
+1-1- 1
+.names ng14776 [6163] [30567] [30568] ng30538
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng4639 ng31950 ng34025
+100 1
+.names [29550] [29551] [30572] [30574] ng31899
+---1 1
+001- 1
+.names ng14861 [6157] [30575] [30576] ng30531
+-1-- 1
+0-1- 1
+1--1 1
+.names ng28982 [6151] [30581] [30583] ng33619
+-1-- 1
+0-1- 1
+0--1 1
+.names ng10632 [6148] [30585] [30586] ng26903
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng4284 ng4180 ng13517 ng29268
+11-0 1
+1-00 1
+1011 1
+.names pg35 ng6555 ng6549 ng26994 ng33067
+0-1- 1
+-010 1
+1100 1
+.names ng13315 ng10961 [30593] [30596] ng26923
+---1 1
+1-1- 1
+-11- 1
+.names [30611] [30612] [30613] ng28085
+1-- 1
+-1- 1
+--1 1
+.names [6125] [6126] [6127] [6128] ng33583
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng896 ng862 ng890 ng26909
+0--1 1
+101- 1
+11-0 1
+.names pg35 ng6727 ng6732 ng10224 ng24355
+0-1- 1
+-01- 1
+--11 1
+.names [6093] [6094] [6095] [6096] ng29304
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng2841 [30694] [30695] ng26926
+---1 1
+111- 1
+.names pg35 ng17694 ng17727 [30708] ng34796
+---1 1
+11-- 1
+1-1- 1
+.names pg35 ng2537 [6068] [6069] ng33598
+--1- 1
+---1 1
+01-- 1
+.names ng14825 [6067] [30712] [30713] ng30559
+-1-- 1
+0-1- 1
+1--1 1
+.names [30729] [30730] [30731] ng28087
+1-- 1
+-1- 1
+--1 1
+.names pg35 ng2453 [6055] [30737] ng33012
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng2729 ng14291 [30740] ng28060
+---1 1
+101- 1
+110- 1
+.names pg35 ng925 [6048] [6049] ng33540
+--1- 1
+---1 1
+01-- 1
+.names ng29110 [6047] [30746] [30748] ng33627
+-1-- 1
+0-1- 1
+0--1 1
+.names pg35 ng2868 ng2873 ng34615
+01- 1
+1-1 1
+.names ng16187 ng28349 [30752] [30754] ng34040
+---1 1
+111- 1
+.names pg35 ng3484 ng3480 ng23112 ng29267
+0-1- 1
+11-1 1
+10-0 1
+.names ng31509 [6036] [30759] [30760] ng34251
+-1-- 1
+1-1- 1
+0--1 1
+.names ng22369 [6033] [30763] [30768] ng29243
+-1-- 1
+---1 1
+1-1- 1
+.names pg35 ng4417 [6028] [6029] ng26950
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng1395 ng1322 ng13134 ng25634
+1101 1
+1000 1
+.names ng23324 [6015] [30805] [30807] ng29227
+-1-- 1
+0-1- 1
+0--1 1
+.names [6009] [6010] [6011] [6012] ng26896
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng6541 ng6505 ng10887 ng25764
+01-- 1
+-1-1 1
+1-10 1
+.names [5979] [5980] [5981] [5982] ng29286
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng5069 ng25371 [30880] ng28091
+01-- 1
+--01 1
+.names pg35 ng1644 [5968] [5969] ng33545
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng4284 ng4180 ng14247 ng29297
+11-0 1
+1-00 1
+1011 1
+.names pg35 ng2204 [5963] [5964] ng33577
+--1- 1
+---1 1
+01-- 1
+.names ng25300 [5959] [30893] [30898] ng30357
+-1-- 1
+---1 1
+0-1- 1
+.names ng7142 ng12716 [30900] [30901] ng30544
+---1 1
+0-1- 1
+-01- 1
+.names ng25429 [5952] [30902] [30906] ng30358
+-1-- 1
+---1 1
+0-1- 1
+.names ng25389 [5948] [30908] [30912] ng30367
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 ng577 [5942] [5943] ng31866
+--1- 1
+---1 1
+01-- 1
+.names ng12735 [5941] [30918] [30923] ng25683
+-1-- 1
+---1 1
+1-1- 1
+.names [5928] [5929] [30938] [30939] ng29246
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng5835 ng5841 ng10869 ng25734
+01-- 1
+-1-1 1
+1-10 1
+.names pg35 ng4273 ng4239 ng21892
+01- 1
+1-0 1
+.names pg35 ng5142 ng5148 ng10823 ng25706
+01-- 1
+-1-1 1
+1-10 1
+.names pg35 ng5272 [5888] [5889] ng28093
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng2587 [5883] [31010] ng33016
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng6727 ng6723 ng10224 ng24353
+0-1- 1
+11-1 1
+10-0 1
+.names ng12641 [5878] [31015] [31020] ng25655
+-1-- 1
+---1 1
+1-1- 1
+.names pg35 ng4927 ng4912 ng34642
+11- 1
+0-1 1
+.names pg35 ng5069 ng5073 ng25704
+0-1 1
+-11 1
+.names pg35 ng2319 [5868] [31025] ng33008
+--1- 1
+---1 1
+01-- 1
+.names ng13920 [5866] [31026] [31027] ng30421
+-1-- 1
+0-1- 1
+1--1 1
+.names [5856] [31034] [31036] ng33007
+1-- 1
+-1- 1
+--1 1
+.names pg35 pg9680 ng5752 [31040] ng25730
+---1 1
+101- 1
+.names pg35 ng13211 [5848] [31043] ng25624
+---1 1
+101- 1
+.names ng33394 [31045] ng34255
+0- 1
+-1 1
+.names pg35 ng2279 ng2273 ng25309 ng30371
+0-1- 1
+--10 1
+11-1 1
+.names pg35 ng106 ng26900
+11 1
+.names [5835] [5836] [5837] [5838] ng33607
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng10632 [5834] [31056] [31057] ng26904
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng3502 ng34626
+11 1
+.names ng23666 [5831] [31060] [31063] ng29293
+-1-- 1
+---1 1
+0-1- 1
+.names ng29722 [5827] [31065] [31069] ng34268
+-1-- 1
+---1 1
+1-1- 1
+.names pg35 ng3821 [5821] [5822] ng29271
+--1- 1
+---1 1
+01-- 1
+.names [31086] [31087] [31088] ng28083
+1-- 1
+-1- 1
+--1 1
+.names ng13385 [5814] [31090] [31091] ng26886
+-1-- 1
+0-1- 1
+1--1 1
+.names ng28903 [5811] [31095] ng33576
+-1- 1
+1-1 1
+.names ng23112 [5809] [31098] [31102] ng29266
+-1-- 1
+---1 1
+0-1- 1
+.names ng31003 ng10831 [31105] ng34260
+101 1
+.names pg35 ng5352 [5803] [5804] ng33618
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng4922 ng4907 ng34640
+01- 1
+1-1 1
+.names ng14055 [5800] [31111] [31112] ng30445
+-1-- 1
+0-1- 1
+1--1 1
+.names ng14968 [5797] [31114] [31115] ng30514
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng1854 ng1848 ng25300 ng30356
+0-1- 1
+--10 1
+11-1 1
+.names pg35 ng2841 ng4064 ng4072 ng25685
+10-- 1
+1-0- 1
+0--1 1
+.names ng12581 ng12667 [31121] [31122] ng30525
+---1 1
+0-1- 1
+-01- 1
+.names ng25895 [5783] [5785] [31124] ng30342
+-1-- 1
+--1- 1
+1--1 1
+.names ng12629 [5782] [31126] [31127] ng30560
+-1-- 1
+0-1- 1
+1--1 1
+.names [5773] [5774] [5775] [5776] ng33567
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng5485 ng5489 ng23630 ng29290
+01-- 1
+1-11 1
+1-00 1
+.names ng11676 [5769] [31140] [31141] ng25602
+-1-- 1
+0-1- 1
+1--1 1
+.names ng28853 [5766] [31146] ng33544
+-1- 1
+1-1 1
+.names pg35 ng2689 ng34606
+11 1
+.names ng29496 [31149] [31151] [31153] ng34013
+---1 1
+01-- 1
+1-1- 1
+.names ng13929 [5755] [31155] [31156] ng30441
+-1-- 1
+0-1- 1
+1--1 1
+.names ng30298 [5747] [5748] [31158] ng33977
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng2950 ng2936 ng34621
+11- 1
+0-1 1
+.names ng10632 [5740] [31161] [31162] ng26908
+-1-- 1
+1-1- 1
+0--1 1
+.names ng30583 [5737] [31165] [31167] ng34257
+-1-- 1
+0-1- 1
+0--1 1
+.names ng23699 [5734] [31170] [31173] ng29299
+-1-- 1
+---1 1
+0-1- 1
+.names ng14797 [5730] [31174] [31175] ng30470
+-1-- 1
+0-1- 1
+1--1 1
+.names ng4438 [6690] [29524] [31178] ng26954
+---1 1
+100- 1
+.names [31182] [31183] [31184] [31189] ng21901
+---1 1
+111- 1
+.names pg35 ng2112 [5718] [5719] ng33574
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng2689 ng2697 ng34607
+01- 1
+1-1 1
+.names pg35 ng2461 [5712] [31198] ng33011
+--1- 1
+---1 1
+01-- 1
+.names pg35 pg10306 ng4534 ng26965
+0-1 1
+-01 1
+110 1
+.names ng14151 [5705] [31201] [31202] ng30429
+-1-- 1
+0-1- 1
+1--1 1
+.names ng847 ng8806 [31205] [31206] ng25619
+---1 1
+0-1- 1
+-11- 1
+.names pg35 ng3506 ng3518 ng27617 ng30414
+1000 1
+.names pg35 ng1030 [5697] [5698] ng33541
+--1- 1
+---1 1
+01-- 1
+.names [5693] [5694] [31215] ng33615
+1-- 1
+-1- 1
+--1 1
+.names pg35 ng1700 [5690] [5691] ng33548
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng5517 ng28010 [31220] ng33053
+01-- 1
+--01 1
+.names pg35 ng6195 ng6159 ng10874 ng25750
+01-- 1
+-1-1 1
+1-10 1
+.names pg35 ng2950 ng2960 ng34622
+01- 1
+1-1 1
+.names pg35 ng5489 ng5495 ng10838 ng25720
+01-- 1
+-1-1 1
+1-10 1
+.names pg35 ng2975 ng2965 [31226] ng34804
+---1 1
+11-- 1
+0-1- 1
+.names pg35 ng6561 ng6549 ng26994 ng30543
+1000 1
+.names ng30307 [5671] [5672] [31229] ng34005
+-1-- 1
+--1- 1
+1--1 1
+.names ng25498 [5669] [31233] [31237] ng30383
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 ng6545 ng34647
+11 1
+.names [5663] [5664] [31242] ng29255
+1-- 1
+-1- 1
+--1 1
+.names ng10341 ng12667 [31245] [31246] ng30523
+---1 1
+0-1- 1
+-01- 1
+.names pg35 ng546 [5653] [5654] ng24211
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng1834 [5650] [5651] ng33556
+--1- 1
+---1 1
+01-- 1
+.names [5645] [5648] [31259] ng24214
+1-- 1
+-1- 1
+--1 1
+.names pg35 ng5188 ng25700
+11 1
+.names [5638] [5643] [5644] [31271] ng25691
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng3133 ng3129 ng23067 ng29261
+0-1- 1
+11-1 1
+10-0 1
+.names pg54 pg53 [29926] ng27511
+101 1
+.names pg35 ng1913 [5632] [5633] ng33561
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng4907 ng4912 ng34641
+01- 1
+1-1 1
+.names [5627] [5628] [31283] ng29245
+1-- 1
+-1- 1
+--1 1
+.names pg35 ng3857 ng3869 ng27635 ng30435
+1000 1
+.names ng29489 [31288] [31290] [31292] ng34006
+---1 1
+01-- 1
+1-1- 1
+.names ng28349 ng13486 [31297] [31298] ng34038
+---1 1
+111- 1
+.names pg35 pg9019 ng4291 ng21899
+0-1 1
+101 1
+110 1
+.names [5603] [31317] [31318] [31319] ng30391
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng736 [5600] [5601] ng29228
+--1- 1
+---1 1
+01-- 1
+.names [5597] [31326] [31327] [31328] ng25696
+1--- 1
+---1 1
+-11- 1
+.names [5593] [31333] ng34029
+1- 1
+-1 1
+.names ng17625 ng12377 [31334] [31337] ng26929
+---1 1
+101- 1
+.names ng15039 [5589] [31338] [31339] ng30548
+-1-- 1
+0-1- 1
+1--1 1
+.names ng25492 [5586] [31342] [31346] ng30364
+-1-- 1
+---1 1
+0-1- 1
+.names ng11480 [5580] [31347] [31348] ng30431
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng2193 [5574] [31356] ng33003
+--1- 1
+---1 1
+01-- 1
+.names [31363] [31364] ng33014
+1- 1
+-1 1
+.names ng15748 [31367] [31372] [31374] ng25631
+---1 1
+01-- 1
+1-1- 1
+.names ng13307 ng10929 [31378] [31380] ng26916
+---1 1
+1-1- 1
+-11- 1
+.names pg35 ng1221 ng1087 ng1205 ng24246
+0--1 1
+110- 1
+11-0 1
+1011 1
+.names pg35 ng1632 [5555] [31390] ng32987
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng1844 [5552] [5553] ng33558
+--1- 1
+---1 1
+01-- 1
+.names ng31009 ng10862 [31397] [31398] ng34468
+---1 1
+101- 1
+.names pg35 ng2999 ng2994 ng34732
+01- 1
+1-1 1
+.names ng10929 ng10909 [31400] [31403] ng25626
+---1 1
+001- 1
+.names ng28973 [5542] [31406] ng33592
+-1- 1
+1-1 1
+.names pg35 ng6533 ng6527 ng10887 ng25762
+0-1- 1
+--11 1
+11-0 1
+.names pg35 ng358 ng370 ng8721 ng25597
+01-- 1
+1-01 1
+1-10 1
+.names ng30304 [5533] [5534] [31414] ng33986
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng2837 ng2841 ng4125 ng25690
+0-1- 1
+11-0 1
+.names pg35 ng5481 ng5475 ng23630 ng29288
+0-1- 1
+--10 1
+11-1 1
+.names [30202] [30203] [30204] [30205] ng33212
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng2331 [5524] [5525] ng33586
+--1- 1
+---1 1
+01-- 1
+.names ng25435 [5523] [31425] [31429] ng30373
+-1-- 1
+---1 1
+0-1- 1
+.names ng827 ng20905 [31433] [31434] ng29229
+---1 1
+0-1- 1
+-11- 1
+.names pg35 ng37 ng94 ng34614
+01- 1
+1-1 1
+.names pg35 ng3698 [5512] [5513] ng33611
+--1- 1
+---1 1
+01-- 1
+.names [31445] [31446] ng33041
+1- 1
+-1 1
+.names pg35 ng1932 [5503] [31452] ng32997
+--1- 1
+---1 1
+01-- 1
+.names ng23324 [5502] [31454] [31456] ng29226
+-1-- 1
+0-1- 1
+0--1 1
+.names pg6748 pg35 ng4555 ng26966
+11- 1
+-01 1
+.names pg35 ng4836 ng31009 ng34034
+01- 1
+-11 1
+.names pg35 pg7946 ng1521 [31460] ng24253
+---1 1
+111- 1
+.names ng13242 [5491] [31463] [31464] ng26920
+---1 1
+1-1- 1
+-11- 1
+.names ng25432 [5487] [31466] [31470] ng30369
+-1-- 1
+---1 1
+0-1- 1
+.names ng10838 [5483] [31472] [31477] ng25721
+-1-- 1
+---1 1
+1-1- 1
+.names pg35 ng4180 [5476] ng21891
+--1 1
+01- 1
+.names ng14996 [5475] [31478] [31479] ng30506
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng6163 ng6167 ng10874 ng25747
+01-- 1
+1-01 1
+1-10 1
+.names ng14154 [5469] [31484] [31485] ng30440
+-1-- 1
+0-1- 1
+1--1 1
+.names [5463] [5464] [5465] [5466] ng33597
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng14659 [5462] [31494] [31495] ng30475
+-1-- 1
+0-1- 1
+1--1 1
+.names ng27635 [5456] [31498] [31499] ng33034
+-1-- 1
+0-1- 1
+0--1 1
+.names ng14879 [5451] [31501] [31502] ng30472
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng4727 ng4732 ng34634
+01- 1
+1-1 1
+.names pg35 ng333 ng347 ng26890
+01- 1
+1-0 1
+.names pg91 pg35 ng2882 ng2878 ng34797
+01-- 1
+-01- 1
+-1-1 1
+.names pg35 ng930 [5438] ng32982
+--1 1
+01- 1
+.names pg35 ng4146 ng4157 ng34629
+01- 1
+1-1 1
+.names pg35 ng3857 ng3863 ng27635 ng33031
+01-- 1
+-100 1
+1010 1
+.names pg35 ng1664 [5430] [31512] ng32989
+--1- 1
+---1 1
+01-- 1
+.names [5427] [31515] ng28069
+1- 1
+-1 1
+.names pg35 ng667 ng686 ng11607 ng25615
+0-1- 1
+--11 1
+11-0 1
+.names pg35 ng5475 ng5471 ng10838 ng25719
+0-1- 1
+10-1 1
+11-0 1
+.names ng14927 [5419] [31521] [31522] ng30493
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng2715 ng2841 ng2719 ng25639
+01-- 1
+1-0- 1
+-1-0 1
+10-1 1
+.names ng14142 [5412] [31527] [31528] ng30448
+-1-- 1
+0-1- 1
+1--1 1
+.names ng8359 [5406] [5407] [31530] ng25593
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng33394 [31533] [31534] ng34254
+--1- 1
+---1 1
+10-- 1
+.names pg35 ng4253 ng4249 ng34631
+01- 1
+1-1 1
+.names ng14683 [5397] [31536] [31537] ng30467
+-1-- 1
+0-1- 1
+1--1 1
+.names ng31009 ng10862 [31542] [31543] ng34465
+---1 1
+101- 1
+.names [5390] [31546] ng33578
+1- 1
+-1 1
+.names pg35 pg9553 ng5062 [31550] ng25702
+---1 1
+101- 1
+.names ng25779 ng34056 ng34051 ng34424 ng34650
+0111 1
+1011 1
+1101 1
+0001 1
+1110 1
+0010 1
+0100 1
+1000 1
+.names pg35 ng424 ng411 ng8806 ng24202
+0-1- 1
+--10 1
+11-1 1
+.names ng19140 [31553] [31555] ng26919
+--1 1
+01- 1
+.names ng20248 [5376] [31556] [31557] ng28049
+-1-- 1
+0-1- 1
+1--1 1
+.names ng30300 [5372] [5373] [31559] ng33998
+-1-- 1
+--1- 1
+1--1 1
+.names ng13211 [5848] [31564] [31565] ng26913
+---1 1
+1-1- 1
+-11- 1
+.names pg35 ng1351 [5365] [5366] ng28059
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng5689 ng5698 ng10160 ng24342
+01-- 1
+100- 1
+1-01 1
+.names ng30314 [5361] [5362] [31571] ng34010
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng5619 [5357] [5358] ng28096
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng3689 ng3698 ng8728 ng24273
+01-- 1
+100- 1
+1-01 1
+.names ng17625 ng12377 [31578] [31581] ng26928
+---1 1
+101- 1
+.names pg35 ng358 ng370 ng376 ng25596
+0-1- 1
+10-1 1
+11-0 1
+.names ng907 ng22992 ng19063 [31587] ng28056
+---1 1
+110- 1
+.names pg35 ng20248 [31589] ng28053
+--1 1
+10- 1
+.names ng23067 [5342] [31591] [31595] ng29260
+-1-- 1
+---1 1
+0-1- 1
+.names ng29657 [5338] [31596] [31600] ng34261
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 ng6035 ng6031 ng10185 ng24345
+0-1- 1
+11-1 1
+10-0 1
+.names pg113 ng4473 ng4459 [31604] ng30458
+---1 1
+110- 1
+.names pg35 ng4031 ng4040 ng8751 ng24276
+01-- 1
+1-11 1
+1-00 1
+.names ng12453 ng12558 [31609] [31610] ng30483
+---1 1
+0-1- 1
+-01- 1
+.names ng27629 [5319] [31612] [31613] ng32978
+-1-- 1
+0-1- 1
+1--1 1
+.names ng30298 [5315] [5316] [31616] ng33976
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng1306 ng1296 ng1291 ng34729
+10-- 1
+1-1- 1
+0--1 1
+.names [5308] [5309] [31623] ng26947
+1-- 1
+-1- 1
+--1 1
+.names pg35 ng979 ng1052 ng13121 ng25625
+1011 1
+1000 1
+.names ng28892 [5304] [31631] ng33552
+-1- 1
+1-1 1
+.names ng15737 [5299] [31640] [31642] ng25622
+-1-- 1
+---1 1
+1-1- 1
+.names pg35 ng333 ng355 ng351 ng26892
+0--1 1
+11-0 1
+1-10 1
+.names pg35 ng6727 ng6444 ng25757
+11- 1
+0-1 1
+.names ng10632 [5294] [31645] [31646] ng26901
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng5863 ng28020 [31650] ng33058
+01-- 1
+--01 1
+.names ng28353 [5289] [31652] [31653] ng33534
+-1-- 1
+0-1- 1
+1--1 1
+.names ng17625 ng12377 [31655] [31658] ng26932
+---1 1
+101- 1
+.names ng4098 ng22654 [31660] [31662] ng33035
+---1 1
+0-1- 1
+-01- 1
+.names ng28020 [5279] [31664] [31665] ng33060
+-1-- 1
+0-1- 1
+0--1 1
+.names ng10909 [5276] [31667] [31668] ng24233
+-1-- 1
+0-1- 1
+1--1 1
+.names ng11607 [5273] [31671] [31672] ng25612
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 ng66 [31677] [31678] ng24335
+01-- 1
+--11 1
+.names pg35 ng5037 [5258] [5259] ng31900
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng2994 ng2988 ng34624
+01- 1
+1-1 1
+.names pg35 ng24609 [31686] ng30345
+--1 1
+11- 1
+.names ng14708 [28793] [31689] [31690] ng26895
+---1 1
+101- 1
+.names pg35 pg10122 ng4297 ng4239 ng21900
+0--1 1
+100- 1
+.names [31696] [31697] ng33045
+1- 1
+-1 1
+.names pg35 pg9741 ng6098 [31701] ng25744
+---1 1
+101- 1
+.names ng14899 [5231] [31702] [31703] ng30532
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng5120 ng5156 ng10823 ng25708
+0-1- 1
+--11 1
+11-0 1
+.names pg35 ng1333 ng16272 ng24257
+01- 1
+-10 1
+101 1
+.names ng30583 ng15591 [31714] [31715] ng34450
+---1 1
+011- 1
+.names ng14841 [5214] [31716] [31717] ng30471
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng1270 [5209] [5210] ng33542
+--1- 1
+---1 1
+01-- 1
+.names [29550] [29551] [31729] [31731] ng31904
+---1 1
+001- 1
+.names [31746] [31747] [31748] ng28088
+1-- 1
+-1- 1
+--1 1
+.names pg35 ng5092 ng5084 ng5097 ng25698
+01-- 1
+10-1 1
+1-01 1
+1110 1
+.names pg35 ng939 ng943 ng19402 ng34728
+---1 1
+01-- 1
+1-1- 1
+.names ng12772 ng12492 [31755] [31756] ng30461
+---1 1
+0-1- 1
+-01- 1
+.names pg35 ng2912 ng2907 ng34618
+11- 1
+0-1 1
+.names pg35 ng3347 [5176] [5177] ng33609
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng3119 ng3125 ng23067 ng29259
+01-- 1
+-1-0 1
+1-11 1
+.names pg35 ng1988 ng1982 ng25341 ng30361
+0-1- 1
+--10 1
+11-1 1
+.names pg35 ng5343 ng5352 ng10124 ng24338
+01-- 1
+100- 1
+1-01 1
+.names pg35 ng4455 [6028] [6029] ng26958
+--1- 1
+---1 1
+01-- 1
+.names ng30304 [5164] [5165] [31771] ng33981
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng2541 ng2547 ng25400 ng30381
+01-- 1
+-1-0 1
+1-11 1
+.names pg35 ng5343 ng5339 ng10124 ng24337
+0-1- 1
+11-1 1
+10-0 1
+.names ng14807 [5156] [31779] [31780] ng30499
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 pg12919 pg17400 [31783] ng24239
+---1 1
+111- 1
+.names pg35 ng732 [5148] [5149] ng26897
+--1- 1
+---1 1
+01-- 1
+.names pg35 pg7540 ng347 ng26891
+0-1 1
+110 1
+.names ng27602 [5145] [31788] [31789] ng33024
+-1-- 1
+0-1- 1
+0--1 1
+.names pg35 ng29503 [31794] [31797] ng34447
+---1 1
+111- 1
+.names ng29482 [31799] [31801] [31803] ng33971
+---1 1
+01-- 1
+1-1- 1
+.names ng23666 [5132] [31806] [31811] ng29295
+-1-- 1
+---1 1
+0-1- 1
+.names ng13948 [5128] [31812] [31813] ng30402
+-1-- 1
+0-1- 1
+1--1 1
+.names pg6748 pg35 ng4483 ng26961
+11- 1
+-01 1
+.names ng14688 [5123] [31815] [31816] ng30487
+-1-- 1
+0-1- 1
+1--1 1
+.names ng14905 [5120] [31818] [31819] ng30552
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng3752 ng4040 ng25677
+01- 1
+1-1 1
+.names [29325] [29326] [31821] [31822] ng26949
+---1 1
+111- 1
+.names pg6750 pg35 ng4561 ng26967
+11- 1
+-01 1
+.names [31829] [31830] ng33018
+1- 1
+-1 1
+.names ng11534 [5103] [31831] [31832] ng30452
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng2852 ng2860 ng34611
+01- 1
+1-1 1
+.names ng15033 [5098] [31834] [31835] ng30556
+-1-- 1
+0-1- 1
+1--1 1
+.names ng8906 ng11571 [31839] [31840] ng30415
+---1 1
+0-1- 1
+-01- 1
+.names ng23733 [5089] [31842] [31847] ng29307
+-1-- 1
+---1 1
+0-1- 1
+.names ng14011 [5085] [31848] [31849] ng30413
+-1-- 1
+0-1- 1
+1--1 1
+.names ng14018 [5082] [31851] [31852] ng30433
+-1-- 1
+0-1- 1
+1--1 1
+.names ng14855 [5079] [31854] [31855] ng30511
+-1-- 1
+0-1- 1
+1--1 1
+.names [31871] [31872] [31873] ng28086
+1-- 1
+-1- 1
+--1 1
+.names ng28349 ng13486 [31878] [31879] ng34039
+---1 1
+111- 1
+.names ng24591 [5067] [31881] [31883] ng30340
+-1-- 1
+0-1- 1
+0--1 1
+.names ng14892 [5064] [31885] [31886] ng30512
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng1146 ng1152 ng10909 ng24234
+01-- 1
+-1-0 1
+1-11 1
+.names pg35 ng17657 ng17700 [31902] ng34793
+---1 1
+11-- 1
+1-1- 1
+.names pg35 ng990 ng16246 ng24241
+01- 1
+-10 1
+101 1
+.names ng25467 [5036] [31906] [31910] ng30359
+-1-- 1
+---1 1
+0-1- 1
+.names [29971] [29972] [30013] [30014] ng33176
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng5170 ng5164 ng27999 ng33047
+0-1- 1
+-010 1
+1100 1
+.names ng11171 ng11149 [31915] [31917] ng25638
+---1 1
+011- 1
+.names ng31009 ng10862 [31920] [31921] ng34466
+---1 1
+101- 1
+.names ng14984 [5018] [31922] [31923] ng30563
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng2860 ng2894 ng34612
+01- 1
+1-1 1
+.names ng30583 ng15591 [31926] [31928] ng34449
+011- 1
+01-1 1
+.names ng13889 [5011] [31929] [31930] ng30400
+-1-- 1
+0-1- 1
+1--1 1
+.names ng14101 [5008] [31932] [31933] ng30407
+-1-- 1
+0-1- 1
+1--1 1
+.names ng14851 [5005] [31935] [31936] ng30500
+-1-- 1
+0-1- 1
+1--1 1
+.names ng34703 [5002] [31942] [31943] ng34911
+-1-- 1
+0-1- 1
+1--1 1
+.names [31951] [31952] ng32994
+1- 1
+-1 1
+.names pg35 ng4864 ng31009 ng34035
+01- 1
+-11 1
+.names ng11320 ng31950 [4993] [30570] ng34259
+--1- 1
+00-1 1
+.names pg35 ng34 ng2980 ng2886 ng34800
+11-- 1
+1-1- 1
+0--1 1
+.names ng12609 ng12515 [31955] [31956] ng30504
+---1 1
+0-1- 1
+-01- 1
+.names ng13756 [31958] [31960] [31962] ng24210
+01-- 1
+0-1- 1
+0--1 1
+.names ng31003 ng10831 [31966] [31967] ng34462
+---1 1
+101- 1
+.names ng10929 ng13260 [31970] [31972] ng26915
+---1 1
+1-1- 1
+-11- 1
+.names ng11626 ng8958 [31974] [31975] ng30436
+---1 1
+111- 1
+.names pg35 ng4098 ng22654 [31978] ng31894
+---1 1
+101- 1
+110- 1
+.names [31984] [31985] ng33039
+1- 1
+-1 1
+.names pg35 pg12923 ng1585 ng24261
+11- 1
+0-1 1
+.names ng29036 [4958] [31989] [31991] ng33623
+-1-- 1
+0-1- 1
+0--1 1
+.names ng14817 [4955] [31993] [31994] ng30530
+-1-- 1
+0-1- 1
+1--1 1
+.names ng10421 ng12667 [31997] [31998] ng30524
+---1 1
+0-1- 1
+-01- 1
+.names pg35 pg9615 ng5406 [32002] ng25716
+---1 1
+101- 1
+.names pg35 ng164 [4944] [4945] ng32976
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng209 ng538 ng34719
+11- 1
+1-1 1
+.names ng29672 [4941] [32007] [32011] ng34262
+-1-- 1
+---1 1
+1-1- 1
+.names ng14956 [4937] [32012] [32013] ng30485
+-1-- 1
+0-1- 1
+1--1 1
+.names ng10266 ng12492 [32016] [32017] ng30460
+---1 1
+0-1- 1
+-01- 1
+.names pg35 ng2357 [4929] [32022] ng33009
+--1- 1
+---1 1
+01-- 1
+.names ng4443 ng4452 [29521] [32024] ng26956
+-1-- 1
+0011 1
+.names pg35 ng160 [7582] ng33536
+--1 1
+01- 1
+.names ng23975 [4912] [32051] [32052] ng32980
+-1-- 1
+0--1 1
+--11 1
+.names [4908] [4909] [32058] ng29253
+1-- 1
+-1- 1
+--1 1
+.names ng28144 [4906] [32061] [32063] ng34456
+-1-- 1
+1-1- 1
+0--1 1
+.names ng25495 [4903] [32066] [32070] ng30379
+-1-- 1
+---1 1
+0-1- 1
+.names ng25400 [4899] [32072] [32077] ng30382
+-1-- 1
+---1 1
+0-1- 1
+.names ng29313 [4893] [4895] [32080] ng34018
+-1-- 1
+--1- 1
+1--1 1
+.names ng13990 [4892] [32082] [32083] ng30443
+-1-- 1
+0-1- 1
+1--1 1
+.names ng30311 [4888] [4889] [32086] ng33988
+-1-- 1
+--1- 1
+1--1 1
+.names ng31009 ng10862 [32091] ng34265
+101 1
+.names pg35 ng2102 [4884] [4885] ng33572
+--1- 1
+---1 1
+01-- 1
+.names ng29313 [4882] [4883] [32096] ng34016
+-1-- 1
+--1- 1
+1--1 1
+.names [4878] [4879] [32103] ng29247
+1-- 1
+-1- 1
+--1 1
+.names ng11171 ng13597 [32107] [32109] ng25637
+---1 1
+011- 1
+.names ng11473 ng11514 [32111] [32112] ng30397
+---1 1
+111- 1
+.names pg35 ng1720 ng1714 ng25275 ng30351
+0-1- 1
+--10 1
+11-1 1
+.names [4861] [4863] [32118] ng26918
+1-- 1
+-1- 1
+--1 1
+.names ng14127 [4860] [32120] [32121] ng30408
+-1-- 1
+0-1- 1
+1--1 1
+.names ng12609 ng12824 [32124] [32125] ng30503
+---1 1
+0-1- 1
+-01- 1
+.names pg35 ng4392 ng24298
+01 1
+.names pg35 ng6227 ng25742
+11 1
+.names ng10939 ng10961 [32127] [32130] ng25635
+---1 1
+1-1- 1
+-11- 1
+.names [4842] [4843] [32133] ng33044
+1-- 1
+-1- 1
+--1 1
+.names ng8864 ng11514 [32136] [32137] ng30394
+---1 1
+0-1- 1
+-01- 1
+.names ng28962 [4836] [32141] ng33568
+-1- 1
+1-1 1
+.names ng8728 [4834] [32145] [32146] ng24271
+-1-- 1
+1-11 1
+.names [4827] [4828] [32166] [32167] ng33963
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng4722 ng4717 ng34636
+11- 1
+0-1 1
+.names [4795] [4796] [4797] [4798] ng29298
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng14953 [4794] [32234] [32235] ng30474
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 ng3151 ng34625
+11 1
+.names pg35 ng2946 ng2878 ng2886 ng34798
+11-- 1
+0-1- 1
+1--1 1
+.names pg35 ng6381 ng6390 ng10207 ng24350
+01-- 1
+100- 1
+1-01 1
+.names ng28484 [32242] [32244] ng33613
+--1 1
+01- 1
+.names pg35 ng3470 ng3476 ng23112 ng29265
+01-- 1
+-1-0 1
+1-11 1
+.names [4757] [32304] [32305] [32306] ng29276
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng5869 ng5873 ng28020 ng33059
+01-- 1
+-100 1
+1010 1
+.names [4749] [30550] [30551] [30552] ng29278
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng4467 ng4462 ng33394 ng34253
+10-- 1
+1-0- 1
+1--0 1
+.names ng14943 [4745] [32313] [32314] ng30542
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng6311 [4740] [4741] ng28102
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng3329 ng3338 ng8691 ng24268
+01-- 1
+1-11 1
+1-00 1
+.names ng25382 [4736] [32323] [32327] ng30349
+-1-- 1
+---1 1
+0-1- 1
+.names [30215] [30216] [30231] [30232] ng33219
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng13955 [4729] [32328] [32329] ng30422
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 ng2375 [4724] [4725] ng33587
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng2643 [4721] [4722] ng33603
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng316 ng106 ng26888
+11- 1
+0-1 1
+.names ng31997 [4715] [32336] [32338] ng34453
+-1-- 1
+0-1- 1
+0--1 1
+.names ng29313 [4711] [4712] [32340] ng34021
+-1-- 1
+--1- 1
+1--1 1
+.names ng23975 [32051] [32344] [32353] ng34440
+---1 1
+101- 1
+.names pg35 ng2856 ng2864 ng28220 ng34794
+01-- 1
+1-1- 1
+1--1 1
+.names [30095] [30096] [30115] [30116] ng33164
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg6749 pg35 ng4558 ng26968
+11- 1
+-01 1
+.names pg35 ng4284 ng4180 ng14211 ng29285
+11-0 1
+1-00 1
+1011 1
+.names pg35 ng2269 [4692] [4693] ng33582
+--1- 1
+---1 1
+01-- 1
+.names pg35 pg12919 ng904 ng24231
+110 1
+.names ng26977 [4689] [32367] [32368] ng33065
+-1-- 1
+0-1- 1
+0--1 1
+.names pg35 ng6215 ng6203 ng26977 ng30522
+1000 1
+.names pg35 ng4358 [4685] ng24334
+--1 1
+01- 1
+.names ng30300 [4683] [4684] [32382] ng34000
+-1-- 1
+--1- 1
+1--1 1
+.names ng4145 ng13806 [32385] [32387] ng28071
+---1 1
+110- 1
+.names pg35 ng1978 [4676] [4677] ng33566
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng4732 ng4717 ng34635
+01- 1
+1-1 1
+.names ng14098 [4673] [32391] [32392] ng30398
+-1-- 1
+1-1- 1
+0--1 1
+.names ng25917 [4669] [32395] [32396] ng31871
+---1 1
+1-1- 1
+-11- 1
+.names pg35 ng2028 [4663] [32401] ng33000
+--1- 1
+---1 1
+01-- 1
+.names [4659] [4660] [32406] ng29241
+1-- 1
+-1- 1
+--1 1
+.names [4652] [4653] [32423] [32424] ng29234
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng5817 ng5821 ng10869 ng25733
+01-- 1
+1-01 1
+1-10 1
+.names ng23975 [32431] [32432] [32434] ng29222
+---1 1
+01-- 1
+1-1- 1
+.names pg35 ng2841 ng4064 ng4057 ng25686
+0-1- 1
+1101 1
+1110 1
+.names pg35 ng2661 ng2657 ng25439 ng30385
+0-1- 1
+11-1 1
+10-0 1
+.names pg35 ng2960 ng2970 ng34623
+01- 1
+1-1 1
+.names ng31950 [4633] [32443] [32445] ng34457
+-1-- 1
+0-1- 1
+0--1 1
+.names pg35 ng29503 [32450] [32453] ng34441
+---1 1
+111- 1
+.names ng13898 [4626] [32454] [32455] ng30420
+-1-- 1
+1-1- 1
+0--1 1
+.names ng33851 [30331] [32459] [32460] ng34790
+---1 1
+101- 1
+.names pg35 ng3853 ng34627
+11 1
+.names pg35 ng4072 ng2941 [32462] ng34806
+---1 1
+11-- 1
+1-1- 1
+.names pg35 ng4722 ng4737 ng34637
+01- 1
+1-1 1
+.names ng29694 [4608] [32464] [32468] ng34263
+-1-- 1
+---1 1
+1-1- 1
+.names ng28349 ng13486 [32472] [32473] ng34041
+---1 1
+111- 1
+.names [4596] [4598] [32488] [32489] ng28090
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng12692 [4595] [32493] [32498] ng25669
+-1-- 1
+---1 1
+1-1- 1
+.names [32513] [32514] [32515] ng28084
+1-- 1
+-1- 1
+--1 1
+.names pg35 ng2472 [4583] [4584] ng33593
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng4917 ng34638
+11 1
+.names ng30298 [4581] [4582] [32522] ng33975
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng3179 ng25648
+11 1
+.names pg35 ng749 [4577] [4578] ng32979
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng102 ng1211 ng24242
+11- 1
+0-1 1
+.names [32535] [32536] ng32990
+1- 1
+-1 1
+.names ng20000 [32540] [32541] ng26894
+--1 1
+01- 1
+.names pg35 ng94 ng2848 ng22585 ng34792
+01-- 1
+1-1- 1
+1--1 1
+.names pg35 ng1548 ng1564 ng1430 ng24262
+01-- 1
+101- 1
+1-10 1
+1101 1
+.names ng13284 [4550] [32550] [32551] ng25627
+-1-- 1
+1-1- 1
+0--1 1
+.names [4538] [4539] [4540] [4541] ng29272
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng28336 ng13464 [32562] [32563] ng34033
+---1 1
+111- 1
+.names [4531] [4532] [4533] [4534] ng29292
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng30304 [4528] [4530] [32572] ng33984
+-1-- 1
+--1- 1
+1--1 1
+.names pg64 pg35 ng753 ng24213
+11- 1
+-01 1
+.names ng12512 [4525] [32574] [32575] ng30518
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng4087 [4517] [4518] ng30456
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng2625 [4514] [32586] ng33017
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng718 ng661 ng20248 ng28052
+01-- 1
+-1-0 1
+1-11 1
+.names ng24609 [4509] [32590] [32592] ng30347
+-1-- 1
+0-1- 1
+0--1 1
+.names ng30307 [4505] [4506] [32595] ng34004
+-1-- 1
+--1- 1
+1--1 1
+.names ng34162 [31938] [32600] [32601] ng34850
+---1 1
+011- 1
+.names pg35 ng2661 [4494] [4495] ng33604
+--1- 1
+---1 1
+01-- 1
+.names ng29001 [4493] [32606] ng33600
+-1- 1
+1-1 1
+.names pg35 ng4473 ng4467 ng4462 ng26969
+0--1 1
+100- 1
+.names ng30293 [4488] [4489] [32609] ng33969
+-1-- 1
+--1- 1
+1--1 1
+.names pg6745 pg35 ng26880
+11 1
+.names ng10632 [4486] [32612] [32613] ng26902
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng608 [4477] [4478] ng34599
+--1- 1
+---1 1
+01-- 1
+.names ng8806 ng14279 [32621] [32623] ng25617
+---1 1
+101- 1
+.names ng11607 [4466] [4467] [32624] ng25614
+-1-- 1
+--1- 1
+0--1 1
+.names pg6749 pg35 ng4486 ng26962
+11- 1
+-01 1
+.names ng29737 [4462] [32628] [32632] ng34269
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 ng2671 [4456] [4457] ng33606
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng2527 [4445] [4446] ng33596
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng2922 ng2936 ng34620
+01- 1
+1-1 1
+.names ng15024 [4439] [32638] [32639] ng30536
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 ng316 ng305 ng311 ng26882
+01-- 1
+1-1- 1
+1--1 1
+.names ng15748 [4430] [32642] [32647] ng25632
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 ng661 ng728 ng20248 ng28054
+01-- 1
+-1-0 1
+1-11 1
+.names ng29495 [32652] [32654] [32656] ng33992
+---1 1
+01-- 1
+1-1- 1
+.names [4415] [32664] ng28048
+1- 1
+-1 1
+.names pg35 ng5689 ng5694 ng10160 ng24343
+0-1- 1
+-01- 1
+--11 1
+.names ng4527 ng12228 [32665] [32667] ng26964
+---1 1
+011- 1
+101- 1
+.names ng30304 [4404] [4406] [32670] ng33982
+-1-- 1
+--1- 1
+1--1 1
+.names ng29073 [4403] [32675] [32677] ng33625
+-1-- 1
+0-1- 1
+0--1 1
+.names pg35 ng5128 ng5134 ng23590 ng29282
+01-- 1
+-1-0 1
+1-11 1
+.names pg35 ng4076 ng13217 [32683] ng28070
+---1 1
+111- 1
+100- 1
+.names pg35 ng1495 ng1489 ng10939 ng24250
+0-1- 1
+--10 1
+11-1 1
+.names pg35 ng5160 ng34643
+11 1
+.names pg35 pg7916 ng1189 [32689] ng24237
+---1 1
+101- 1
+.names pg35 ng441 ng437 ng8806 ng24206
+01-- 1
+-1-0 1
+1-11 1
+.names pg35 ng5523 ng5511 ng28010 ng30480
+1000 1
+.names ng14085 [4378] [32694] [32695] ng30455
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 ng6181 ng6187 ng10874 ng25748
+01-- 1
+-1-1 1
+1-10 1
+.names pg35 ng911 [4367] [4368] ng30336
+--1- 1
+---1 1
+01-- 1
+.names ng12450 [4366] [32702] [32703] ng30497
+-1-- 1
+0-1- 1
+1--1 1
+.names [4359] [32707] ng32986
+1- 1
+-1 1
+.names ng34550 [4355] [32710] [32711] ng34880
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 pg12919 ng1242 ng24245
+11- 1
+0-1 1
+.names [32717] [32718] ng33037
+1- 1
+-1 1
+.names ng29486 [32720] [32722] [32724] ng33999
+---1 1
+11-- 1
+0-1- 1
+.names [4335] [4336] [32740] [32741] ng29250
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng2756 ng25317 [32745] ng33019
+---1 1
+101- 1
+110- 1
+.names pg35 ng2509 [4319] [4320] ng33595
+--1- 1
+---1 1
+01-- 1
+.names [4315] [4316] [32751] ng34022
+1-- 1
+-1- 1
+--1 1
+.names ng15042 [4314] [32753] [32754] ng30557
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng3863 ng27635 [32757] ng33032
+01-- 1
+--01 1
+.names [4308] [32760] ng33602
+1- 1
+-1 1
+.names ng28471 [4306] [32762] [32764] ng33612
+-1-- 1
+0-1- 1
+0--1 1
+.names ng10632 [4303] [32766] [32767] ng26906
+-1-- 1
+0-1- 1
+1--1 1
+.names ng14170 [4300] [32769] [32770] ng30450
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng24591 [32775] ng30339
+--1 1
+11- 1
+.names ng31003 ng10831 [32779] [32780] ng34464
+---1 1
+101- 1
+.names ng14133 [4288] [32781] [32782] ng30428
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng4681 ng31003 ng34028
+01- 1
+-11 1
+.names ng13915 [4283] [32784] [32785] ng30401
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 ng2047 [4278] [4279] ng33569
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng5869 ng5857 ng28020 ng30501
+1000 1
+.names ni30751 [30176] [30177] [30181] ng33204
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng79 ng550 ng534 ng34720
+10-- 1
+1-1- 1
+0--1 1
+.names pg35 ng283 ng278 ng23204 ng28043
+0-1- 1
+10-1 1
+.names ng17625 ng12377 [32795] [32798] ng26930
+---1 1
+101- 1
+.names pg35 pg8358 ng222 ng11737 ng25592
+0-1- 1
+11-1 1
+10-0 1
+.names pg35 ng6044 [4253] [4254] ng33622
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng4082 ng10808 [32808] ng26938
+---1 1
+101- 1
+110- 1
+.names ng19140 [4248] [32810] [32811] ng28058
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng5523 ng5527 ng28010 ng33054
+01-- 1
+-100 1
+1010 1
+.names ng14915 [4242] [32817] [32818] ng30464
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 ng1283 ng1287 ng19422 ng34731
+---1 1
+01-- 1
+1-1- 1
+.names [4233] [4234] [4235] [4236] ng33551
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng5170 ng27999 [32830] ng33048
+01-- 1
+--01 1
+.names [4227] [4228] [32834] ng26925
+1-- 1
+-1- 1
+--1 1
+.names ng14627 [4226] [32836] [32837] ng30465
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 ng4284 ng4180 ng13539 ng29274
+11-0 1
+1-00 1
+1011 1
+.names ng30307 [4220] [4221] [32842] ng34002
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng3050 ng3338 ng25649
+01- 1
+1-1 1
+.names pg35 ng324 ng311 [32846] ng26887
+---1 1
+110- 1
+.names pg35 ng6523 ng6527 ng23733 ng29308
+01-- 1
+1-11 1
+1-00 1
+.names ng29008 [4210] [32851] [32853] ng33621
+-1-- 1
+0-1- 1
+0--1 1
+.names ng14157 [4207] [32855] [32856] ng30449
+-1-- 1
+0-1- 1
+1--1 1
+.names ng23042 [28708] [32860] [32861] ng31864
+---1 1
+111- 1
+.names pg35 ng1624 [4199] [32865] ng32988
+--1- 1
+---1 1
+01-- 1
+.names ng15008 [4197] [32866] [32867] ng30535
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng1798 [4191] [32873] ng32993
+--1- 1
+---1 1
+01-- 1
+.names ng29313 [4189] [4190] [32874] ng34019
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng3689 ng3401 ng25663
+11- 1
+0-1 1
+.names pg35 ng278 ng11144 [32878] ng25594
+--01 1
+110- 1
+.names pg35 ng6390 [4176] [4177] ng33624
+--1- 1
+---1 1
+01-- 1
+.names ng28504 [4175] [32884] [32885] ng33539
+-1-- 1
+1-1- 1
+0--1 1
+.names ng25337 [4172] [32887] [32891] ng30348
+-1-- 1
+---1 1
+0-1- 1
+.names ng24875 [4168] [32893] [32894] ng30335
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng1495 ng1442 ng10939 ng24251
+01-- 1
+-1-0 1
+1-11 1
+.names [4157] [4158] [32913] [32914] ng29239
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng28942 [4156] [32919] ng33584
+-1- 1
+1-1 1
+.names ng14130 [4154] [32921] [32922] ng30419
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 ng681 ng645 ng20248 ng28047
+0-1- 1
+--10 1
+11-1 1
+.names pg35 ng3512 ng27617 [32927] ng33027
+01-- 1
+--01 1
+.names pg35 ng3831 [4144] [4145] ng29273
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng182 ng174 ng11676 ng25601
+01-- 1
+-1-0 1
+1-11 1
+.names pg35 ng29503 [32936] [32939] ng34442
+---1 1
+111- 1
+.names ng12578 [4133] [32940] [32941] ng30539
+-1-- 1
+0-1- 1
+1--1 1
+.names [30033] [30034] [30052] [30053] ng33187
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng10632 [4127] [32943] [32944] ng26905
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng5176 ng5164 ng27999 ng30459
+1000 1
+.names ng25476 [4124] [32949] [32953] ng30378
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 ng4473 ng4459 ng26970
+11- 1
+0-1 1
+.names ng28458 [4118] [32955] [32957] ng33610
+-1-- 1
+0-1- 1
+0--1 1
+.names pg35 ng1263 ng25895 [32961] ng31870
+---1 1
+100- 1
+.names ng31003 ng10831 [32965] [32966] ng34463
+---1 1
+101- 1
+.names [4106] [4107] [4108] [4109] ng33575
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [29520] [29521] [32975] [32976] ng26957
+---1 1
+111- 1
+.names pg35 ng568 [4100] [4101] ng28045
+--1- 1
+---1 1
+01-- 1
+.names ng28484 ng23342 [32983] [32985] ng33614
+---1 1
+011- 1
+.names pg35 ng843 [4094] [4095] ng26898
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng3614 [4068] [4069] ng28066
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng429 ng401 ng8806 ng24203
+01-- 1
+-1-0 1
+1-11 1
+.names ng23978 [4064] [33054] [33055] ng29224
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 ng2393 ng2389 ng25349 ng30375
+0-1- 1
+11-1 1
+10-0 1
+.names pg35 ng2595 [4051] [33065] ng33015
+--1- 1
+---1 1
+01-- 1
+.names ng14773 [4050] [33066] [33067] ng30529
+-1-- 1
+0-1- 1
+1--1 1
+.names ng30311 [4045] [4047] [33070] ng33990
+-1-- 1
+--1- 1
+1--1 1
+.names ng11676 [4044] [33072] [33073] ng25605
+-1-- 1
+0-1- 1
+1--1 1
+.names ng14069 [4041] [33075] [33076] ng30406
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 ng222 ng136 ng199 ng34721
+11-- 1
+0-1- 1
+1--1 1
+.names [4034] [33081] ng25695
+1- 1
+-1 1
+.names pg35 ng17694 ng17727 [33083] ng34808
+---1 1
+11-- 1
+1-1- 1
+.names ng1395 ng13134 [33087] [33088] ng26921
+---1 1
+0-1- 1
+-11- 1
+.names ng33851 [4025] [33090] [33091] ng34724
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng3161 ng3155 ng27602 ng33021
+0-1- 1
+-010 1
+1100 1
+.names [4016] [4017] [4018] [4019] ng33557
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng1950 [4011] [4012] ng33563
+--1- 1
+---1 1
+01-- 1
+.names ng23324 [4007] [33105] [33107] ng29225
+-1-- 1
+0-1- 1
+0--1 1
+.names [4003] [33111] ng32984
+1- 1
+-1 1
+.names ng14732 [4001] [33112] [33113] ng30508
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 ng29503 [33118] [33121] ng34444
+---1 1
+111- 1
+.names ng12716 ng12680 [33123] [33124] ng30547
+---1 1
+0-1- 1
+-01- 1
+.names ng13806 [33126] [33128] [33129] ng28073
+---1 1
+0-1- 1
+-11- 1
+.names ng10869 [3988] [33131] [33136] ng25735
+-1-- 1
+---1 1
+1-1- 1
+.names ng11483 ng11571 [33138] [33139] ng30417
+---1 1
+111- 1
+.names pg35 ng1682 [3979] [3980] ng33547
+--1- 1
+---1 1
+01-- 1
+.names [3975] [3976] [3977] [3978] ng33549
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng10823 [3974] [33150] [33155] ng25707
+-1-- 1
+---1 1
+1-1- 1
+.names pg35 ng2066 [3967] [33160] ng33001
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng5041 [3961] [3962] ng31901
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng4515 [6826] [6827] ng33616
+01-- 1
+1-00 1
+.names ng14051 [3958] [33165] [33166] ng30434
+-1-- 1
+0-1- 1
+1--1 1
+.names ng14800 [3955] [33168] [33169] ng30479
+-1-- 1
+1-1- 1
+0--1 1
+.names ng30583 [3952] [33172] [33174] ng34258
+-1-- 1
+0-1- 1
+0--1 1
+.names pg35 ng2975 ng18597
+01 1
+.names ng14918 [3946] [33176] [33177] ng30473
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 ng4297 ng4300 ng4242 ng34735
+01-- 1
+1-1- 1
+1--1 1
+.names ng30307 [3939] [3940] [33180] ng34007
+-1-- 1
+--1- 1
+1--1 1
+.names pg6750 pg35 ng4489 ng26963
+11- 1
+-01 1
+.names pg35 ng3881 ng25676
+11 1
+.names ng14024 [3932] [33183] [33184] ng30453
+-1-- 1
+0-1- 1
+1--1 1
+.names [3926] [3927] [3928] [3929] ng24336
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng1894 [3922] [33211] ng32996
+--1- 1
+---1 1
+01-- 1
+.names ng14895 [3921] [33212] [33213] ng30521
+-1-- 1
+0-1- 1
+1--1 1
+.names ng14810 [3918] [33215] [33216] ng30510
+-1-- 1
+1-1- 1
+0--1 1
+.names ng14993 [3915] [33218] [33219] ng30495
+-1-- 1
+0-1- 1
+1--1 1
+.names [6804] [6805] [33225] [33227] ng34023
+---1 1
+001- 1
+.names pg35 ng446 ng417 ng8806 ng24209
+1-11 1
+11-0 1
+.names ng30293 [3905] [3906] [33230] ng33972
+-1-- 1
+--1- 1
+1--1 1
+.names ng30311 [3902] [3903] [33233] ng33993
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng2116 ng2122 ng25389 ng30366
+01-- 1
+-1-0 1
+1-11 1
+.names ng30314 [3895] [3897] [33239] ng34014
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng4153 [3894] ng26940
+--1 1
+01- 1
+.names ng15014 [3892] [33241] [33242] ng30555
+-1-- 1
+1-1- 1
+0--1 1
+.names ng11527 ng11571 [33245] [33246] ng30418
+---1 1
+111- 1
+.names ng28353 [28711] [33249] [33250] ng33960
+---1 1
+101- 1
+.names ng14735 [3883] [33251] [33252] ng30517
+-1-- 1
+0-1- 1
+1--1 1
+.names ng14947 [3880] [33254] [33255] ng30553
+-1-- 1
+0-1- 1
+1--1 1
+.names ng11130 ng11148 [33259] [33261] ng25629
+---1 1
+101- 1
+.names ng12405 ng12492 [33263] [33264] ng30462
+---1 1
+0-1- 1
+-01- 1
+.names ng29485 [33266] [33268] [33270] ng33978
+---1 1
+11-- 1
+0-1- 1
+.names [3853] [3854] [3855] [3856] ng33589
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng947 ng962 ng952 ng34726
+01-- 1
+1-0- 1
+1--1 1
+.names [33286] [33287] ng33006
+1- 1
+-1 1
+.names ng15018 [3845] [33288] [33289] ng30516
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng2130 ng34603
+11 1
+.names pg35 ng817 [3837] [3838] ng25618
+--1- 1
+---1 1
+01-- 1
+.names ng17625 ng12377 [33296] [33299] ng26933
+---1 1
+101- 1
+.names pg35 ng6044 ng6035 ng10185 ng24346
+0-1- 1
+100- 1
+10-1 1
+.names pg35 ng1768 [3828] [33306] ng32991
+--1- 1
+---1 1
+01-- 1
+.names ng25396 [3827] [33308] [33312] ng30368
+-1-- 1
+---1 1
+1-1- 1
+.names pg35 pg12919 ng1236 ng24243
+11- 1
+0-1 1
+.names [3821] [33316] [33317] ng31896
+1-- 1
+-1- 1
+--1 1
+.names ng13983 [3816] [33319] [33320] ng30423
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng5467 ng5503 ng10838 ng25722
+0-1- 1
+--11 1
+11-0 1
+.names ng27020 [3810] [33325] [33327] ng34454
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 ng1902 [3804] [33334] ng32995
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng6657 [3801] [3802] ng28105
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng5857 ng5863 ng28020 ng33057
+01-- 1
+-100 1
+1010 1
+.names pg35 pg9817 ng6444 [33343] ng25758
+---1 1
+101- 1
+.names ng14758 [3791] [33344] [33345] ng30478
+-1-- 1
+0-1- 1
+1--1 1
+.names [3786] [3787] [33351] ng29251
+1-- 1
+-1- 1
+--1 1
+.names [3782] [33354] ng28082
+1- 1
+-1 1
+.names ng10939 [3780] [33355] [33357] ng24249
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 pg8839 ng4281 ng4245 ng21896
+0--1 1
+110- 1
+100- 1
+.names pg35 ng3343 ng3338 ng8691 ng24270
+01-- 1
+-10- 1
+-1-1 1
+.names pg35 ng2259 [3771] [3772] ng33580
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng1968 [3768] [3769] ng33564
+--1- 1
+---1 1
+01-- 1
+.names [3762] [3763] [33370] ng29232
+1-- 1
+-1- 1
+--1 1
+.names ng30314 [3760] [3761] [33373] ng34008
+-1-- 1
+--1- 1
+1--1 1
+.names [3755] [3756] [3757] [3758] ng33565
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng6381 ng6386 ng10207 ng24351
+0-1- 1
+-01- 1
+--11 1
+.names ng11514 ng11435 [33383] [33384] ng30396
+---1 1
+111- 1
+.names ng30298 [3746] [3747] [33385] ng33979
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng2675 ng2681 ng25439 ng30386
+01-- 1
+-1-0 1
+1-11 1
+.names pg35 ng2407 ng2413 ng25349 ng30376
+01-- 1
+-1-0 1
+1-11 1
+.names pg35 ng5348 ng5343 ng10124 ng24339
+01-- 1
+-10- 1
+-1-1 1
+.names ng14822 [3736] [33392] [33393] ng30550
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng2697 ng2704 ng34608
+01- 1
+1-1 1
+.names [3729] [3730] [33399] ng29249
+1-- 1
+-1- 1
+--1 1
+.names [33407] [33408] ng33010
+1- 1
+-1 1
+.names [3720] [3721] [3722] [3723] ng29280
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng14848 [3719] [33416] [33417] ng30491
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng2735 ng17297 [33421] ng29256
+---1 1
+111- 1
+100- 1
+.names ng31003 ng10831 [33426] [33427] ng34461
+---1 1
+101- 1
+.names [3704] [3705] [33443] [33444] ng29231
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng542 ng301 ng534 ng34723
+01-- 1
+1-1- 1
+1--1 1
+.names pg35 pg7946 ng1339 [33450] ng24252
+---1 1
+111- 1
+.names pg35 ng767 [3695] [3696] ng34252
+--1- 1
+---1 1
+01-- 1
+.names ng29313 [3693] [3694] [33456] ng34015
+-1-- 1
+--1- 1
+1--1 1
+.names ng14110 [3691] [33459] [33460] ng30427
+-1-- 1
+0-1- 1
+1--1 1
+.names ng28444 [3688] [33463] [33464] ng33535
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 pg12919 ng904 ng921 ng25621
+0-1- 1
+-110 1
+1101 1
+.names pg35 ng3518 ng3522 ng27617 ng33028
+01-- 1
+-100 1
+1010 1
+.names pg35 ng1373 [3677] [3678] ng33543
+--1- 1
+---1 1
+01-- 1
+.names ng14761 [3676] [33475] [33476] ng30489
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng1339 ng16272 ng8476 ng24256
+01-- 1
+1-11 1
+1-00 1
+.names pg35 ng4264 ng4258 ng21894
+0-1 1
+-01 1
+110 1
+.names ng14974 [3667] [33485] [33486] ng30534
+-1-- 1
+1-1- 1
+0--1 1
+.names [3658] [3659] [33492] ng34807
+1-- 1
+-1- 1
+--1 1
+.names ng23067 [3657] [33494] [33497] ng29258
+-1-- 1
+---1 1
+0-1- 1
+.names ng25275 [3653] [33499] [33503] ng30352
+-1-- 1
+---1 1
+0-1- 1
+.names ng23699 [3649] [33505] [33509] ng29301
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 ng4584 [3643] [3644] ng34452
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng25911 [7652] [33517] ng31869
+---1 1
+101- 1
+.names pg35 pg8719 ng385 ng376 ng25599
+0-1- 1
+1111 1
+.names ng27670 [3635] [33519] [33520] ng33046
+-1-- 1
+0-1- 1
+1--1 1
+.names ng28336 ng13464 [33525] [33526] ng34031
+---1 1
+111- 1
+.names ng14804 [3629] [33527] [33528] ng30490
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 ng5507 ng34644
+11 1
+.names pg35 ng460 ng452 ng11676 ng25604
+01-- 1
+-1-0 1
+1-11 1
+.names pg35 ng794 [3618] [3619] ng34881
+--1- 1
+---1 1
+01-- 1
+.names ng30293 [3616] [3617] [33537] ng33966
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng4639 ng4621 ng31950 ng34460
+01-- 1
+-100 1
+1010 1
+.names pg35 ng1152 ng1099 ng10909 ng24235
+01-- 1
+-1-0 1
+1-11 1
+.names ng30311 [3607] [3608] [33544] ng33991
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng4235 [3600] [3601] ng24279
+--1- 1
+---1 1
+01-- 1
+.names ng2735 ng17297 [33560] [33561] ng30388
+---1 1
+0-1- 1
+-11- 1
+.names pg35 ng2223 [3594] [33566] ng33005
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng6215 ng6219 ng26977 ng33064
+01-- 1
+-100 1
+1010 1
+.names pg35 ng1710 [3584] [3585] ng33550
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng1964 ng1968 ng25341 ng30360
+01-- 1
+1-11 1
+1-00 1
+.names pg35 ng4871 ng31009 ng34036
+01- 1
+-11 1
+.names ng8691 [3578] [33579] [33580] ng24267
+-1-- 1
+1-11 1
+.names pg35 ng4284 ng4180 ng14227 ng29291
+11-0 1
+1-00 1
+1011 1
+.names ng27629 [28803] [33591] [33592] ng33538
+---1 1
+101- 1
+.names ng11747 ng11571 [33594] [33595] ng30416
+---1 1
+0-1- 1
+-01- 1
+.names pg35 ng854 ng847 ng8806 ng24216
+01-- 1
+-1-0 1
+1-11 1
+.names ng10185 [3565] [33600] [33601] ng24344
+-1-- 1
+1-11 1
+.names ng30298 [3562] [3563] [33609] ng33973
+-1-- 1
+--1- 1
+1--1 1
+.names ng25473 [3560] [33613] [33617] ng30374
+-1-- 1
+---1 1
+0-1- 1
+.names [3549] [3551] [33632] [33633] ng29254
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [33641] [33642] ng33002
+1- 1
+-1 1
+.names pg35 ng4258 ng21893
+10 1
+.names ng14656 [3541] [33643] [33644] ng30466
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng4284 ng4180 ng13500 ng29262
+11-0 1
+1-00 1
+1011 1
+.names ng12798 ng12558 [33649] [33650] ng30482
+---1 1
+0-1- 1
+-01- 1
+.names ng13806 [33651] [33653] [33654] ng28074
+---1 1
+101- 1
+.names [3526] [33656] [33657] ng24248
+1-- 1
+-1- 1
+--1 1
+.names ng30293 [3521] [3522] [33660] ng33968
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng5849 ng5813 ng10869 ng25736
+01-- 1
+-1-1 1
+1-10 1
+.names pg35 ng4153 ng4172 ng34733
+11- 1
+1-1 1
+.names ng482 ng20000 [33666] [33668] ng29223
+---1 1
+0-1- 1
+-01- 1
+.names [3504] [3505] [3506] [3507] ng29263
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng2890 ng2844 ng34609
+01- 1
+1-1 1
+.names ng28336 ng16173 [33678] [33680] ng34032
+---1 1
+111- 1
+.names pg35 ng1291 ng34602
+11 1
+.names ng30314 [3497] [3498] [33681] ng34012
+-1-- 1
+--1- 1
+1--1 1
+.names ng14723 [3495] [33684] [33685] ng30477
+-1-- 1
+1-1- 1
+0--1 1
+.names ng25426 [3492] [33688] [33693] ng30354
+-1-- 1
+---1 1
+0-1- 1
+.names [29325] [29326] [33695] [33696] ng26945
+---1 1
+111- 1
+.names pg35 ng2984 ng2907 ng34617
+01- 1
+1-1 1
+.names [33699] [33700] ng24232
+1- 1
+-1 1
+.names [3468] [3470] [33715] [33716] ng29248
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng10160 [3464] [33720] [33721] ng24340
+-1-- 1
+1-11 1
+.names ng14940 [3462] [33728] [33729] ng30533
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng5176 ng5180 ng27999 ng33049
+01-- 1
+-100 1
+1010 1
+.names ng25888 [3456] [33735] [33736] ng31868
+-1-- 1
+0-1- 1
+1--1 1
+.names ng14933 [3453] [33738] [33739] ng30513
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng5511 ng5517 ng28010 ng33052
+01-- 1
+-100 1
+1010 1
+.names pg35 ng4249 ng4245 ng34632
+01- 1
+1-1 1
+.names pg35 ng2241 [3443] [3444] ng33579
+--1- 1
+---1 1
+01-- 1
+.names [33751] [33752] ng32998
+1- 1
+-1 1
+.names pg35 pg17423 pg12923 [33754] ng24255
+---1 1
+111- 1
+.names ng14082 [3435] [33755] [33756] ng30446
+-1-- 1
+1-1- 1
+0--1 1
+.names ng30298 [3431] [3432] [33759] ng33974
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng3506 ng3512 ng27617 ng33026
+01-- 1
+-100 1
+1010 1
+.names ng25514 [3426] [33765] [33770] ng30384
+-1-- 1
+---1 1
+0-1- 1
+.names ng29702 [3422] [33771] [33775] ng34267
+-1-- 1
+---1 1
+1-1- 1
+.names ng31509 [30328] [33778] [33779] ng34438
+---1 1
+011- 1
+.names ng30304 [3411] [3412] [33780] ng33983
+-1-- 1
+--1- 1
+1--1 1
+.names ng15737 [3408] [33786] [33789] ng25623
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 ng446 ng645 ng20248 ng28046
+1-11 1
+11-0 1
+.names ng8806 [3402] [33794] [33795] ng24200
+-1-- 1
+0-1- 1
+1--1 1
+.names ng23042 [3399] [33798] [33800] ng30333
+-1-- 1
+1-1- 1
+1--1 1
+.names [3393] [3394] [3395] [3396] ng33605
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng6561 ng6565 ng26994 ng33069
+01-- 1
+-100 1
+1010 1
+.names ng12609 ng12571 [33813] [33814] ng30505
+---1 1
+111- 1
+.names [3382] [3383] [33842] ng34882
+1-- 1
+-1- 1
+--1 1
+.names pg35 ng3155 ng3167 ng27602 ng30393
+1000 1
+.names ng14959 [3376] [33846] [33847] ng30494
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng4512 ng4531 ng4581 ng26971
+01-- 1
+1-0- 1
+1--0 1
+.names [3367] [3368] [3369] [33862] ng25613
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng14048 [3356] [33865] [33866] ng30425
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng2036 [3350] [33873] ng32999
+--1- 1
+---1 1
+01-- 1
+.names ng25439 [3349] [33875] [33879] ng30387
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 ng1772 [3343] [3344] ng33554
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng3484 ng3490 ng12692 ng25668
+01-- 1
+-1-1 1
+1-10 1
+.names pg35 ng3161 ng27602 [33886] ng33022
+01-- 1
+--01 1
+.names ng30307 [3336] [3337] [33888] ng34001
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng3849 ng3813 ng12735 ng25684
+01-- 1
+-1-1 1
+1-10 1
+.names pg35 ng1087 ng1205 ng24244
+01- 1
+-10 1
+101 1
+.names pg35 ng2185 [3326] [33898] ng33004
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng11292 ng21284 ng12332 ng25616
+1111 1
+1001 1
+1010 1
+1100 1
+.names pg35 ng4072 ng4172 ng4176 ng34734
+11-- 1
+0-1- 1
+1--1 1
+.names ng15021 [3307] [33902] [33903] ng30527
+-1-- 1
+1-1- 1
+0--1 1
+.names [3304] [33908] [33909] ng31897
+1-- 1
+-1- 1
+--1 1
+.names [3298] [31317] [31318] [31319] ng30389
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng6736 ng6727 ng10224 ng24354
+0-1- 1
+100- 1
+10-1 1
+.names ng13986 [3295] [33912] [33913] ng30432
+-1-- 1
+1-1- 1
+0--1 1
+.names ng24875 [28810] [33917] [33918] ng31867
+---1 1
+101- 1
+.names ng14691 [3289] [33919] [33920] ng30496
+-1-- 1
+1-1- 1
+0--1 1
+.names pg35 ng6199 ng34646
+11 1
+.names pg35 ng2084 [3284] [3285] ng33571
+--1- 1
+---1 1
+01-- 1
+.names pg35 ng6381 ng6098 ng25743
+11- 1
+0-1 1
+.names ng11626 ng11584 [33925] [33926] ng30439
+---1 1
+0-1- 1
+-01- 1
+.names [3276] [3278] [33927] ng34802
+1-- 1
+-1- 1
+--1 1
+.names [3271] [3272] [33943] [33944] ng29252
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [33949] [33950] [33954] [33955] ng24275
+11-- 1
+--11 1
+.names pg35 ng2338 [3257] [3258] ng33585
+--1- 1
+---1 1
+01-- 1
+.names ng10491 ng12716 [33961] [33962] ng30545
+---1 1
+0-1- 1
+-01- 1
+.names ng14981 [3253] [33963] [33964] ng30554
+-1-- 1
+0-1- 1
+1--1 1
+.names [33970] [33971] ng33043
+1- 1
+-1 1
+.names pg35 pg12923 ng1579 ng24259
+11- 1
+0-1 1
+.names ng28504 [28813] [33974] [33975] ng33965
+---1 1
+011- 1
+.names pg35 ng5881 ng25728
+11 1
+.names ng14902 [3237] [33976] [33977] ng30541
+-1-- 1
+1-1- 1
+0--1 1
+.names ng14116 [3234] [33979] [33980] ng30447
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng2741 [3229] [3230] ng31872
+--1- 1
+---1 1
+01-- 1
+.names ng25309 [3228] [33988] [33993] ng30372
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 ng3689 ng3694 ng8728 ng24274
+0-1- 1
+-01- 1
+--11 1
+.names pg6744 pg35 ng305 ng26881
+11- 1
+-01 1
+.names pg35 ng13242 [5491] [33996] ng25633
+---1 1
+101- 1
+.names pg35 ng5853 ng34645
+11 1
+.names ng14764 [3215] [33997] [33998] ng30498
+-1-- 1
+0-1- 1
+1--1 1
+.names ng14813 [3212] [34000] [34001] ng30519
+-1-- 1
+0-1- 1
+1--1 1
+.names ng23630 [3209] [34004] [34007] ng29287
+-1-- 1
+---1 1
+0-1- 1
+.names ng30300 [3203] [3205] [34010] ng33995
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng5138 ng5152 ng20841
+11- 1
+1-1 1
+.names pg35 ng6191 ng6177 ng21193
+11- 1
+1-1 1
+.names pg35 ng5485 ng5499 ng20982
+11- 1
+1-1 1
+.names ng21193 ng20982 ng21127 ng21256 ni24685
+0000 1
+.names pg35 ng3480 ng3494 ng19968
+11- 1
+1-1 1
+.names pg35 ng3845 ng3831 ng20014
+11- 1
+1-1 1
+.names pg35 ng3143 ng3129 ng19919
+11- 1
+1-1 1
+.names pg35 ng5831 ng5845 ng21127
+11- 1
+1-1 1
+.names pg35 ng6537 ng6523 ng21256
+11- 1
+1-1 1
+.names pg35 ng1312 ng1351 ng1536 ng19422
+1--0 1
+100- 1
+.names pg35 ng969 ng1193 ng1008 ng19402
+1-0- 1
+10-0 1
+.names pg35 ng3817 ng19984
+11 1
+.names pg35 ng4427 ng4420 ng26365
+11- 1
+1-1 1
+.names [31890] [31891] [31892] [31893] ng17657
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [31896] [31897] [31898] [31899] ng17700
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng30735 [29984] [29985] [34142] ni31106
+0001 1
+.names pg54 pg53 ng17653 [29926] ng30937
+1011 1
+.names [29948] [29949] [29950] ng31021
+1-- 1
+-1- 1
+--1 1
+.names ng27511 ng17613 ng17747 [29985] ng31376
+---1 1
+11-- 1
+1-1- 1
+.names ng31 ng28 ng13156 [30042] ng30673
+0111 1
+.names ng31 ng28 ng13156 [30045] ng30614
+0011 1
+.names ng30735 [29984] [29985] [34136] ni31271
+0001 1
+.names ng31 ng28 ng13156 [30000] ng30735
+0111 1
+.names pg54 pg53 [29926] ng28180
+-1- 1
+101 1
+.names ng30735 [29984] [29985] [34130] ni31191
+1001 1
+.names ng30735 [29984] [29985] [34154] ni31121
+0001 1
+.names ng30735 [29984] [29985] [34124] ni31141
+01-1 1
+0-11 1
+.names ng30735 [29984] [29985] [34118] ni30330
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [29984] [29985] [34149] ni31221
+001 1
+.names ng31 ng28 ng13156 [29997] ng31327
+0111 1
+.names [30696] [30697] [30698] [30699] ng17694
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [30702] [30703] [30704] [30705] ng17727
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng31 ng28 ng13156 [29962] ng31566
+0011 1
+.names ng31 ng28 ng13156 [29966] ng31710
+1011 1
+.names [3165] [3166] [34198] [34199] ng34237
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng30614 ng31070 [34201] [34206] ng33496
+0011 1
+.names ng31566 [29984] [29985] [34239] ni31171
+1001 1
+.names ng30937 [29948] [29949] [29950] ng31070
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [3155] [3156] [3157] [3158] ni31843
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ni31843 [3151] [3152] [34248] ng34235
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng25590
+ 1
+.names ng43 ng29503 ng24688 [28470] ng26977
+1111 1
+.names ng4322 ng4311 ng10511 ng8347 ng18935
+1100 1
+.names ng110 ng29503 ng25357 [28503] ng27903
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng14367 [7725] [28488] ng22472
+-1- 1
+1-1 1
+.names pg35 ng4423 ng26390
+11 1
+.names ng1193 ng10666 [7709] [28519] ng24591
+0-1- 1
+-11- 1
+0--1 1
+-1-1 1
+.names ng3171 ng3179 ng3161 ng3155 ng13977
+0--- 1
+-1-- 1
+--0- 1
+---1 1
+.names pg99 pg134 pg113 ng37 ng29503
+-10- 1
+1-01 1
+.names ng24374 ng11834 ng11283 [28575] ng29676
+-11- 1
+1--0 1
+.names [1421] ng4818 ng71 ng24374 ng30590
+0011 1
+.names ng385 ng358 ng370 ng376 ng8806
+0--- 1
+-0-- 1
+---0 1
+1101 1
+.names ng896 ng862 ng890 ng10632
+001 1
+.names ng11111 [7624] [7625] [28651] ng23590
+0--- 1
+-000 1
+.names ng43 ng29503 ng24688 [28661] ng27635
+1111 1
+.names ng112 ng29503 ng26314 [28687] ng28761
+1111 1
+.names ng43 ng29503 ng24688 [28694] ng27602
+1111 1
+.names ng385 ng358 ng370 ng376 ng11676
+0--- 1
+-0-- 1
+--1- 1
+---0 1
+.names ng153 ng157 ng23042 ng28353 ng31134
+1111 1
+.names [28543] [28544] [28706] [28707] ng23042
+001- 1
+00-1 1
+.names ng1361 ng1345 ng7601 ng15748 ng25917
+--1- 1
+0--0 1
+-0-0 1
+.names ng6573 ng6555 ng6549 ng6565 ng14868
+0--- 1
+-1-- 1
+--0- 1
+---0 1
+.names pg14694 pg17580 pg17711 pg12300 ng10160
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng11139 [7351] [7352] [28734] ng23666
+0--- 1
+-000 1
+.names pg13272 ng1514 ng1526 ng10939
+0-- 1
+-1- 1
+--1 1
+.names ng1312 ng1351 ng1536 ng1319 ng13378
+1-10 1
+-110 1
+.names ng305 ng324 ng311 ng13385
+11- 1
+-01 1
+.names ng385 ng358 ng376 ng11607
+110 1
+.names ng4180 ng1242 ng24457 [7269] ng30304
+--1- 1
+0--1 1
+-100 1
+.names ng14367 [7257] [28834] [28836] ng25385
+---1 1
+00-- 1
+-00- 1
+.names ng11160 [7248] [7249] [28843] ng23699
+0--- 1
+-000 1
+.names ng4180 ng1585 ng24447 [7306] ng30300
+--1- 1
+0--1 1
+-100 1
+.names ng14367 [7257] [28834] ng22369
+-1- 1
+1-1 1
+.names ng110 ng29503 ng12377 ng25357 ng27775
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng6209 ng6227 ng6203 ng6219 ng15036
+0--- 1
+-0-- 1
+--0- 1
+---1 1
+.names ng3530 ng3518 ng3522 ng12692
+111 1
+.names ng528 ng11607 ng11185 ng12812 ng20000
+11-1 1
+-111 1
+.names ng14367 [7257] [28834] [28887] ng25300
+---1 1
+00-- 1
+-00- 1
+.names ng1783 ng1760 ng12371
+10 1
+.names ng1536 ng10699 [7193] [28903] ng24609
+0-1- 1
+-11- 1
+0--1 1
+-1-1 1
+.names ng3873 ng3881 ng3869 ng14058
+1-- 1
+-0- 1
+--0 1
+.names ng5535 ng5511 ng5527 ng5517 ng14885
+0--- 1
+-1-- 1
+--0- 1
+---0 1
+.names [7137] [7138] [28996] ng20887
+1-- 1
+-1- 1
+--1 1
+.names ng3873 ng3881 ng3869 ng12735
+111 1
+.names ng4180 ng1242 ng24468 [7126] ng30311
+--1- 1
+0--1 1
+-000 1
+.names ng2756 ng2735 ng2741 ng2748 ng17625
+10-- 1
+1-0- 1
+0--1 1
+-0-1 1
+--01 1
+1--0 1
+.names ng2756 ng2741 ng2748 ng12377
+010 1
+.names ng63 ng29503 ng24380 [28640] ng31003
+0--- 1
+-0-- 1
+--1- 1
+---0 1
+.names ng63 ng29503 ng24380 [28640] ng28336
+0--- 1
+-0-- 1
+--1- 1
+---0 1
+.names ng4785 ng4793 ng4776 ng10831 ng16173
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng43 ng29503 ng24688 [29495] ng28010
+1111 1
+.names pg13259 ng1171 ng1183 ng13307
+0-- 1
+-0- 1
+--0 1
+.names ng6573 ng6555 ng6549 ng6565 ng15039
+1--- 1
+-1-- 1
+--0- 1
+---1 1
+.names ng5188 ng5170 ng5164 ng5180 ng14683
+0--- 1
+-1-- 1
+--0- 1
+---0 1
+.names ng5041 ng5046 [29549] ng25371
+111 1
+.names ng5869 ng5881 ng5873 ng14858
+0-- 1
+-0- 1
+--1 1
+.names ng3857 ng3863 ng3869 ng11626
+000 1
+.names ng3873 ng3881 ng11537
+01 1
+.names ng6573 ng6565 ng7142
+00 1
+.names ng6573 ng6555 ng6549 ng6565 ng14905
+1--- 1
+-0-- 1
+--1- 1
+---1 1
+.names ng947 ng956 ng10925
+01 1
+.names ng947 ng956 [7608] [7609] ng24468
+--1- 1
+---1 1
+01-- 1
+.names ng10925 [7126] [7608] [7609] ng26759
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng32212 [28816] [29718] [29789] ng34162
+0--- 1
+-1-- 1
+--0- 1
+---1 1
+.names ng5881 ng5873 ng10312
+00 1
+.names ng5869 ng5857 ng5863 ng12609
+000 1
+.names ng5881 ng5873 ng12515
+10 1
+.names ng3873 ng3881 ng8958
+00 1
+.names ng3873 ng3881 ng3869 ng11534
+1-- 1
+-1- 1
+--0 1
+.names ng1514 ng1526 ng10715
+11 1
+.names pg13272 ng1514 ng1526 ng13315
+0-- 1
+-0- 1
+--0 1
+.names ng5881 ng5873 ng12824
+01 1
+.names ng5881 ng5873 ng5857 ng5863 ng14697
+1--- 1
+-0-- 1
+--0- 1
+---1 1
+.names [29507] [29508] ng28140
+1- 1
+-1 1
+.names pg73 pg72 ng27972
+1- 1
+-1 1
+.names ng14367 [7030] [29111] ng22432
+-1- 1
+1-1 1
+.names ng2342 ng2319 ng12437
+10 1
+.names ng12437 ng14367 [7030] [29111] ng25473
+0--- 1
+-00- 1
+--00 1
+.names ng6573 ng6565 ng10491
+01 1
+.names ng6573 ng6555 ng6549 ng6565 ng14947
+1--- 1
+-0-- 1
+--1- 1
+---0 1
+.names ng31 ng28 ng13156 [29982] ng17766
+1011 1
+.names ng31 ng28 ng13156 [29980] ng17613
+0011 1
+.names ng31 ng28 ng13156 [29978] ng17747
+0011 1
+.names ng31 ng28 ng13156 [29976] ng17724
+1111 1
+.names ng31 ng28 ng13156 [29974] ng17690
+0111 1
+.names pg99 pg134 ng37 ng24374
+-1- 1
+1-1 1
+.names [7351] [7352] [28734] ng20875
+1-- 1
+-1- 1
+--1 1
+.names ng6049 [7351] [7352] [28734] ng23932
+0--- 1
+-000 1
+.names ng27629 [28803] [28804] [30327] ng31509
+0--- 1
+-1-- 1
+--0- 1
+---1 1
+.names ng5881 ng5873 ng12571
+11 1
+.names ng5881 ng5873 ng5857 ng5863 ng14735
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng1936 ng1862 ng9694
+00 1
+.names pg73 pg72 ng482 ng490 ng26314
+1111 1
+1001 1
+0110 1
+0000 1
+.names ng504 ng518 ng528 ng26314 ng27494
+0111 1
+.names ng31 ng28 ng13156 ni18740
+001 1
+.names ng1448 ng1291 ng10967
+10 1
+.names ng5869 ng5881 ng5873 ng12512
+0-- 1
+-1- 1
+--1 1
+.names ng6573 ng6565 ng12632
+10 1
+.names ng6573 ng6561 ng6565 ng14950
+0-- 1
+-0- 1
+--1 1
+.names ng10999 [6912] [7308] [7309] ng26770
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg17423 ng10715 ng7675 [29269] ng17424
+---1 1
+10-- 1
+1-0- 1
+.names ng4849 ng4843 ng4878 ng11012
+111 1
+.names ng4785 ng4709 ng11797
+11 1
+.names ng4801 ng4793 ng4776 ng11261
+011 1
+.names ng4653 ng4669 ng4688 ng4659 ng10831
+1111 1
+.names ng24374 ng11804 ng11283 [28575] ng29737
+-11- 1
+1--0 1
+.names ng3352 ng3288 ng11194
+00 1
+.names pg11349 ng3338 ng11350
+01 1
+10 1
+.names ng3352 ng3288 ng13700
+10 1
+.names ng3352 ng3288 ng13765
+11 1
+.names ng947 ng1129 [7608] [7609] ng24457
+--1- 1
+---1 1
+01-- 1
+.names ng10902 [7269] [7608] [7609] ng26725
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng2724 ng2729 ng12026
+00 1
+.names ng2756 ng2735 ng2741 ng2748 ng14367
+0100 1
+.names ng2495 ng2465 ng11960
+10 1
+.names ng4975 ng4899 ng11804
+01 1
+.names ng4991 ng4966 ng4983 ng11173
+1-- 1
+-0- 1
+--1 1
+.names [6966] [6967] [29216] ng21024
+1-- 1
+-1- 1
+--1 1
+.names pg11388 ng3689 ng11389
+01 1
+10 1
+.names ng4087 ng4098 ng4093 ng4076 ng13806
+0000 1
+.names ng24374 ng11261 ng8933 [29730] ng29672
+-11- 1
+1--0 1
+.names pg9048 pg12368 ng74 ng14708
+1-1 1
+-01 1
+.names ng31 ng28 ng13156 [29959] ng17653
+0011 1
+.names pg73 pg72 ng4104 ng4108 ng24688
+1111 1
+0101 1
+1010 1
+0000 1
+.names pg73 pg72 ng65 ng29503 ng30583
+1-1- 1
+-11- 1
+--11 1
+.names ng4975 ng4899 ng11780
+10 1
+.names ng14367 [7041] [29097] ng22342
+-1- 1
+1-1 1
+.names ng14367 [7041] [29097] [29099] ng25275
+---1 1
+00-- 1
+-00- 1
+.names ng4639 ng4628 ng4621 ng10511
+1-- 1
+-0- 1
+--0 1
+.names ng947 ng1129 ng10902
+01 1
+.names ng31 ng28 ng14988 [29946] ng16244
+0011 1
+.names ng31 ng28 ng13156 [29941] ng16194
+0111 1
+.names ng31 ng28 ng13156 [29939] ng17725
+0111 1
+.names ng31 ng28 ng14988 [29936] ng16283
+0111 1
+.names ng31 ng28 ng13156 [29934] ng16205
+1111 1
+.names ng1624 ng1648 ng12333
+01 1
+.names pg72 ng4322 [29233] ng25776
+111 1
+001 1
+.names ng63 ng29503 ng24380 [29233] ng31009
+0--- 1
+-0-- 1
+--1- 1
+---0 1
+.names ng14367 [6319] [30342] ng22457
+-1- 1
+1-1 1
+.names ng14367 [6319] [30342] [30343] ng25470
+---1 1
+00-- 1
+-00- 1
+.names pg13272 ng1514 ng1526 ng13273
+0-- 1
+-1- 1
+--0 1
+.names ng1495 ng1442 ng10961
+1- 1
+-0 1
+.names ng31 ng28 ng14988 [29944] ng16539
+0011 1
+.names ng31 ng28 ng14988 [29930] ng16486
+0111 1
+.names ng2735 ng2741 ng2748 ng17297 ng25317
+1110 1
+.names ng3171 ng3179 ng11473
+11 1
+.names ng3171 ng3179 ng3161 ng3155 ng13892
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng1514 ng1526 ng10671
+10 1
+.names pg13272 ng1514 ng1526 ng13861
+0-- 1
+-0- 1
+--1 1
+.names ng6227 ng6219 ng12581
+10 1
+.names ng482 ng528 ng490 ng11185
+101 1
+.names ng6573 ng6555 ng6549 ng6565 ng14822
+0--- 1
+-1-- 1
+--0- 1
+---1 1
+.names ng14367 ng12333 [7041] [29097] ng25382
+-0-- 1
+0-0- 1
+--00 1
+.names ng2715 ng2724 ng2719 ng14291
+111 1
+.names ng2715 ng2724 ng2729 ng2719 ng17297
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng3171 ng3179 ng8864
+00 1
+.names ng3161 ng3155 ng3167 ng11514
+000 1
+.names ng4801 ng4793 ng4776 ng11155
+1-- 1
+-1- 1
+--0 1
+.names ng4785 ng4709 ng11755
+10 1
+.names [6832] [6833] [29346] ng20739
+1-- 1
+-1- 1
+--1 1
+.names ng4141 ng4064 ng4057 ng10808
+111 1
+.names ng4141 ng4064 ng4057 ng4082 ng13217
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names [7284] [28543] [28544] [28809] ng24875
+01-1 1
+0-11 1
+.names ng6561 ng6555 ng6549 ng12716
+000 1
+.names ng3530 ng3522 ng8906
+00 1
+.names ng3530 ng3518 ng3522 ng11480
+1-- 1
+-0- 1
+--1 1
+.names ng969 ng7598 [28607] [28609] ng15737
+1--- 1
+---1 1
+-01- 1
+.names ng1018 ng1002 ng15737 ng7567 ng25911
+---1 1
+0-0- 1
+-00- 1
+.names ng34162 [31938] [31939] [31940] ng34703
+0101 1
+.names ng4264 ng4258 ng8967
+0- 1
+-0 1
+.names ng5881 ng5873 ng5857 ng5863 ng14996
+1--- 1
+-1-- 1
+--0- 1
+---1 1
+.names pg99 pg134 ng37 ng4507 ng29186
+---0 1
+00-- 1
+-00- 1
+.names ng14367 [6655] [29571] ng22417
+-1- 1
+1-1 1
+.names ng6227 ng6219 ng10421
+01 1
+.names ng6209 ng6227 ng6203 ng6219 ng14741
+1--- 1
+-1-- 1
+--0- 1
+---0 1
+.names ng4639 ng4628 ng4621 ng12911
+0-- 1
+-0- 1
+--0 1
+.names ng1322 ng1333 ng1339 ng13242
+00- 1
+1-1 1
+0-0 1
+.names ng504 ng518 ng528 ng26314 ng27440
+1101 1
+.names pg17400 ng7661 ng10695 [28827] ng17401
+---1 1
+10-- 1
+1-0- 1
+.names ng6227 ng6219 ng10341
+00 1
+.names ng6209 ng6227 ng6203 ng6219 ng14861
+0--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng31 ng28 ng13156 ni18785
+101 1
+.names ng2756 ng2741 ng2748 ng12289
+1-- 1
+-1- 1
+--1 1
+.names ng2724 ng2729 ng2735 ng12289 ng21277
+0000 1
+.names ng1152 ng1099 ng10929
+1- 1
+-0 1
+.names ng3530 ng3506 ng3522 ng3512 ng14015
+1--- 1
+-1-- 1
+--0- 1
+---0 1
+.names ng6215 ng6195 ng6227 ng6219 ng14271
+01-- 1
+-10- 1
+-1-0 1
+.names pg35 pg12919 ng22992
+11 1
+.names ng2197 ng2153 ng26703 ng17321 ng28903
+0--- 1
+-1-- 1
+--00 1
+.names ng3873 ng3857 ng3881 ng3863 ng14021
+1--- 1
+-1-- 1
+--1- 1
+---0 1
+.names ng3171 ng3179 ng3167 ng12641
+111 1
+.names ng6573 ng6555 ng6549 ng6565 ng12915
+0--- 1
+-0-- 1
+--0- 1
+---1 1
+.names ng112 ng29503 ng26314 [29061] ng28880
+1111 1
+.names ng11178 [7046] [7047] [29091] ng23733
+0--- 1
+-000 1
+.names ng4180 ng1246 ng24457 [7269] ng29488
+--1- 1
+0--1 1
+-100 1
+.names ng14367 [7030] [29111] [29113] ng25349
+---1 1
+00-- 1
+-00- 1
+.names pg17760 pg14779 pg17649 pg12422 ng10207
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng1772 ng1802 ng11915
+01 1
+.names ng43 ng29503 ng24688 [29192] ng27999
+1111 1
+.names ng6541 ng6573 ng6561 ng6565 ng14306
+10-- 1
+1-0- 1
+1--0 1
+.names pg13259 pg8416 [29209] ng8417
+1-- 1
+-1- 1
+--1 1
+.names ng979 ng1236 ng13211 [29210] ng16246
+0100 1
+1000 1
+.names ng10733 [6966] [6967] [29216] ng23112
+0--- 1
+-000 1
+.names ng6573 ng6555 ng6549 ng6565 ng14782
+1--- 1
+-1-- 1
+--0- 1
+---0 1
+.names pg64 pg35 ng23280
+11 1
+.names ng4180 ng1589 ng24478 [7065] ng29501
+--1- 1
+0--1 1
+-000 1
+.names ng4180 ng1242 ng24433 [6925] ng30293
+--1- 1
+0--1 1
+-100 1
+.names ng112 ng29503 ng26314 [29272] ng28846
+1111 1
+.names ng5535 ng5511 ng5527 ng5517 ng14727
+0--- 1
+-0-- 1
+--0- 1
+---1 1
+.names ng5188 ng5170 ng5164 ng5180 ng14755
+1--- 1
+-0-- 1
+--1- 1
+---0 1
+.names pg12919 ng936 ng904 ng921 ng19063
+1111 1
+.names pg12919 ng904 ng921 ng15674
+0-- 1
+-0- 1
+--0 1
+.names ng5041 ng5046 [29316] ng25290
+001 1
+.names ng3530 ng3506 ng3522 ng3512 ng13923
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng4975 ng4966 ng4983 ng10862 ng16187
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng63 ng29503 ng24380 [29233] ng28349
+0--- 1
+-0-- 1
+--1- 1
+---0 1
+.names ng20739 ng24380 [28640] [29348] ng29008
+1011 1
+.names ng4486 ng4483 ng4489 ng4492 ng12228
+1111 1
+.names pg13259 ng1171 ng1183 ng10909
+0-- 1
+-1- 1
+--1 1
+.names ng969 ng1193 ng976 ng1008 ng13336
+110- 1
+-101 1
+.names ng110 ng29503 ng25357 [28614] ng27833
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng1917 ng1894 ng12432
+10 1
+.names ng1959 ng1917 ng1894 ng14678
+10- 1
+1-1 1
+.names ng28504 [28813] [28814] [28815] ng32212
+0101 1
+.names pg35 pg12923 ng22862
+11 1
+.names ng3873 ng3857 ng3881 ng3863 ng14142
+1--- 1
+-0-- 1
+--1- 1
+---0 1
+.names pg8358 ng191 ng8359
+01 1
+10 1
+.names pg11418 pg16659 pg16775 pg13966 ng8751
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng1668 ng1636 ng11893
+10 1
+.names pg12923 ng1266 ng1249 ng15695
+0-- 1
+-0- 1
+--0 1
+.names pg12923 ng1266 ng1249 ng1280 ng19140
+1111 1
+.names ng14367 [6655] [29571] [30314] ng25429
+---1 1
+00-- 1
+-00- 1
+.names ng14367 [6319] [30342] [30349] ng25389
+---1 1
+00-- 1
+-00- 1
+.names ng1211 ng1221 ng1216 ng1205 ng7661
+0000 1
+.names ng1171 ng1183 ng10695
+11 1
+.names ng6573 ng6561 ng6565 ng14908
+1-- 1
+-0- 1
+--0 1
+.names ng1300 ng1291 [7308] [7309] ng24478
+--1- 1
+---1 1
+10-- 1
+.names ng11003 [7065] [7308] [7309] ng26793
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng4180 ng1585 ng24478 [7065] ng29313
+--1- 1
+0--1 1
+-000 1
+.names ng5188 ng5180 ng12405
+10 1
+.names ng5188 ng5170 ng5164 ng5180 ng14656
+0--- 1
+-1-- 1
+--0- 1
+---1 1
+.names ng5037 ng5041 ng17217 ng14317 ng25233
+000- 1
+11-0 1
+.names ng4601 ng4593 ng24411 ng27020
+111 1
+.names ng4601 ng4608 ng4593 ng24411 ng28144
+1111 1
+.names ng7 ng6 ng8 ng13156
+000 1
+.names pg73 pg72 ng2759 ng2763 ng25357
+1111 1
+1001 1
+0110 1
+0000 1
+.names ng513 ng518 ng12812
+01 1
+.names ng5881 ng5873 ng5857 ng5863 ng14855
+1--- 1
+-0-- 1
+--1- 1
+---0 1
+.names ng3171 ng3179 ng11729
+10 1
+.names ng3171 ng3179 ng3167 ng13951
+0-- 1
+-1- 1
+--0 1
+.names ng1472 ng1291 ng10999
+10 1
+.names ng1472 ng1291 [7308] [7309] ng24471
+--1- 1
+---1 1
+10-- 1
+.names ng65 ng29503 ng27972 ng10511 ng31971
+---0 1
+11-- 1
+1-1- 1
+.names ng3530 ng3506 ng3522 ng3512 ng13983
+1--- 1
+-1-- 1
+--1- 1
+---0 1
+.names ng3530 ng3522 ng11747
+01 1
+.names ng3171 ng3179 ng3161 ng3155 ng14101
+0--- 1
+-1-- 1
+--0- 1
+---0 1
+.names pg56 pg54 ng34 ng25779
+--0 1
+01- 1
+.names ng5535 ng5527 ng10281
+00 1
+.names ng5535 ng5511 ng5527 ng5517 ng14927
+1--- 1
+-0-- 1
+--1- 1
+---0 1
+.names ng5188 ng5180 ng12772
+01 1
+.names ng5188 ng5176 ng5180 ng14723
+1-- 1
+-0- 1
+--0 1
+.names ng3703 [6966] [6967] [29216] ng23309
+0--- 1
+-000 1
+.names ng5881 ng5873 ng5857 ng5863 ng14768
+0--- 1
+-0-- 1
+--0- 1
+---1 1
+.names ng24374 ng11797 ng11261 [29730] ng29657
+-11- 1
+1--0 1
+.names ng2421 ng2465 ng26770 ng17424 ng28973
+1--- 1
+-0-- 1
+--00 1
+.names [28543] [28544] [28551] [28558] ng23204
+001- 1
+00-1 1
+.names ng1548 ng1559 ng1554 ng1564 ng7675
+0000 1
+.names ng1514 ng1526 ng7352
+00 1
+.names ng1430 ng7675 ng7352 [29058] ng14506
+---1 1
+10-- 1
+1-0- 1
+.names pg17685 ng6381 ng6336 ng6395 ng11160
+1111 1
+.names [7248] [7249] [28843] ng21012
+1-- 1
+-1- 1
+--1 1
+.names ng2756 ng2735 ng2741 ng2748 ng11405
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng3530 ng3506 ng3522 ng3512 ng14133
+1--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng14708 [28793] [28794] [28795] ng23978
+0--- 1
+-1-- 1
+--0- 1
+---1 1
+.names ng504 ng518 ng528 ng26314 ng27395
+0001 1
+.names ng112 ng29503 ng26314 [30283] ng28739
+1111 1
+.names ng14367 [5887] [31005] ng22498
+-1- 1
+1-1 1
+.names ng6573 ng6561 ng6565 ng12629
+1-- 1
+-0- 1
+--1 1
+.names ng14367 [6655] [29571] [29573] ng25341
+---1 1
+00-- 1
+-00- 1
+.names ng23978 [28796] [28801] [28802] ng27629
+0101 1
+.names ng1087 ng7661 ng7304 [29009] ng14438
+---1 1
+10-- 1
+1-0- 1
+.names ng3171 ng3179 ng3167 ng11432
+1-- 1
+-1- 1
+--0 1
+.names [1421] ng4818 ng101 ng24374 ng30576
+0011 1
+.names pg12300 ng5689 ng12301
+01 1
+10 1
+.names ng504 ng518 ng528 ng26314 ng27474
+1111 1
+.names ng504 ng518 ng528 ng26314 ng27445
+1011 1
+.names pg17404 ng7675 ng10699 [29405] ng17405
+---1 1
+10-- 1
+1-0- 1
+.names pg16624 ng3352 ng3338 ng3288 ng10721
+1111 1
+.names ng10721 [7137] [7138] [28996] ng23067
+0--- 1
+-000 1
+.names ng5535 ng5527 ng12798
+01 1
+.names ng5535 ng5523 ng5527 ng14764
+1-- 1
+-0- 1
+--0 1
+.names ng1448 ng1291 [7308] [7309] ng24460
+--1- 1
+---1 1
+10-- 1
+.names ng10967 [6770] [7308] [7309] ng26737
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng31 ng28 ng13156 ni17529
+011 1
+.names ng2476 ng2453 ng12483
+10 1
+.names ng2153 ng2227 ng9649
+00 1
+.names ng4633 ng4639 ng4621 ng11320
+0-- 1
+-1- 1
+--0 1
+.names ng2756 ng2741 ng2748 ng25357 ng26218
+1011 1
+.names ng4785 ng4709 ng11773
+01 1
+.names ng4975 ng4899 ng11834
+11 1
+.names ng4991 ng4966 ng4983 ng11283
+011 1
+.names ng3530 ng3522 ng11527
+11 1
+.names ng3530 ng3506 ng3522 ng3512 ng13955
+0--- 1
+-0-- 1
+--0- 1
+---1 1
+.names ng6215 ng6227 ng6219 ng14902
+0-- 1
+-0- 1
+--1 1
+.names ng1478 ng1291 [7308] [7309] ng24447
+--1- 1
+---1 1
+10-- 1
+.names ng10948 [7306] [7308] [7309] ng26703
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg12923 pg19357 pg7946 ng1333 ng13134
+0--- 1
+-000 1
+.names ng2756 ng2741 ng2748 ng25357 ng26195
+1101 1
+.names ng1221 ng1087 ng1205 ng11130
+0-- 1
+-0- 1
+--0 1
+.names ng33851 [30331] [30332] [32708] ng34550
+0--- 1
+-1-- 1
+--0- 1
+---1 1
+.names ng3171 ng3179 ng3161 ng3155 ng13948
+1--- 1
+-1-- 1
+--0- 1
+---1 1
+.names ng14367 [5887] [31005] [31232] ng25498
+---1 1
+00-- 1
+-00- 1
+.names ng14367 [5887] [31005] [32438] ng25439
+---1 1
+00-- 1
+-00- 1
+.names ng3530 ng3518 ng3522 ng13986
+1-- 1
+-0- 1
+--0 1
+.names ng5535 ng5527 ng12453
+10 1
+.names ng5535 ng5523 ng5527 ng14807
+0-- 1
+-0- 1
+--1 1
+.names ng479 ng890 ng528 ng26314 ng28652
+01-- 1
+-11- 1
+-1-0 1
+.names ng3873 ng3857 ng3881 ng3863 ng13960
+1--- 1
+-0-- 1
+--0- 1
+---1 1
+.names ng3171 ng3179 ng11435
+01 1
+.names ng3171 ng3179 ng3161 ng3155 ng14008
+1--- 1
+-0-- 1
+--0- 1
+---1 1
+.names ng504 ng518 ng528 ng26314 ng27421
+0011 1
+.names pg17320 ng10671 ng7675 [28783] ng17321
+---1 1
+10-- 1
+1-0- 1
+.names ng6573 ng6565 ng12680
+11 1
+.names ng6573 ng6555 ng6549 ng6565 ng15014
+0--- 1
+-0-- 1
+--1- 1
+---0 1
+.names ng14367 ng12432 [6655] [29571] ng25467
+-0-- 1
+0-0- 1
+--00 1
+.names ng14367 ng12483 [7725] [28488] ng25495
+-0-- 1
+0-0- 1
+--00 1
+.names ng5037 ng5041 ng5046 ng17217 ng25144
+0000 1
+.names ng5037 ng5041 ng5046 ng14317 ng23560
+1110 1
+.names ng5052 ng25144 ng23560 ng27670
+01- 1
+1-1 1
+.names [28637] [28638] ng30286
+1- 1
+-1 1
+.names ng14367 [7030] [29111] [31424] ng25435
+---1 1
+00-- 1
+-00- 1
+.names ng5188 ng5180 ng10266
+00 1
+.names ng5188 ng5176 ng5180 ng12402
+1-- 1
+-0- 1
+--1 1
+.names pg7916 ng1171 ng1183 ng13284
+0-- 1
+-0- 1
+--0 1
+.names ng6573 ng6555 ng6549 ng6565 ng14981
+0--- 1
+-0-- 1
+--1- 1
+---1 1
+.names ng11676 [6781] [6784] [29397] ng20248
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng817 ng832 ng8806 ng17264
+0-- 1
+-0- 1
+--1 1
+.names ng837 ng812 ng847 ng14279
+0-1 1
+-11 1
+.names ng3873 ng3857 ng3881 ng3863 ng13963
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng5022 ng5016 ng5062 ng12933
+10- 1
+-11 1
+.names ng5535 ng5511 ng5527 ng5517 ng14665
+1--- 1
+-0-- 1
+--0- 1
+---1 1
+.names ng25144 ng23560 ng26625
+00 1
+.names ng65 ng4643 ng29503 ng27972 ng31950
+-1-- 1
+1-1- 1
+1--1 1
+.names ng1211 ng1221 ng1087 ng1205 ng11148
+1111 1
+.names ng6573 ng6561 ng6565 ng10887
+111 1
+.names ng5188 ng5170 ng5164 ng5180 ng14720
+1--- 1
+-0-- 1
+--1- 1
+---1 1
+.names ng990 ng979 ng7567
+00 1
+.names ng4180 ng1585 ng24471 [6912] ng30314
+--1- 1
+0--1 1
+-100 1
+.names ng24374 ng11261 ng11773 [29730] ng29719
+-11- 1
+1--0 1
+.names ng43 ng29503 ng24688 [29502] ng26994
+1111 1
+.names ng11123 [6832] [6833] [29346] ng23630
+0--- 1
+-000 1
+.names ng1221 ng1087 ng1216 ng1205 ng13570
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names pg14828 pg12470 pg17778 pg17688 ng10224
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng3530 ng3506 ng3522 ng3512 ng14075
+0--- 1
+-1-- 1
+--0- 1
+---0 1
+.names ng5881 ng5873 ng5857 ng5863 ng14999
+1--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng4340 ng4349 ng4358 ng8347
+0-- 1
+-0- 1
+--0 1
+.names ng5188 ng5176 ng5180 ng10823
+111 1
+.names ng2185 ng2208 ng12374
+01 1
+.names ng14367 [6172] [30555] ng22384
+-1- 1
+1-1 1
+.names ng14367 [6172] [30555] [30557] ng25309
+---1 1
+00-- 1
+-00- 1
+.names ng14367 [6172] [30555] [33307] ng25396
+---1 1
+00-- 1
+-00- 1
+.names ng2476 ng2453 ng2518 ng14713
+0-1 1
+-11 1
+.names [7624] [7625] [28651] ng20682
+1-- 1
+-1- 1
+--1 1
+.names ng20682 ng24380 [28640] [30578] ng28982
+1011 1
+.names ng5188 ng5170 ng5164 ng5180 ng14915
+1--- 1
+-1-- 1
+--0- 1
+---1 1
+.names ng2361 ng2331 ng11939
+10 1
+.names ng112 ng29503 ng26314 [30377] ng28833
+1111 1
+.names ng1322 ng1333 ng7601
+00 1
+.names ng1312 ng7620 [28716] [28718] ng15748
+1--- 1
+---1 1
+-01- 1
+.names ng1345 ng1367 ng1379 ng11869
+111 1
+.names ng3530 ng3506 ng3522 ng3512 ng14048
+0--- 1
+-1-- 1
+--1- 1
+---0 1
+.names ng5535 ng5527 ng12505
+11 1
+.names ng5535 ng5523 ng5527 ng10838
+111 1
+.names ng5188 ng5176 ng5180 ng14758
+0-- 1
+-0- 1
+--1 1
+.names ng3171 ng3179 ng3161 ng3155 ng13889
+1--- 1
+-0-- 1
+--1- 1
+---0 1
+.names ng6227 ng6219 ng12622
+11 1
+.names ng6215 ng6227 ng6219 ng10874
+111 1
+.names ng4584 ng10511 ng8347 [28475] ng24411
+1000 1
+.names ng2756 ng2741 ng2748 ng25357 ng26166
+0101 1
+.names pg13259 ng1171 ng1183 ng13846
+0-- 1
+-0- 1
+--1 1
+.names ng6209 ng6227 ng6203 ng6219 ng14899
+0--- 1
+-1-- 1
+--1- 1
+---0 1
+.names pg12470 ng6727 ng12471
+01 1
+10 1
+.names ng3873 ng3857 ng3881 ng3863 ng14170
+1--- 1
+-0-- 1
+--0- 1
+---0 1
+.names pg16718 pg16603 pg13895 pg11349 ng8691
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng2715 ng1945 ng2079 ng2719 ng23618
+00-1 1
+1-01 1
+.names ng7 ng6 ng8 ng14988
+111 1
+.names pg16656 ng3689 ng3703 ng3639 ng10733
+1111 1
+.names pg16693 ng4040 ng4054 ng3990 ng10756
+1111 1
+.names ng5881 ng5873 ng5857 ng5863 ng15018
+0--- 1
+-1-- 1
+--0- 1
+---0 1
+.names ng112 ng29503 ng26314 [30616] ng28768
+1111 1
+.names ng3530 ng3522 ng11483
+10 1
+.names ng1171 ng1183 ng10666
+01 1
+.names ng1178 ng1189 ng996 ng10893
+101 1
+.names ng5535 ng5511 ng5527 ng5517 ng14848
+0--- 1
+-1-- 1
+--1- 1
+---0 1
+.names ng232 ng225 ng255 ng11292
+111 1
+001 1
+010 1
+100 1
+.names ng93 ng29503 ni27429
+11 1
+.names pg72 ng4322 [28640] ng25851
+111 1
+001 1
+.names ng21012 ng24380 [28640] [32672] ng29073
+1011 1
+.names ng150 ng164 ng23042 [28708] ng28353
+1111 1
+.names ng911 ng907 ng914 ng19063 ng25888
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng5357 [7624] [7625] [28651] ng23890
+0--- 1
+-000 1
+.names ng4854 ng4849 ng4843 ng4878 ng13346
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng2495 ng2421 ng9762
+00 1
+.names ng1862 ng1906 ng26725 ng17401 ng28927
+1--- 1
+-0-- 1
+--00 1
+.names ng6573 ng6555 ng6549 ng6565 ng15033
+1--- 1
+-0-- 1
+--0- 1
+---1 1
+.names ng6215 ng6209 ng6203 ng12667
+000 1
+.names ng671 ng8806 ng11185 [30776] ng20375
+1011 1
+.names pg115 pg116 ng4157 ng26256
+-11 1
+0-0 1
+.names pg126 pg124 ng4146 ng26212
+-11 1
+0-0 1
+.names pg113 pg35 ng24627
+11 1
+.names ng6215 ng6227 ng6219 ng14864
+0-- 1
+-1- 1
+--0 1
+.names ng65 ng29503 ng27972 [6408] ng31997
+---1 1
+11-- 1
+1-1- 1
+.names ng1548 ng1554 ng1564 ng1430 ng11171
+1111 1
+.names ng4180 ng1585 ng24460 [6770] ng30307
+--1- 1
+0--1 1
+-000 1
+.names ng112 ng29503 ng26314 [30276] ng28789
+1111 1
+.names pg13926 pg11388 pg16627 pg16744 ng8728
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng822 ng817 ng832 ng8806 ng20905
+0--- 1
+-0-- 1
+--0- 1
+---1 1
+.names [7046] [7047] [29091] ng20751
+1-- 1
+-1- 1
+--1 1
+.names ng93 ng29503 ng20751 [30365] ng29110
+1111 1
+.names ng4507 ng27972 ng24374 [30386] ng33394
+---1 1
+-00- 1
+101- 1
+.names ng14367 ng12729 [7041] [29097] ng25337
+-0-- 1
+0-0- 1
+--00 1
+.names pg7946 ng1514 ng1526 ng13291
+0-- 1
+-0- 1
+--0 1
+.names ng3171 ng3179 ng3161 ng3155 ng13873
+0--- 1
+-1-- 1
+--1- 1
+---0 1
+.names ng3171 ng3179 ng3167 ng13980
+1-- 1
+-0- 1
+--0 1
+.names ng14367 [7725] [28488] [30467] ng25400
+---1 1
+00-- 1
+-00- 1
+.names ng2815 ng2715 ng2819 ng2719 ng23553
+10-1 1
+-111 1
+.names ng2715 ng2719 ng2638 ng2504 ng23657
+110- 1
+01-0 1
+.names ng20875 ng24380 [28640] [31986] ng29036
+1011 1
+.names ng1256 ng1259 ng1252 ng19140 ng25895
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng12371 ng14367 [7257] [28834] ng25426
+0--- 1
+-00- 1
+--00 1
+.names ng513 ng518 ng203 ng13756
+1-- 1
+-0- 1
+--0 1
+.names ng110 ng29503 ng25357 [28625] ng27796
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng4180 ng1589 ng24471 [6912] ng29496
+--1- 1
+0--1 1
+-100 1
+.names ng1300 ng1291 ng11003
+10 1
+.names ng4859 ng4849 ng4843 ng4878 ng10862
+1111 1
+.names ng4087 ng4098 ng4093 ng11245
+1-- 1
+-1- 1
+--1 1
+.names ng4064 ng4057 [3192] [34061] ng25448
+--1- 1
+00-1 1
+.names ng3171 ng3179 ng3161 ng3155 ng14069
+1--- 1
+-1-- 1
+--0- 1
+---0 1
+.names ng5535 ng5511 ng5527 ng5517 ng14959
+1--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng4340 ng4639 ng4628 ng4621 ng12925
+0--- 1
+-1-- 1
+--0- 1
+---0 1
+.names ng14367 ng12374 [6172] [30555] ng25432
+-0-- 1
+0-0- 1
+--00 1
+.names pg17604 ng5689 ng5703 ng5644 ng11123
+1111 1
+.names ng5188 ng5180 ng12443
+11 1
+.names ng5188 ng5170 ng5164 ng5180 ng14659
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng504 ng518 ng528 ng26314 ng27469
+0101 1
+.names ng291 ng287 ng283 ng23204 ng28444
+1111 1
+.names ng2599 ng2555 ng26793 ng14506 ng29001
+0--- 1
+-1-- 1
+--00 1
+.names ng4180 ng1589 ng24447 [7306] ng29486
+--1- 1
+0--1 1
+-100 1
+.names pg17722 ng6741 ng6682 ng6727 ng11178
+1111 1
+.names ng3873 ng3881 ng11584
+11 1
+.names ng3530 ng3506 ng3522 ng3512 ng13920
+0--- 1
+-0-- 1
+--1- 1
+---1 1
+.names ng5535 ng5511 ng5527 ng5517 ng14688
+0--- 1
+-0-- 1
+--1- 1
+---1 1
+.names ng6215 ng6227 ng6219 ng12578
+0-- 1
+-1- 1
+--1 1
+.names ng3506 ng3518 ng3512 ng11571
+000 1
+.names pg113 ng2868 ng25531
+0- 1
+-0 1
+.names ng5297 ng5357 ng10588
+11 1
+.names [29245] [29246] ng31783
+1- 1
+-1 1
+.names ng4653 ng4688 ng4659 ng11006
+111 1
+.names ng4653 ng4688 ng4664 ng4659 ng13330
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng5188 ng5170 ng5164 ng5180 ng14627
+1--- 1
+-1-- 1
+--0- 1
+---0 1
+.names ng6209 ng6227 ng6203 ng6219 ng14974
+0--- 1
+-0-- 1
+--1- 1
+---0 1
+.names ng3171 ng3179 ng3161 ng3155 ng14041
+0--- 1
+-0-- 1
+--0- 1
+---1 1
+.names ng43 ng29503 ng24688 [29499] ng27617
+1111 1
+.names [6178] [30547] [30551] [30552] ng28626
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng6209 ng6227 ng6203 ng6219 ng14776
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng3530 ng3498 ng3518 ng3522 ng13517
+01-- 1
+-10- 1
+-1-0 1
+.names ng2197 ng2227 ng11916
+01 1
+.names ng6573 ng6555 ng6549 ng6565 ng14825
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng6741 [7046] [7047] [29091] ng23972
+0--- 1
+-000 1
+.names ng1783 ng1825 ng1760 ng14640
+01- 1
+-11 1
+.names ng703 ng16846 [30802] [30803] ng23324
+0--- 1
+-11- 1
+-1-1 1
+.names ng499 ng504 ng8806 ng11185 ng16846
+1001 1
+.names ng5849 ng5869 ng5881 ng5873 ng14247
+10-- 1
+1-0- 1
+1--0 1
+.names ng2051 ng2028 ng12479
+10 1
+.names ng5869 ng5881 ng5873 ng10869
+111 1
+.names ng5535 ng5511 ng5527 ng5517 ng14761
+1--- 1
+-1-- 1
+--1- 1
+---0 1
+.names [32354] [32355] [32357] [32358] ng28220
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng3352 [7137] [7138] [28996] ng23286
+0--- 1
+-000 1
+.names ng3171 ng3179 ng3161 ng3155 ng14098
+1--- 1
+-1-- 1
+--1- 1
+---0 1
+.names ng110 ng29503 ng25357 [28632] ng27738
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng979 ng996 ng7598
+01 1
+10 1
+.names ng990 ng979 ng996 ng13211
+00- 1
+-11 1
+-00 1
+.names ng4087 ng4093 ng4076 ng13217 ng22654
+1110 1
+.names ng2756 ng2741 ng2748 ng25357 ng26171
+1001 1
+.names ng4332 ng4322 ng10511 ng8347 ng15591
+0--- 1
+-0-- 1
+--1- 1
+---1 1
+.names ng3873 ng3881 ng3869 ng14085
+0-- 1
+-0- 1
+--0 1
+.names ng1636 ng1592 ng26673 ng17292 ng28853
+0--- 1
+-1-- 1
+--00 1
+.names pg11418 ng4040 ng11419
+01 1
+10 1
+.names ng4054 ng3990 ng11255
+01 1
+.names ng3530 ng3518 ng3522 ng14018
+0-- 1
+-0- 1
+--1 1
+.names pg17646 ng6035 ng5990 ng6049 ng11139
+1111 1
+.names ng3530 ng3518 ng3522 ng14051
+0-- 1
+-0- 1
+--0 1
+.names ng1135 ng947 [7608] [7609] ng24433
+--1- 1
+---1 1
+10-- 1
+.names ng10878 [6925] [7608] [7609] ng26673
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng5869 ng5881 ng5873 ng14813
+0-- 1
+-1- 1
+--0 1
+.names pg17577 ng5297 ng5357 ng5343 ng11111
+1111 1
+.names pg12238 ng5343 ng12239
+01 1
+10 1
+.names pg12422 ng6381 ng12423
+01 1
+10 1
+.names ng1668 ng1592 ng9586
+00 1
+.names ng6573 ng6555 ng6549 ng6565 ng15042
+1--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng5170 ng5176 ng5164 ng12492
+000 1
+.names ng3171 ng3179 ng3161 ng3155 ng14127
+1--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng1322 ng1339 ng7620
+01 1
+10 1
+.names ng5188 ng5170 ng5164 ng5180 ng14879
+1--- 1
+-0-- 1
+--0- 1
+---1 1
+.names ng1996 ng2040 ng26759 ng14438 ng28962
+1--- 1
+-0-- 1
+--00 1
+.names ng5188 ng5170 ng5164 ng5180 ng14953
+0--- 1
+-0-- 1
+--0- 1
+---1 1
+.names ng110 ng29503 ng25357 [28622] ng27933
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng110 ng29503 ng25357 [28629] ng27854
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng2599 ng2629 ng11978
+01 1
+.names ng24374 ng11780 ng11283 [28575] ng29722
+-11- 1
+1--0 1
+.names ng3873 ng3857 ng3881 ng3863 ng14055
+0--- 1
+-1-- 1
+--1- 1
+---0 1
+.names ng5881 ng5873 ng5857 ng5863 ng14968
+1--- 1
+-1-- 1
+--0- 1
+---0 1
+.names ng1936 ng1906 ng11937
+10 1
+.names ng3873 ng3857 ng3881 ng3863 ng13929
+0--- 1
+-0-- 1
+--1- 1
+---1 1
+.names ng4180 ng1242 ng24444 [7606] ng30298
+--1- 1
+0--1 1
+-000 1
+.names ng5188 ng5170 ng5164 ng5180 ng14797
+0--- 1
+-0-- 1
+--1- 1
+---1 1
+.names ng43 ng29503 ng24688 [29491] ng28020
+1111 1
+.names ng4180 ng1589 ng24460 [6770] ng29489
+--1- 1
+0--1 1
+-000 1
+.names ng2342 ng2319 ng2384 ng14679
+0-1 1
+-11 1
+.names ng5092 ng5084 ng9724
+0- 1
+-0 1
+.names ng110 ng29503 ng25357 [28617] ng27882
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names pg14738 pg17607 pg17739 pg12350 ng10185
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names pg13259 ng1171 ng1183 ng13260
+0-- 1
+-1- 1
+--0 1
+.names ng4785 ng4709 ng8933
+00 1
+.names ng2775 ng2724 ng2729 ng2771 ng23554
+110- 1
+-001 1
+.names ng1135 ng947 ng10878
+10 1
+.names ng5022 ng5029 ng5016 ng5062 ng15585
+00-- 1
+-01- 1
+0-0- 1
+-10- 1
+0--0 1
+-1-0 1
+--10 1
+.names ng504 ng518 ng528 ng26314 ng27416
+1001 1
+.names ng2756 ng2741 ng2748 ng25357 ng26148
+0001 1
+.names ng2756 ng2741 ng2748 ng25357 ng26213
+0111 1
+.names ng3873 ng3881 ng11763
+10 1
+.names ng5703 [6832] [6833] [29346] ng23909
+0--- 1
+-000 1
+.names ng1171 ng1183 ng7304
+00 1
+.names ng5535 ng5511 ng5527 ng5517 ng14956
+1--- 1
+-0-- 1
+--1- 1
+---1 1
+.names ng24374 ng11283 ng8984 [28575] ng29702
+-11- 1
+1--0 1
+.names pg19334 pg12919 pg7916 ng990 ng13121
+-0-- 1
+0-00 1
+.names ng2610 ng2587 ng12540
+10 1
+.names ng14367 ng12540 [5887] [31005] ng25514
+-0-- 1
+0-0- 1
+--00 1
+.names ng6573 ng6561 ng6565 ng14984
+0-- 1
+-0- 1
+--0 1
+.names ng3530 ng3506 ng3522 ng3512 ng14130
+1--- 1
+-0-- 1
+--1- 1
+---1 1
+.names ng3530 ng3506 ng3522 ng3512 ng14151
+0--- 1
+-0-- 1
+--1- 1
+---0 1
+.names ng2610 ng2652 ng2587 ng14752
+01- 1
+-11 1
+.names ng14367 ng12479 [6319] [30342] ng25492
+-0-- 1
+0-0- 1
+--00 1
+.names pg8719 ng385 ng376 ng8721
+111 1
+.names ng112 ng29503 ng26314 [30356] ng28799
+1111 1
+.names ng93 ng29503 ng21024 [31435] ng28471
+1111 1
+.names ng1772 ng1728 ng17317 ng26694 ng28892
+0--- 1
+-1-- 1
+--00 1
+.names ng5037 ng17217 ng14317 ng23586
+01- 1
+1-1 1
+-11 1
+.names ng5188 ng5156 ng5176 ng5180 ng14211
+01-- 1
+-10- 1
+-1-0 1
+.names ng25776 ng25851 [29253] [29254] ng29730
+-11- 1
+1--1 1
+.names pg72 ng4322 ng24380
+01 1
+10 1
+.names ng1514 ng1526 ng10699
+01 1
+.names ng1532 ng1521 ng1339 ng10918
+011 1
+.names ng5881 ng5873 ng5857 ng5863 ng14892
+0--- 1
+-1-- 1
+--1- 1
+---0 1
+.names ng2070 ng2040 ng11956
+10 1
+.names pg113 ng2873 ng25537
+0- 1
+-0 1
+.names ng5535 ng5523 ng5527 ng12450
+1-- 1
+-0- 1
+--1 1
+.names ng4975 ng4899 ng8984
+00 1
+.names ng6215 ng6227 ng6219 ng14943
+0-- 1
+-0- 1
+--0 1
+.names pg17316 ng7661 ng10666 [28673] ng17317
+---1 1
+10-- 1
+1-0- 1
+.names ng5523 ng5511 ng5517 ng12558
+000 1
+.names ng4966 ng4983 ng10862 ng13486
+0-- 1
+-0- 1
+--0 1
+.names ni27429 [28765] [28766] [32239] ng28484
+11-1 1
+1-11 1
+.names ng947 ng1105 ng10890
+01 1
+.names [30158] [30159] [30160] ni30751
+1-- 1
+-1- 1
+--1 1
+.names ng3873 ng3857 ng3881 ng3863 ng14157
+0--- 1
+-0-- 1
+--1- 1
+---0 1
+.names ng5188 ng5170 ng5164 ng5180 ng14918
+1--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng3873 ng3857 ng3881 ng3863 ng14154
+1--- 1
+-0-- 1
+--1- 1
+---1 1
+.names ng3171 ng3179 ng3147 ng3167 ng13500
+0-1- 1
+-01- 1
+--10 1
+.names ng5881 ng5873 ng5857 ng5863 ng14732
+0--- 1
+-1-- 1
+--0- 1
+---1 1
+.names ng1171 ng1183 ng10649
+10 1
+.names pg17291 ng7661 ng10649 [29263] ng17292
+---1 1
+10-- 1
+1-0- 1
+.names [30515] [30516] ng16696
+1- 1
+-1 1
+.names ng5188 ng5176 ng5180 ng14800
+0-- 1
+-0- 1
+--0 1
+.names pg8291 pg8358 ng191 ng218 ng11737
+0--- 1
+---0 1
+-01- 1
+-10- 1
+.names ng2070 ng1996 ng9755
+00 1
+.names ng5188 ng5170 ng5164 ng5180 ng14841
+0--- 1
+-0-- 1
+--1- 1
+---0 1
+.names ng3873 ng3881 ng3869 ng14024
+0-- 1
+-1- 1
+--0 1
+.names [32542] [32543] [32544] [32545] ng22585
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg12350 ng6035 ng12351
+01 1
+10 1
+.names ng1002 ng1036 ng1024 ng11846
+111 1
+.names ng1322 ng1579 ng13242 [30238] ng16272
+0100 1
+1000 1
+.names ng93 ng29503 ng20887 [31757] ng28458
+1111 1
+.names ng246 ng232 ng239 [28549] ng11144
+1111 1
+.names ng6209 ng6227 ng6203 ng6219 ng14773
+1--- 1
+-0-- 1
+--0- 1
+---1 1
+.names ng5535 ng5523 ng5527 ng5503 ng14227
+0--1 1
+-0-1 1
+--01 1
+.names ng2715 ng2719 ng2783 ng2787 ng23532
+011- 1
+11-1 1
+.names ng1478 ng1291 ng10948
+10 1
+.names ng3873 ng3857 ng3881 ng3863 ng14082
+1--- 1
+-1-- 1
+--0- 1
+---0 1
+.names ng5869 ng5881 ng5873 ng14895
+0-- 1
+-0- 1
+--0 1
+.names ng5881 ng5873 ng5857 ng5863 ng14933
+0--- 1
+-0-- 1
+--1- 1
+---0 1
+.names ng4054 [7325] [7326] [28766] ng23342
+0--- 1
+-000 1
+.names ng947 ng1105 [7608] [7609] ng24444
+--1- 1
+---1 1
+01-- 1
+.names ng10890 [7606] [7608] [7609] ng26694
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg8719 ng385 ng370 ng376 ng11326
+0--- 1
+-1-- 1
+--0- 1
+---0 1
+.names pg17674 pg14662 pg17519 pg12238 ng10124
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng1548 ng1564 ng1430 ng11149
+0-- 1
+-0- 1
+--0 1
+.names ng1548 ng1559 ng1564 ng1430 ng13597
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng3530 ng3506 ng3522 ng3512 ng13898
+1--- 1
+-0-- 1
+--0- 1
+---1 1
+.names ng5535 ng5511 ng5527 ng5517 ng14691
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng4180 ng1246 ng24433 [6925] ng29482
+--1- 1
+0--1 1
+-100 1
+.names ng3171 ng3179 ng3167 ng14011
+0-- 1
+-0- 1
+--0 1
+.names ng6395 [7248] [7249] [28843] ng23949
+0--- 1
+-000 1
+.names ng5535 ng5523 ng5527 ng14851
+0-- 1
+-0- 1
+--0 1
+.names ng3873 ng3857 ng3881 ng3863 ng13990
+0--- 1
+-0-- 1
+--0- 1
+---1 1
+.names ng2756 ng2741 ng2748 ng25357 ng26236
+1111 1
+.names ng417 [32031] [32032] ng23975
+01- 1
+0-1 1
+100 1
+.names ng174 ng452 ng392 ng13657
+-11 1
+1-0 1
+.names ng5535 ng5511 ng5527 ng5517 ng14804
+1--- 1
+-1-- 1
+--0- 1
+---0 1
+.names ng1657 ng1648 ng12729
+01 1
+.names ng6209 ng6227 ng6203 ng6219 ng14817
+1--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng2093 ng2051 ng2028 ng14712
+10- 1
+1-1 1
+.names ng3873 ng3881 ng3869 ng3849 ng13539
+0--1 1
+-0-1 1
+--01 1
+.names ng4793 ng4776 ng10831 ng13464
+0-- 1
+-0- 1
+--0 1
+.names ng24875 [28810] [28811] [28812] ng28504
+0--- 1
+-1-- 1
+--0- 1
+---1 1
+.names ng24374 ng11261 ng11755 [29730] ng29694
+-11- 1
+1--0 1
+.names ng2287 ng2331 ng17405 ng26737 ng28942
+1--- 1
+-0-- 1
+--00 1
+.names [4764] [32301] [32305] [32306] ng28440
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng1624 ng1691 ng1648 ng14611
+11- 1
+-10 1
+.names ng1728 ng1802 ng9640
+00 1
+.names pg7946 pg8475 [33480] ng8476
+1-- 1
+-1- 1
+--1 1
+.names ng6209 ng6227 ng6203 ng6219 ng15021
+1--- 1
+-1-- 1
+--0- 1
+---1 1
+.names [31726] [31727] ng30605
+1- 1
+-1 1
+.names ng6209 ng6227 ng6203 ng6219 ng15024
+0--- 1
+-1-- 1
+--0- 1
+---0 1
+.names ng4180 ng1246 ng24468 [7126] ng29495
+--1- 1
+0--1 1
+-000 1
+.names ng3873 ng3857 ng3881 ng3863 ng14116
+0--- 1
+-1-- 1
+--0- 1
+---0 1
+.names ng3530 ng3506 ng3522 ng3512 ng14110
+1--- 1
+-0-- 1
+--1- 1
+---0 1
+.names ng2361 ng2287 ng9700
+00 1
+.names [30517] [30518] ng16757
+1- 1
+-1 1
+.names ng5022 ng5029 ng5016 ng5033 ng17217
+0--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng5029 ng5016 ng5062 ng5033 ng14317
+0--- 1
+-0-- 1
+--0- 1
+---0 1
+.names ng5535 ng5511 ng5527 ng5517 ng14993
+0--- 1
+-0-- 1
+--1- 1
+---0 1
+.names ng3171 ng3179 ng3161 ng3155 ng13915
+0--- 1
+-0-- 1
+--1- 1
+---0 1
+.names ng6209 ng6227 ng6203 ng6219 ng15008
+0--- 1
+-1-- 1
+--0- 1
+---1 1
+.names ng6209 ng6227 ng6203 ng6219 ng14940
+0--- 1
+-0-- 1
+--1- 1
+---1 1
+.names [32269] [32270] ng16663
+1- 1
+-1 1
+.names ng14367 [7725] [28488] [32948] ng25476
+---1 1
+00-- 1
+-00- 1
+.names ng31509 [30328] [30329] [30330] ng33851
+0101 1
+.names ng732 ng11676 [28525] [28526] ng21284
+11-- 1
+1-0- 1
+1--0 1
+.names ng5881 ng5873 ng5857 ng5863 ng14810
+1--- 1
+-1-- 1
+--1- 1
+---0 1
+.names ng4180 ng1246 ng24444 [7606] ng29485
+--1- 1
+0--1 1
+-000 1
+.names ng2185 ng2250 ng2208 ng14642
+11- 1
+-10 1
+.names ni30751 ni30745 [30150] [30182] ng34056
+100- 1
+-001 1
+01-0 1
+0-10 1
+.names ng33212 ng33219 ng34051
+01 1
+10 1
+.names ng33149 ng33176 ng33164 ng33187 ng34424
+0111 1
+1011 1
+1101 1
+0001 1
+1110 1
+0010 1
+0100 1
+1000 1
+.names [32271] [32272] ng16728
+1- 1
+-1 1
+.names ng2555 ng2629 ng9835
+00 1
+.names [30131] [30132] [30136] ni30745
+1-- 1
+-1- 1
+--1 1
+.names ng246 ng262 ng269 ng239 ng12332
+0111 1
+1011 1
+1101 1
+0001 1
+1110 1
+0010 1
+0100 1
+1000 1
+.names [1411] pg8353
+1 1
+.names ng17292 pg33533
+1 1
+.names ng25531 pg34437
+1 1
+.names [1421] pg8132
+1 1
+.names ng25448 pg31521
+1 1
+.names pg6746 pg18101
+1 1
+.names ng25448 pg34435
+1 1
+.names pg6751 pg18100
+1 1
+.names ng79 pg20899
+1 1
+.names ng25537 pg34436
+1 1
+.names ng86 pg20557
+1 1
+.names ng121 pg20654
+1 1
+.names pg92 pg24171
+1 1
+.names pg127 pg24182
+1 1
+.names ng28652 pg33894
+1 1
+.names [1457] pg8235
+1 1
+.names pg99 pg24172
+1 1
+.names pg126 pg24181
+1 1
+.names [1411] pg8403
+1 1
+.names pg54 pg24162
+1 1
+.names pg125 pg24180
+1 1
+.names ng10823 pg26801
+1 1
+.names ng34237 pg34237
+1 1
+.names ng74 pg20763
+1 1
+.names pg53 pg24161
+1 1
+.names pg91 pg24170
+1 1
+.names ng34237 pg34238
+1 1
+.names pg6747 pg18097
+1 1
+.names pg57 pg24164
+1 1
+.names pg114 pg24175
+1 1
+.names ng74 pg29211
+1 1
+.names ng34235 pg34235
+1 1
+.names pg6744 pg18098
+1 1
+.names ng102 pg20901
+1 1
+.names pg56 pg24163
+1 1
+.names pg115 pg24176
+1 1
+.names pg44 pg24185
+1 1
+.names ng59 pg29210
+1 1
+.names pg6745 pg18099
+1 1
+.names ng94 pg20652
+1 1
+.names pg72 pg24166
+1 1
+.names pg100 pg24173
+1 1
+.names pg135 pg24184
+1 1
+.names ng86 pg29213
+1 1
+.names ng128 pg29220
+1 1
+.names ng34235 pg34233
+1 1
+.names ng136 pg21292
+1 1
+.names pg64 pg24165
+1 1
+.names pg113 pg24174
+1 1
+.names pg134 pg24183
+1 1
+.names ng79 pg29212
+1 1
+.names ng136 pg29221
+1 1
+.names ng10823 pg32975
+1 1
+.names ng34235 pg34234
+1 1
+.names ng28652 pg34788
+1 1
+.names pg84 pg24168
+1 1
+.names pg124 pg24179
+1 1
+.names ng5343 pg25219
+1 1
+.names ng102 pg29215
+1 1
+.names ng1242 pg30332
+1 1
+.names pg73 pg24167
+1 1
+.names ng94 pg29214
+1 1
+.names pg116 pg24177
+1 1
+.names ng12729 pg25167
+1 1
+.names ng117 pg29217
+1 1
+.names ng34237 pg34240
+1 1
+.names pg90 pg24169
+1 1
+.names pg120 pg24178
+1 1
+.names ng106 pg29216
+1 1
+.names ng59 pg20049
+1 1
+.names ng11893 pg25259
+1 1
+.names ng25590 pg25583
+1 1
+.names ng121 pg29219
+1 1
+.names ng20682 pg33959
+1 1
+.names ng128 pg21245
+1 1
+.names ng25590 pg25584
+1 1
+.names ng66 pg29218
+1 1
+.names ng25590 pg25585
+1 1
+.names pg6753 pg18092
+1 1
+.names ng25590 pg25586
+1 1
+.names ng106 pg21176
+1 1
+.names ng10588 pg25114
+1 1
+.names ng25590 pg25590
+1 1
+.names pg6748 pg18094
+1 1
+.names ng66 pg18881
+1 1
+.names ng1242 pg23683
+1 1
+.names pg6749 pg18095
+1 1
+.names pg6750 pg18096
+1 1
+.names ng117 pg21270
+1 1
+.names ng25590 pg25582
+1 1
+.names ng12729 pg31863
+1 1
+.names ng17292 pg27831
+1 1
+.names ng5343 pg31861
+1 1
+.names ng11893 pg31862
+1 1
+.names [1457] pg8283
+1 1
+.names ng25590 pg25587
+1 1
+.names ng25531 pg31665
+1 1
+.names pg36 pg21698
+1 1
+.names ng25590 pg25588
+1 1
+.names ng10588 pg31860
+1 1
+.names ng25590 pg25589
+1 1
+.names ng20682 pg28753
+1 1
+.names ng25537 pg31656
+1 1
+.names [1421] pg8178
+1 1
+.names ng2927 ng2922 [3134]
+11 1
+.names ni30330 ng31070 [34258] [34259] [3137]
+0011 1
+.names ng31070 [34230] [34265] [3138]
+111 1
+.names ni31121 ng31070 [34266] [34267] [3139]
+1011 1
+.names ni31171 ng31070 [34202] [34242] [3140]
+1011 1
+.names ng31710 ng31070 [34241] [34271] [3141]
+0011 1
+.names ni30330 ng31070 [34225] [34226] [3148]
+0011 1
+.names ng31070 [34230] [34234] [3149]
+111 1
+.names ni31121 ng31070 [34235] [34236] [3150]
+1011 1
+.names ng30673 ni31171 ng31070 [34242] [3151]
+0101 1
+.names ng31710 ng31070 [34241] [34244] [3152]
+0011 1
+.names ni31141 ng31070 [34207] [34208] [3155]
+1011 1
+.names ni31191 ng31070 [34211] [34212] [3156]
+1011 1
+.names ni31271 ng31070 [34215] [34216] [3157]
+1011 1
+.names ni31106 ng31070 [34219] [34220] [3158]
+1011 1
+.names ng31021 ni31141 [34169] [34170] [3159]
+0111 1
+.names ng31021 ni31191 [34173] [34174] [3160]
+0111 1
+.names ng31021 ni31271 [34177] [34178] [3161]
+0111 1
+.names ni31106 ng31021 [34181] [34182] [3162]
+1011 1
+.names ni30330 [34185] [34186] [3163]
+011 1
+.names ng31021 ni30330 ng31327 [34189] [3164]
+0001 1
+.names ni30330 ng31710 ng31070 [34156] [3165]
+0001 1
+.names ni30330 ng31566 ng31070 [34156] [3166]
+0001 1
+.names ng31021 ng31710 [34188] [34193] [3167]
+0011 1
+.names ng31021 ni30330 [34120] [34121] [3170]
+0011 1
+.names ng31021 ni31141 [34126] [34127] [3171]
+0111 1
+.names ng31021 ni31191 [34132] [34133] [3172]
+0111 1
+.names ng31021 ni31271 [34138] [34139] [3173]
+0111 1
+.names ni31106 ng31021 [34144] [34145] [3174]
+1011 1
+.names ng31021 ni31221 [34150] [34151] [3175]
+0111 1
+.names ng30673 ni31121 ng31070 [34156] [3176]
+0101 1
+.names ng31070 [34156] [34160] [3177]
+011 1
+.names [34071] [34072] [34078] [34079] [3183]
+1111 1
+.names [34071] [34072] [34082] [34083] [3184]
+1111 1
+.names [32354] [32355] [34085] [34086] [3185]
+0011 1
+.names [32354] [32355] [34088] [34089] [3186]
+0011 1
+.names [32354] [32355] [34091] [34092] [3187]
+0011 1
+.names [32354] [32355] [34095] [3189]
+001 1
+.names pg72 ng4322 [28640] [34062] [3190]
+1111 1
+0011 1
+.names pg72 ng4322 [29233] [34063] [3191]
+1111 1
+0011 1
+.names ng4125 ng4112 ng11245 [34059] [3192]
+0101 1
+.names ng26703 ng17321 [34008] [34009] [3203]
+--11 1
+00-1 1
+.names pg35 ng2161 [3205]
+01 1
+.names pg35 ng5462 [3209]
+01 1
+.names pg35 ng5953 [3212]
+01 1
+.names pg35 ng5607 [3215]
+01 1
+.names pg35 ng2279 [3228]
+01 1
+.names ng2735 ng2741 ng17297 [33983] [3229]
+1101 1
+.names ng2735 ng2741 ng17297 [33985] [3230]
+0--1 1
+-0-1 1
+--11 1
+.names pg35 ng3929 [3234]
+01 1
+.names pg35 ng6303 [3237]
+01 1
+.names pg35 ng763 [3240]
+01 1
+.names pg35 ng6617 [3253]
+01 1
+.names pg35 ng6589 [3256]
+01 1
+.names ng17405 ng26737 ng28799 [33956] [3257]
+1-01 1
+-101 1
+.names pg35 ng2331 ng17405 ng26737 [3258]
+1100 1
+.names ng14367 [7725] [28488] [33931] [3267]
+-1-1 1
+1-11 1
+.names ng14367 [7725] [28488] [33934] [3268]
+-1-1 1
+1-11 1
+.names ng14367 [7725] [28488] [33936] [3269]
+-1-1 1
+1-11 1
+.names ng14367 [7725] [28488] [33938] [3271]
+00-1 1
+-001 1
+.names ng14367 [7725] [28488] [33939] [3272]
+-1-1 1
+1-11 1
+.names pg35 ng2485 [3274]
+01 1
+.names pg35 ng969 ng1193 ng1008 [3276]
+1-0- 1
+10-0 1
+.names pg35 ng1312 ng1351 ng1536 [3278]
+1--0 1
+100- 1
+.names pg35 ng3913 [3281]
+01 1
+.names ng26759 ng14438 ng9755 [33922] [3284]
+--01 1
+00-1 1
+.names ng2084 ng26759 ng14438 ng9755 [3285]
+11-1 1
+1-11 1
+.names pg35 ng5599 [3289]
+01 1
+.names pg35 ng744 [3292]
+01 1
+.names pg35 ng3602 [3295]
+01 1
+.names pg35 ng2831 [3298]
+01 1
+.names pg35 ng4581 ng4372 [3304]
+101 1
+.names pg35 ng6235 [3307]
+01 1
+.names ng14367 [6172] [30555] [33896] [3326]
+00-1 1
+-001 1
+.names ng2185 ng14367 [6172] [30555] [3327]
+1-1- 1
+11-1 1
+.names ng17405 ng26737 [33887] [33889] [3336]
+--11 1
+00-1 1
+.names pg35 ng2299 [3337]
+01 1
+.names ng1772 ng28761 ng17317 ng26694 [3343]
+101- 1
+10-1 1
+.names pg35 ng1802 ng17317 ng26694 [3344]
+1100 1
+.names pg35 ng2681 [3349]
+01 1
+.names ng14367 [6319] [30342] [33869] [3350]
+-1-1 1
+1-11 1
+.names ng14367 [6319] [30342] [33870] [3351]
+00-1 1
+-001 1
+.names pg35 ng3574 [3356]
+01 1
+.names pg35 ng626 ng14708 [33854] [3367]
+1011 1
+.names pg35 ng632 ng14708 [33857] [3368]
+1001 1
+.names pg35 ng626 ng14708 [33860] [3369]
+1001 1
+.names pg35 ng559 [3370]
+01 1
+.names pg35 ng5591 [3376]
+01 1
+.names [29834] [29835] [29836] [33832] [3382]
+1--1 1
+-1-1 1
+--11 1
+.names [29834] [29835] [29836] [33834] [3383]
+1--1 1
+-1-1 1
+--11 1
+.names pg35 ng4340 ng4349 ng4358 [3384]
+1100 1
+.names pg35 ng4340 ng4349 ng4358 [3385]
+1111 1
+.names pg35 ng5913 [3389]
+01 1
+.names ng26793 ng14506 ng9835 [33803] [3393]
+1-11 1
+-111 1
+.names ng26793 ng14506 ng9835 [33804] [3394]
+1-11 1
+-111 1
+.names ng26793 ng14506 ng9835 [33805] [3395]
+--01 1
+00-1 1
+.names pg35 ng2667 [3396]
+01 1
+.names pg35 ng142 [3399]
+01 1
+.names pg35 ng401 [3402]
+01 1
+.names pg35 ng990 ng979 ng1008 [3407]
+1001 1
+.names ng990 ng979 ng969 ng996 [3408]
+-110 1
+1011 1
+.names pg35 ng969 [3409]
+01 1
+.names ng26725 ng17401 [30477] [33781] [3411]
+--11 1
+00-1 1
+.names pg35 ng1890 [3412]
+01 1
+.names pg35 ng604 [3418]
+01 1
+.names pg35 ng4939 [3422]
+01 1
+.names pg35 ng2652 [3426]
+01 1
+.names ng17317 ng26694 [33758] [33760] [3431]
+--11 1
+00-1 1
+.names pg35 ng1736 [3432]
+01 1
+.names pg35 ng3925 [3435]
+01 1
+.names pg35 ng1917 [3442]
+01 1
+.names ng9649 ng26703 ng17321 [33743] [3443]
+0--1 1
+-001 1
+.names ng2241 ng9649 ng26703 ng17321 [3444]
+111- 1
+11-1 1
+.names pg35 ng5929 [3453]
+01 1
+.names pg35 ng914 [3456]
+01 1
+.names pg35 ng6271 [3462]
+01 1
+.names pg17604 pg13049 ng10160 [33726] [3464]
+0011 1
+.names ng14367 [6172] [30555] [33703] [3465]
+-1-1 1
+1-11 1
+.names ng14367 [6172] [30555] [33706] [3466]
+-1-1 1
+1-11 1
+.names ng14367 [6172] [30555] [33708] [3467]
+-1-1 1
+1-11 1
+.names ng14367 [6172] [30555] [33709] [3468]
+-1-1 1
+1-11 1
+.names ng14367 [6172] [30555] [33711] [3470]
+00-1 1
+-001 1
+.names pg35 ng2217 [3471]
+01 1
+.names pg35 ng4411 [3485]
+01 1
+.names pg35 ng1825 [3492]
+01 1
+.names pg35 ng5260 [3495]
+01 1
+.names ng26770 ng17424 ng11960 [33682] [3497]
+--01 1
+00-1 1
+.names pg35 ng2437 [3498]
+01 1
+.names pg35 ng4785 [3501]
+01 1
+.names [33024] [33025] [33048] [33670] [3504]
+1--1 1
+-1-1 1
+--11 1
+.names [33024] [33025] [33048] [33672] [3505]
+0001 1
+.names [6966] [6967] [29216] [33673] [3506]
+0001 1
+.names pg35 ng3462 [3507]
+01 1
+.names ng26673 ng17292 [33659] [33661] [3521]
+--11 1
+00-1 1
+.names pg35 ng1616 [3522]
+01 1
+.names pg35 pg12923 ng1395 [3526]
+111 1
+.names pg35 ng4119 [3530]
+01 1
+.names pg35 ng5551 [3533]
+01 1
+.names pg35 ng5208 [3541]
+01 1
+.names pg35 ng2051 [3545]
+01 1
+.names ng14367 [5887] [31005] [33620] [3546]
+-1-1 1
+1-11 1
+.names ng14367 [5887] [31005] [33623] [3547]
+-1-1 1
+1-11 1
+.names ng14367 [5887] [31005] [33625] [3548]
+-1-1 1
+1-11 1
+.names ng14367 [5887] [31005] [33626] [3549]
+-1-1 1
+1-11 1
+.names ng14367 [5887] [31005] [33628] [3551]
+00-1 1
+-001 1
+.names pg35 ng2619 [3553]
+01 1
+.names pg35 ng2384 [3560]
+01 1
+.names ng17317 ng26694 [33608] [33610] [3562]
+--11 1
+00-1 1
+.names pg35 ng1740 [3563]
+01 1
+.names pg17646 pg17739 ng10185 [33606] [3565]
+0011 1
+.names pg35 ng3546 [3571]
+01 1
+.names pg35 ng590 [3574]
+01 1
+.names pg13895 pg14421 ng8691 [33585] [3578]
+0011 1
+.names ng26673 ng9586 ng17292 [33571] [3584]
+11-1 1
+-111 1
+.names ng26673 ng9586 ng17292 [33572] [3585]
+-0-1 1
+0-01 1
+.names ng14367 [6172] [30555] [33563] [3594]
+00-1 1
+-001 1
+.names ng14367 [6172] [30555] [33564] [3595]
+-1-1 1
+1-11 1
+.names [33551] [33552] [33553] [33554] [3600]
+0-01 1
+-001 1
+.names [33551] [33552] [33553] [33555] [3601]
+--11 1
+11-1 1
+.names ng26759 ng14438 ng11956 [33545] [3607]
+--01 1
+00-1 1
+.names pg35 ng2012 [3608]
+01 1
+.names ng26673 ng17292 [33536] [33538] [3616]
+--11 1
+00-1 1
+.names pg35 ng1604 [3617]
+01 1
+.names ng34162 [31938] [31939] [33533] [3618]
+1--1 1
+-0-1 1
+--11 1
+.names ng34162 [31938] [31939] [33534] [3619]
+0101 1
+.names pg35 ng5575 [3629]
+01 1
+.names pg35 ng4801 [3632]
+01 1
+.names pg35 ng5052 [3635]
+01 1
+.names pg35 ng1018 [3642]
+01 1
+.names ng30583 ng24411 [6408] [33510] [3643]
+0101 1
+.names ng30583 ng24411 [6408] [33512] [3644]
+0001 1
+.names pg35 ng6173 [3649]
+01 1
+.names pg35 ng1720 [3653]
+01 1
+.names pg35 ng3106 [3657]
+01 1
+.names pg35 ni24685 [29414] [3658]
+10- 1
+1-1 1
+.names pg35 ng17657 ng17700 [3659]
+11- 1
+1-1 1
+.names pg35 ng6275 [3667]
+01 1
+.names pg35 ng5571 [3676]
+01 1
+.names ng25917 [4362] [4669] [33472] [3677]
+0001 1
+.names ng25917 [4362] [4669] [33473] [3678]
+1--1 1
+-1-1 1
+--11 1
+.names pg35 ng291 [3688]
+01 1
+.names pg35 ng3582 [3691]
+01 1
+.names ng26793 ng14506 [33455] [33457] [3693]
+--11 1
+00-1 1
+.names pg35 ng2567 [3694]
+01 1
+.names ng28504 [28813] [28814] [33452] [3695]
+1--1 1
+-0-1 1
+--11 1
+.names ng28504 [28813] [28814] [33453] [3696]
+0101 1
+.names ng13336 ng13846 [33428] [33429] [3704]
+0011 1
+.names ng13336 ng13846 [33432] [33433] [3705]
+1011 1
+.names pg35 ng4653 [3712]
+01 1
+.names pg35 ng5579 [3719]
+01 1
+.names [30977] [30978] [31001] [33410] [3720]
+1--1 1
+-1-1 1
+--11 1
+.names [30977] [30978] [31001] [33412] [3721]
+0001 1
+.names [7624] [7625] [28651] [33413] [3722]
+0001 1
+.names pg35 ng5120 [3723]
+01 1
+.names pg35 ng2342 [3727]
+01 1
+.names ng14367 [6172] [30555] [33397] [3729]
+-1-1 1
+1-11 1
+.names ng14367 [6172] [30555] [33398] [3730]
+00-1 1
+-001 1
+.names pg35 ng6593 [3736]
+01 1
+.names ng17317 ng26694 ng9640 [33386] [3746]
+--01 1
+00-1 1
+.names pg35 ng1821 [3747]
+01 1
+.names pg35 ng3203 [3752]
+01 1
+.names ng9694 ng26725 ng17401 [33377] [3755]
+11-1 1
+1-11 1
+.names ng9694 ng26725 ng17401 [33378] [3756]
+11-1 1
+1-11 1
+.names ng9694 ng26725 ng17401 [33379] [3757]
+0--1 1
+-001 1
+.names pg35 ng1974 [3758]
+01 1
+.names ng26770 ng17424 [33372] [33374] [3760]
+--11 1
+00-1 1
+.names pg35 ng2433 [3761]
+01 1
+.names ng1129 ng13307 ng13336 [33366] [3762]
+0011 1
+1001 1
+.names pg35 ng1129 ng1124 ng13336 [3763]
+1011 1
+1110 1
+.names ng9694 ng26725 ng17401 [33364] [3768]
+0--1 1
+-001 1
+.names ng1968 ng9694 ng26725 ng17401 [3769]
+111- 1
+11-1 1
+.names ng9649 ng26703 ng17321 [33362] [3771]
+0--1 1
+-001 1
+.names ng2259 ng9649 ng26703 ng17321 [3772]
+111- 1
+11-1 1
+.names pg35 ng1495 ng1489 [3780]
+101 1
+.names [29834] [29835] [29836] [33353] [3782]
+1--1 1
+-1-1 1
+--11 1
+.names ng14367 [7030] [29111] [33349] [3786]
+-1-1 1
+1-11 1
+.names ng14367 [7030] [29111] [33350] [3787]
+00-1 1
+-001 1
+.names pg35 ng5264 [3791]
+01 1
+.names [7046] [7047] [29091] [33335] [3801]
+0001 1
+.names [30659] [30660] [30683] [33336] [3802]
+1--1 1
+-1-1 1
+--11 1
+.names ng14367 [6655] [29571] [33330] [3804]
+-1-1 1
+1-11 1
+.names ng14367 [6655] [29571] [33331] [3805]
+00-1 1
+-001 1
+.names pg35 ng4601 [3810]
+01 1
+.names pg35 ng3566 [3816]
+01 1
+.names pg35 ng4581 ng4372 [3821]
+101 1
+.names pg35 ng2173 [3827]
+01 1
+.names ng14367 [7257] [28834] [33302] [3828]
+-1-1 1
+1-11 1
+.names ng14367 [7257] [28834] [33303] [3829]
+00-1 1
+-001 1
+.names ng817 ng8806 ng14279 [33291] [3837]
+1001 1
+.names ng817 ng8806 ng14279 [33293] [3838]
+0-01 1
+-101 1
+.names pg35 ng5941 [3845]
+01 1
+.names pg35 ng2208 [3849]
+01 1
+.names ng17405 ng26737 ng9700 [33273] [3853]
+1-11 1
+-111 1
+.names ng17405 ng26737 ng9700 [33275] [3854]
+1-11 1
+-111 1
+.names ng17405 ng26737 ng9700 [33276] [3855]
+--01 1
+00-1 1
+.names pg35 ng2399 [3856]
+01 1
+.names pg35 ng1802 [3860]
+01 1
+.names pg35 ng5212 [3868]
+01 1
+.names pg35 ng1221 [3874]
+01 1
+.names pg35 ng6613 [3880]
+01 1
+.names pg35 ng5945 [3883]
+01 1
+.names pg35 ng153 [3886]
+01 1
+.names pg35 ng3562 [3889]
+01 1
+.names pg35 ng6621 [3892]
+01 1
+.names pg116 pg114 pg35 ng4157 [3894]
+1-11 1
+-110 1
+.names ng26770 ng17424 ng9762 [33238] [3895]
+--01 1
+00-1 1
+.names pg35 ng2514 [3897]
+01 1
+.names ng26759 ng14438 ng9755 [33234] [3902]
+--01 1
+00-1 1
+.names pg35 ng2089 [3903]
+01 1
+.names ng26673 ng9586 ng17292 [33231] [3905]
+-0-1 1
+0-01 1
+.names pg35 ng1687 [3906]
+01 1
+.names pg73 pg72 pg35 ng2988 [3910]
+0011 1
+.names pg35 ng4564 [3912]
+01 1
+.names pg35 ng5595 [3915]
+01 1
+.names pg35 ng5917 [3918]
+01 1
+.names pg35 ng5961 [3921]
+01 1
+.names ng14367 [6655] [29571] [33208] [3922]
+00-1 1
+-001 1
+.names ng1894 ng14367 [6655] [29571] [3924]
+1-1- 1
+11-1 1
+.names pg17519 pg13039 ng10124 [33189] [3926]
+0011 1
+.names pg12238 pg13039 ng10124 [33194] [3927]
+1011 1
+.names [33199] [33200] [3928]
+11 1
+.names pg12238 pg13039 ng10124 [33204] [3929]
+1011 1
+.names pg35 ng3953 [3932]
+01 1
+.names ng17405 ng26737 ng9700 [33181] [3939]
+--01 1
+00-1 1
+.names pg35 ng2380 [3940]
+01 1
+.names pg35 ng5244 [3946]
+01 1
+.names pg35 ng4349 [3952]
+01 1
+.names pg35 ng5268 [3955]
+01 1
+.names pg35 ng3610 [3958]
+01 1
+.names ng25233 [29550] [29551] [33161] [3961]
+0001 1
+.names pg35 ng5046 ng25233 [3962]
+101 1
+.names ng14367 [6319] [30342] [33156] [3967]
+00-1 1
+-001 1
+.names ng14367 [6319] [30342] [33158] [3969]
+-1-1 1
+1-11 1
+.names pg35 ng5148 [3974]
+01 1
+.names ng26673 ng9586 ng17292 [33143] [3975]
+11-1 1
+-111 1
+.names ng26673 ng9586 ng17292 [33145] [3976]
+11-1 1
+-111 1
+.names ng26673 ng9586 ng17292 [33146] [3977]
+-0-1 1
+0-01 1
+.names pg35 ng1706 [3978]
+01 1
+.names ng26673 ng9586 ng17292 [33140] [3979]
+-0-1 1
+0-01 1
+.names ng1682 ng26673 ng9586 ng17292 [3980]
+111- 1
+1-11 1
+.names pg35 ng3554 [3984]
+01 1
+.names pg35 ng5841 [3988]
+01 1
+.names pg35 ng4116 [3991]
+01 1
+.names pg35 ng6605 [3994]
+01 1
+.names pg35 ng2795 [3998]
+01 1
+.names pg35 ng5901 [4001]
+01 1
+.names pg35 ng1263 ng1270 ng25895 [4003]
+1100 1
+.names pg35 ng667 [4007]
+01 1
+.names ng9694 ng26725 ng17401 [33102] [4011]
+0--1 1
+-001 1
+.names ng1950 ng9694 ng26725 ng17401 [4012]
+111- 1
+11-1 1
+.names ng17317 ng26694 ng9640 [33096] [4016]
+1-11 1
+-111 1
+.names ng17317 ng26694 ng9640 [33098] [4017]
+1-11 1
+-111 1
+.names ng17317 ng26694 ng9640 [33099] [4018]
+--01 1
+00-1 1
+.names pg35 ng1840 [4019]
+01 1
+.names pg35 ng613 [4025]
+01 1
+.names pg35 ng5069 ng5077 ng5084 [4034]
+1011 1
+.names pg35 ng3231 [4041]
+01 1
+.names pg35 ng168 [4044]
+01 1
+.names ng26759 ng14438 [32138] [33069] [4045]
+--11 1
+00-1 1
+.names pg35 ng2024 [4047]
+01 1
+.names pg35 ng6247 [4050]
+01 1
+.names ng14367 [5887] [31005] [33061] [4051]
+-1-1 1
+1-11 1
+.names ng14367 [5887] [31005] [33063] [4053]
+00-1 1
+-001 1
+.names pg35 ng572 [4064]
+01 1
+.names [6966] [6967] [29216] [32991] [4068]
+0001 1
+.names [33024] [33025] [33048] [33049] [4069]
+1--1 1
+-1-1 1
+--11 1
+.names ng843 ng847 ng8806 [32987] [4094]
+1101 1
+.names ng843 ng847 ng8806 [32989] [4095]
+0--1 1
+-0-1 1
+--11 1
+.names pg35 ng4054 [4099]
+01 1
+.names ng14708 [28793] [28794] [32978] [4100]
+0--1 1
+-1-1 1
+--01 1
+.names ng14708 [28793] [28794] [32979] [4101]
+1011 1
+.names ng29503 ng14438 ng27469 [32969] [4106]
+1111 1
+.names ng29503 ng14438 ng27469 [32971] [4107]
+1111 1
+.names ng29503 ng14438 ng27469 [32972] [4108]
+0--1 1
+-0-1 1
+--01 1
+.names pg35 ng1996 [4109]
+01 1
+.names pg35 ng4659 [4112]
+01 1
+.names pg35 ng1259 [4115]
+01 1
+.names pg35 ng3352 [4118]
+01 1
+.names pg35 ng2441 [4124]
+01 1
+.names pg35 ng262 [4127]
+01 1
+.names pg35 ng6295 [4133]
+01 1
+.names pg35 ng2787 [4137]
+01 1
+.names ng10756 [28765] [28766] [32928] [4144]
+11-1 1
+1-11 1
+.names ng10756 [28765] [28766] [32929] [4145]
+0--1 1
+-001 1
+.names pg35 ng3538 [4154]
+01 1
+.names pg35 ng2287 ng17405 ng26737 [4156]
+1100 1
+.names ng13378 ng13273 [32898] [32899] [4157]
+0011 1
+.names ng13378 ng13273 [32902] [32903] [4158]
+1011 1
+.names pg35 ng739 [4168]
+01 1
+.names pg35 ng1612 [4172]
+01 1
+.names pg35 ng758 [4175]
+01 1
+.names ng21012 ng25851 [32672] [32879] [4176]
+10-1 1
+1-01 1
+.names [7248] [7249] [28843] [32881] [4177]
+0001 1
+.names ng26793 ng14506 ng11978 [32875] [4189]
+--01 1
+00-1 1
+.names pg35 ng2571 [4190]
+01 1
+.names ng14367 [7257] [28834] [32869] [4191]
+00-1 1
+-001 1
+.names ng14367 [7257] [28834] [32871] [4193]
+-1-1 1
+1-11 1
+.names pg35 ng6279 [4197]
+01 1
+.names ng14367 [7041] [29097] [32863] [4199]
+00-1 1
+-001 1
+.names ng1624 ng14367 [7041] [29097] [4200]
+1-1- 1
+11-1 1
+.names pg35 ng146 [4204]
+01 1
+.names pg35 ng3937 [4207]
+01 1
+.names pg35 ng5703 [4210]
+01 1
+.names ng17405 ng26737 [32841] [32843] [4220]
+--11 1
+00-1 1
+.names pg35 ng2295 [4221]
+01 1
+.names pg35 ng5200 [4226]
+01 1
+.names pg35 ng1536 [7193] [28903] [4227]
+101- 1
+10-1 1
+.names ng1542 ng10918 [28896] [32832] [4228]
+0--1 1
+-1-1 1
+--01 1
+.names ng29503 ng27395 ng17292 [32823] [4233]
+1111 1
+.names ng29503 ng27395 ng17292 [32825] [4234]
+1111 1
+.names ng29503 ng27395 ng17292 [32826] [4235]
+0--1 1
+-0-1 1
+--01 1
+.names pg35 ng1592 [4236]
+01 1
+.names pg35 ng5196 [4242]
+01 1
+.names pg35 ng1280 [4248]
+01 1
+.names ng20875 ng25851 [31986] [32802] [4253]
+10-1 1
+1-01 1
+.names [7351] [7352] [28734] [32804] [4254]
+0001 1
+.names ng26759 ng14438 ng28833 [32787] [4278]
+1-01 1
+-101 1
+.names pg35 ng2040 ng26759 ng14438 [4279]
+1100 1
+.names pg35 ng3207 [4283]
+01 1
+.names pg35 ng3586 [4288]
+01 1
+.names pg35 ng4664 [4291]
+01 1
+.names pg35 ng3941 [4300]
+01 1
+.names pg35 ng239 [4303]
+01 1
+.names pg35 ng3703 [4306]
+01 1
+.names ng2599 ng28880 ng26793 ng14506 [4308]
+101- 1
+10-1 1
+.names pg35 ng2599 [4309]
+01 1
+.names pg35 ng6629 [4314]
+01 1
+.names ng2759 ng2756 ng25317 [32749] [4315]
+1111 1
+.names ng2759 ng2756 ng25317 [32750] [4316]
+0--1 1
+-0-1 1
+--01 1
+.names ng26770 ng17424 ng9762 [32747] [4319]
+--01 1
+00-1 1
+.names ng2509 ng26770 ng17424 ng9762 [4320]
+11-1 1
+1-11 1
+.names ng14367 [7030] [29111] [32728] [4332]
+-1-1 1
+1-11 1
+.names ng14367 [7030] [29111] [32731] [4333]
+-1-1 1
+1-11 1
+.names ng14367 [7030] [29111] [32733] [4334]
+-1-1 1
+1-11 1
+.names ng14367 [7030] [29111] [32734] [4335]
+-1-1 1
+1-11 1
+.names ng14367 [7030] [29111] [32735] [4336]
+00-1 1
+-001 1
+.names pg35 ng2351 [4339]
+01 1
+.names pg35 ng2227 [4343]
+01 1
+.names pg35 ng626 [4355]
+01 1
+.names pg35 ng25917 [4362] [4669] [4359]
+1010 1
+.names pg35 ng1367 [4361]
+01 1
+.names ng1373 ng15748 [4362]
+00 1
+.names pg35 ng5603 [4366]
+01 1
+.names ng911 ng907 ng19063 [32699] [4367]
+1111 1
+.names ng911 ng907 ng19063 [32700] [4368]
+0--1 1
+-0-1 1
+--01 1
+.names pg35 ng3961 [4378]
+01 1
+.names pg35 ng6395 [4403]
+01 1
+.names ng26725 ng17401 [32668] [32669] [4404]
+--11 1
+00-1 1
+.names pg35 ng1886 [4406]
+01 1
+.names pg35 ng714 ng703 ng691 [4414]
+1011 1
+.names [30802] [30803] [32625] [32661] [4415]
+1-01 1
+-101 1
+.names pg35 ng79 [4417]
+01 1
+.names pg35 ng2070 [4421]
+01 1
+.names pg35 ng1322 ng1351 ng1333 [4429]
+1010 1
+.names ng1322 ng1312 ng1333 ng1339 [4430]
+11-0 1
+0111 1
+.names pg35 ng1312 [4431]
+01 1
+.names pg35 ng6283 [4439]
+01 1
+.names ng26770 ng17424 ng9762 [32636] [4445]
+--01 1
+00-1 1
+.names ng2527 ng26770 ng17424 ng9762 [4446]
+11-1 1
+1-11 1
+.names ng26793 ng14506 ng9835 [32633] [4456]
+1-11 1
+-111 1
+.names ng26793 ng14506 ng9835 [32634] [4457]
+--01 1
+00-1 1
+.names pg35 ng4961 [4462]
+01 1
+.names [30802] [30803] [32625] [32626] [4466]
+--11 1
+00-1 1
+.names pg35 ng691 [4467]
+01 1
+.names pg35 ng812 [4470]
+01 1
+.names ng31509 [30328] [30329] [32616] [4477]
+1--1 1
+-0-1 1
+--11 1
+.names ng31509 [30328] [30329] [32617] [4478]
+0101 1
+.names pg35 ng225 [4486]
+01 1
+.names ng26673 ng17292 [31143] [32610] [4488]
+--11 1
+00-1 1
+.names pg35 ng1620 [4489]
+01 1
+.names pg35 ng2555 ng26793 ng14506 [4493]
+1100 1
+.names ng26793 ng14506 ng9835 [32602] [4494]
+--01 1
+00-1 1
+.names ng2661 ng26793 ng14506 ng9835 [4495]
+11-1 1
+1-11 1
+.names pg35 ng790 [4499]
+01 1
+.names ng17405 ng26737 [32594] [32596] [4505]
+--11 1
+00-1 1
+.names pg35 ng2315 [4506]
+01 1
+.names pg35 ng1542 [4509]
+01 1
+.names ng14367 [5887] [31005] [32583] [4514]
+00-1 1
+-001 1
+.names ng14367 [5887] [31005] [32584] [4515]
+-1-1 1
+1-11 1
+.names ng4087 ng4076 ng13217 [32578] [4517]
+1101 1
+.names ng4087 ng4076 ng13217 [32580] [4518]
+0--1 1
+-0-1 1
+--11 1
+.names pg35 ng5949 [4525]
+01 1
+.names ng26725 ng17401 ng11937 [32571] [4528]
+--01 1
+00-1 1
+.names pg35 ng1878 [4530]
+01 1
+.names [29451] [29452] [29475] [32565] [4531]
+1--1 1
+-1-1 1
+--11 1
+.names [29451] [29452] [29475] [32567] [4532]
+0001 1
+.names [7351] [7352] [28734] [32568] [4533]
+0001 1
+.names pg35 ng5813 [4534]
+01 1
+.names pg35 ng4818 [4537]
+01 1
+.names ng10756 [28765] [28766] [32554] [4538]
+11-1 1
+1-11 1
+.names ng10756 [28765] [28766] [32555] [4539]
+0--1 1
+-001 1
+.names ng10756 [28765] [28766] [32556] [4540]
+11-1 1
+1-11 1
+.names pg35 ng3827 [4541]
+01 1
+.names pg35 ng1178 [4550]
+01 1
+.names pg35 ng518 [4570]
+01 1
+.names pg35 ng1648 [4574]
+01 1
+.names ng24875 [28810] [28811] [32526] [4577]
+0--1 1
+-1-1 1
+--01 1
+.names ng24875 [28810] [28811] [32527] [4578]
+1011 1
+.names ng17317 ng26694 [32521] [32523] [4581]
+--11 1
+00-1 1
+.names pg35 ng1752 [4582]
+01 1
+.names ng26770 ng17424 ng28846 [32517] [4583]
+1-01 1
+-101 1
+.names pg35 ng2465 ng26770 ng17424 [4584]
+1100 1
+.names ng4785 ng4709 ng11261 [32511] [4590]
+0011 1
+.names pg35 ng3490 [4595]
+01 1
+.names ng4054 [28765] [28766] [32476] [4596]
+11-1 1
+1-11 1
+.names ng4054 [28765] [28766] [32482] [4598]
+11-1 1
+1-11 1
+.names ng4975 ng4899 ng11283 [32486] [4600]
+0111 1
+.names pg35 ng4818 [4604]
+01 1
+.names pg35 ng4760 [4608]
+01 1
+.names pg35 ng617 [4623]
+01 1
+.names pg35 ng3542 [4626]
+01 1
+.names pg35 ng2775 [4630]
+01 1
+.names pg35 ng4621 [4633]
+01 1
+.names ng13336 ng13260 [32408] [32409] [4652]
+0011 1
+.names ng13336 ng13260 [32412] [32413] [4653]
+1011 1
+.names ng14367 [7041] [29097] [32404] [4659]
+-1-1 1
+1-11 1
+.names ng14367 [7041] [29097] [32405] [4660]
+00-1 1
+-001 1
+.names ng14367 [6319] [30342] [32399] [4663]
+00-1 1
+-001 1
+.names ng2028 ng14367 [6319] [30342] [4664]
+1-1- 1
+11-1 1
+.names ng1367 ng15748 [4669]
+00 1
+.names pg35 ng3187 [4673]
+01 1
+.names ng9694 ng26725 ng17401 [32388] [4676]
+11-1 1
+1-11 1
+.names ng9694 ng26725 ng17401 [32389] [4677]
+0--1 1
+-001 1
+.names pg35 ng4145 [4681]
+01 1
+.names ng9649 ng26703 ng17321 [32383] [4683]
+0--1 1
+-001 1
+.names pg35 ng2246 [4684]
+01 1
+.names ng11320 [32377] [32378] [32379] [4685]
+0111 1
+.names pg35 ng6219 [4689]
+01 1
+.names ng9649 ng26703 ng17321 [32363] [4692]
+11-1 1
+1-11 1
+.names ng9649 ng26703 ng17321 [32364] [4693]
+0--1 1
+-001 1
+.names pg35 ng896 ng862 [4708]
+101 1
+.names ng26793 ng14506 ng9835 [32341] [4711]
+--01 1
+00-1 1
+.names pg35 ng2648 [4712]
+01 1
+.names pg35 ng4593 [4715]
+01 1
+.names ng26793 ng14506 ng9835 [32333] [4721]
+--01 1
+00-1 1
+.names ng2643 ng26793 ng14506 ng9835 [4722]
+11-1 1
+1-11 1
+.names ng17405 ng26737 ng9700 [32331] [4724]
+--01 1
+00-1 1
+.names ng2375 ng17405 ng26737 ng9700 [4725]
+11-1 1
+1-11 1
+.names pg35 ng3558 [4729]
+01 1
+.names pg35 ng1691 [4736]
+01 1
+.names [7248] [7249] [28843] [32316] [4740]
+0001 1
+.names [32202] [32203] [32226] [32317] [4741]
+1--1 1
+-1-1 1
+--11 1
+.names pg35 ng6307 [4745]
+01 1
+.names pg35 ng4572 [4749]
+01 1
+.names pg35 ng59 [4757]
+01 1
+.names [32251] [32252] [32253] [4759]
+111 1
+.names ng4688 ng4776 [32259] [32260] [4760]
+0011 1
+.names ng4688 ng4776 [32266] [32267] [4761]
+0011 1
+.names [32269] [32270] [32288] [32289] [4764]
+1-11 1
+-111 1
+.names ng4681 ng4646 ng11261 [32293] [4765]
+0011 1
+.names pg35 ng4826 ng4688 [4766]
+101 1
+.names pg35 ng4674 ng4821 [4767]
+110 1
+.names pg35 ng128 ng4646 [4768]
+111 1
+.names pg35 ng4831 ng4681 [4769]
+111 1
+.names pg35 ng4049 [4783]
+01 1
+.names pg35 ng5248 [4794]
+01 1
+.names [32202] [32203] [32226] [32228] [4795]
+1--1 1
+-1-1 1
+--11 1
+.names [32202] [32203] [32226] [32230] [4796]
+0001 1
+.names [7248] [7249] [28843] [32231] [4797]
+0001 1
+.names pg35 ng6159 [4798]
+01 1
+.names pg73 pg72 pg35 ng255 [4826]
+1011 1
+.names pg73 pg72 pg35 ng269 [4827]
+0011 1
+.names pg73 pg72 pg35 ng262 [4828]
+0111 1
+.names pg16627 pg16656 ng8728 [32151] [4834]
+0011 1
+.names pg35 ng1996 ng26759 ng14438 [4836]
+1100 1
+.names pg35 ng3179 [4839]
+01 1
+.names pg73 pg72 pg35 ng4581 [4842]
+1-11 1
+-111 1
+.names pg35 ng4578 ng4581 [4843]
+111 1
+.names pg35 ng5897 [4857]
+01 1
+.names pg35 ng3239 [4860]
+01 1
+.names pg35 ng1193 [7709] [28519] [4861]
+101- 1
+10-1 1
+.names ng1199 ng10893 [29901] [32117] [4863]
+0--1 1
+-1-1 1
+--01 1
+.names pg35 ng3211 [4870]
+01 1
+.names pg35 ng1559 [4873]
+01 1
+.names ng14367 [6319] [30342] [32101] [4878]
+-1-1 1
+1-11 1
+.names ng14367 [6319] [30342] [32102] [4879]
+00-1 1
+-001 1
+.names ng26793 ng14506 [32095] [32097] [4882]
+--11 1
+00-1 1
+.names pg35 ng2563 [4883]
+01 1
+.names ng26759 ng14438 ng9755 [32093] [4884]
+--01 1
+00-1 1
+.names ng2102 ng26759 ng14438 ng9755 [4885]
+11-1 1
+1-11 1
+.names ng26759 ng14438 [32085] [32087] [4888]
+--11 1
+00-1 1
+.names pg35 ng2004 [4889]
+01 1
+.names pg35 ng3909 [4892]
+01 1
+.names ng26793 ng14506 [32078] [32079] [4893]
+--11 1
+00-1 1
+.names pg35 ng2583 [4895]
+01 1
+.names pg35 ng2547 [4899]
+01 1
+.names pg35 ng2518 [4903]
+01 1
+.names pg35 ng4608 [4906]
+01 1
+.names ng14367 [7725] [28488] [32056] [4908]
+-1-1 1
+1-11 1
+.names ng14367 [7725] [28488] [32057] [4909]
+00-1 1
+-001 1
+.names pg35 ng854 ng11326 [4912]
+111 1
+.names ng691 ng417 ng13657 [32035] [4913]
+0001 1
+.names ng691 ng417 ng13657 [32039] [4914]
+0001 1
+.names ng691 ng417 ng13657 [32043] [4915]
+0011 1
+.names ng691 ng417 ng13657 [32047] [4916]
+0011 1
+.names ng14367 [7030] [29111] [32019] [4929]
+00-1 1
+-001 1
+.names ng14367 [7030] [29111] [32020] [4930]
+-1-1 1
+1-11 1
+.names pg35 ng5188 [4934]
+01 1
+.names pg35 ng5543 [4937]
+01 1
+.names pg35 ng4749 [4941]
+01 1
+.names ng164 ng23042 [28708] [32003] [4944]
+01-1 1
+-101 1
+.names ng164 ng23042 [28708] [32005] [4945]
+1111 1
+.names pg35 ng6243 [4952]
+01 1
+.names pg35 ng6255 [4955]
+01 1
+.names pg35 ng6049 [4958]
+01 1
+.names pg35 ng3881 [4972]
+01 1
+.names pg35 ng4688 [4982]
+01 1
+.names pg35 ng5905 [4988]
+01 1
+.names pg35 ng4633 [4993]
+01 1
+.names pg35 ng1783 [4999]
+01 1
+.names pg35 ng807 [5002]
+01 1
+.names pg35 ng5615 [5005]
+01 1
+.names pg35 ng3235 [5008]
+01 1
+.names pg35 ng3199 [5011]
+01 1
+.names pg35 ng6653 [5018]
+01 1
+.names pg35 ng4878 [5021]
+01 1
+.names pg35 ng1564 [5024]
+01 1
+.names pg35 ng1959 [5036]
+01 1
+.names pg35 ng5925 [5064]
+01 1
+.names pg35 ng1193 [5067]
+01 1
+.names pg35 ng4991 [5070]
+01 1
+.names ng4785 ng4709 ng11261 [31870] [5076]
+0111 1
+.names pg35 ng5921 [5079]
+01 1
+.names pg35 ng3606 [5082]
+01 1
+.names pg35 ng3259 [5085]
+01 1
+.names pg35 ng6519 [5089]
+01 1
+.names pg35 ng3530 [5092]
+01 1
+.names pg35 ng6625 [5098]
+01 1
+.names pg35 ng3949 [5103]
+01 1
+.names pg35 ng2610 [5107]
+01 1
+.names pg35 ng6609 [5120]
+01 1
+.names pg35 ng5555 [5123]
+01 1
+.names pg35 ng3215 [5128]
+01 1
+.names pg35 ng5827 [5132]
+01 1
+.names pg35 ng1668 [5136]
+01 1
+.names pg35 ng2815 [5142]
+01 1
+.names pg35 ng3171 [5145]
+01 1
+.names ng11676 [28525] [28526] [31784] [5148]
+1--1 1
+-0-1 1
+--01 1
+.names ng732 ng11676 [28525] [28526] [5149]
+1011 1
+.names pg35 ng5611 [5156]
+01 1
+.names ng26725 ng17401 [31770] [31772] [5164]
+--11 1
+00-1 1
+.names pg35 ng1870 [5165]
+01 1
+.names ng20887 ni27429 [31757] [31759] [5176]
+10-1 1
+1-01 1
+.names [7137] [7138] [28996] [31761] [5177]
+0001 1
+.names pg35 ng5204 [5183]
+01 1
+.names ng4975 ng4899 ng11283 [31744] [5196]
+0011 1
+.names ng2070 ng2040 ng26314 [30377] [5201]
+1011 1
+.names ng2599 ng2629 ng26314 [29061] [5202]
+0111 1
+.names ng1668 ng1636 ng26314 [30283] [5203]
+1011 1
+.names ng2495 ng2465 ng26314 [29272] [5204]
+1011 1
+.names ng1936 ng1906 ng26314 [30276] [5205]
+1011 1
+.names ng1772 ng1802 ng26314 [28687] [5206]
+0111 1
+.names ng2197 ng2227 ng26314 [30616] [5207]
+0111 1
+.names ng2361 ng2331 ng26314 [30356] [5208]
+1011 1
+.names ng1263 ng1270 ng25895 [31719] [5209]
+1101 1
+.names ng1263 ng1270 ng25895 [31720] [5210]
+0--1 1
+-0-1 1
+--11 1
+.names pg35 ng5236 [5214]
+01 1
+.names pg35 ng4311 [5217]
+01 1
+.names pg35 ng6267 [5231]
+01 1
+.names pg35 ng562 [5251]
+01 1
+.names ng23586 [29550] [29551] [31679] [5258]
+1001 1
+.names ng5037 ng17217 ng14317 [31681] [5259]
+00-1 1
+1-01 1
+.names pg35 ng513 [5273]
+01 1
+.names pg35 ng1146 ng1152 [5276]
+110 1
+.names pg35 ng5873 [5279]
+01 1
+.names pg35 ng150 [5289]
+01 1
+.names pg35 ng872 [5294]
+01 1
+.names ng979 ng996 ng11846 [31634] [5299]
+1111 1
+0011 1
+.names pg35 ng990 ng979 ng969 [5302]
+1001 1
+.names pg35 ng1728 ng17317 ng26694 [5304]
+1100 1
+.names ng4375 ng4411 [29326] [31622] [5308]
+1--1 1
+-1-1 1
+--01 1
+.names pg35 [29325] [29326] [30770] [5309]
+1111 1
+.names pg35 ng4388 [5310]
+01 1
+.names ng17317 ng26694 [31615] [31617] [5315]
+--11 1
+00-1 1
+.names pg35 ng1756 [5316]
+01 1
+.names pg35 ng582 [5319]
+01 1
+.names pg35 ng5559 [5322]
+01 1
+.names pg35 ng4704 [5338]
+01 1
+.names pg35 ng3125 [5342]
+01 1
+.names [6832] [6833] [29346] [31574] [5357]
+0001 1
+.names [30848] [30849] [30872] [31575] [5358]
+1--1 1
+-1-1 1
+--11 1
+.names ng26770 ng17424 [31570] [31572] [5361]
+--11 1
+00-1 1
+.names pg35 ng2445 [5362]
+01 1
+.names pg35 ng1322 ng1345 ng1333 [5365]
+1010 1
+.names pg35 ng1345 ng7601 ng15748 [5366]
+1000 1
+.names pg35 ng1041 [5370]
+01 1
+.names ng26703 ng17321 ng11916 [31560] [5372]
+--01 1
+00-1 1
+.names pg35 ng2169 [5373]
+01 1
+.names pg35 ng699 [5376]
+01 1
+.names ng2197 ng26703 ng17321 ng28768 [5390]
+11-0 1
+1-10 1
+.names pg35 ng2197 [5391]
+01 1
+.names pg35 ng4843 [5394]
+01 1
+.names pg35 ng5216 [5397]
+01 1
+.names pg35 pg8291 ng209 ng218 [5406]
+101- 1
+1-10 1
+.names pg35 ng191 [5407]
+01 1
+.names pg35 ng3933 [5412]
+01 1
+.names pg35 ng5587 [5419]
+01 1
+.names [29614] [29615] [29638] [31514] [5427]
+1--1 1
+-1-1 1
+--11 1
+.names pg35 ng3965 [5428]
+01 1
+.names ng14367 [7041] [29097] [31509] [5430]
+-1-1 1
+1-11 1
+.names ng14367 [7041] [29097] [31510] [5431]
+00-1 1
+-001 1
+.names ng925 ng918 ng25888 [31505] [5438]
+1101 1
+.names pg35 ng5240 [5451]
+01 1
+.names pg35 ng3873 [5456]
+01 1
+.names pg35 ng5252 [5462]
+01 1
+.names ng26770 ng17424 ng9762 [31488] [5463]
+1-11 1
+-111 1
+.names ng26770 ng17424 ng9762 [31490] [5464]
+1-11 1
+-111 1
+.names ng26770 ng17424 ng9762 [31491] [5465]
+--01 1
+00-1 1
+.names pg35 ng2533 [5466]
+01 1
+.names pg35 ng3889 [5469]
+01 1
+.names pg35 ng5889 [5475]
+01 1
+.names pg35 ng4145 ng4253 ng4164 [5476]
+100- 1
+1-10 1
+.names pg35 ng5495 [5483]
+01 1
+.names pg35 ng2250 [5487]
+01 1
+.names pg35 ng1384 [5490]
+01 1
+.names ng1351 ng1384 [5491]
+10 1
+.names pg35 ng671 [5502]
+01 1
+.names ng14367 [6655] [29571] [31447] [5503]
+-1-1 1
+1-11 1
+.names ng14367 [6655] [29571] [31450] [5505]
+00-1 1
+-001 1
+.names ng21024 ni27429 [31435] [31437] [5512]
+10-1 1
+1-01 1
+.names [6966] [6967] [29216] [31439] [5513]
+0001 1
+.names pg35 ng2307 [5523]
+01 1
+.names ng2331 ng17405 ng26737 ng28799 [5524]
+11-0 1
+1-10 1
+.names pg35 ng2361 ng17405 ng26737 [5525]
+1100 1
+.names ng9694 ng26725 ng17401 [31415] [5533]
+0--1 1
+-001 1
+.names pg35 ng1955 [5534]
+01 1
+.names pg35 ng2421 ng26770 ng17424 [5542]
+1100 1
+.names pg35 ng4854 [5551]
+01 1
+.names ng17317 ng26694 ng9640 [31391] [5552]
+1-11 1
+-111 1
+.names ng17317 ng26694 ng9640 [31392] [5553]
+--01 1
+00-1 1
+.names ng14367 [7041] [29097] [31385] [5555]
+-1-1 1
+1-11 1
+.names ng14367 [7041] [29097] [31388] [5557]
+00-1 1
+-001 1
+.names pg35 ng2476 [5573]
+01 1
+.names ng14367 [6172] [30555] [31351] [5574]
+-1-1 1
+1-11 1
+.names ng14367 [6172] [30555] [31354] [5576]
+00-1 1
+-001 1
+.names pg35 ng3598 [5580]
+01 1
+.names pg35 ng2093 [5586]
+01 1
+.names pg35 ng6581 [5589]
+01 1
+.names pg35 ng4785 ng28336 ng13464 [5593]
+1010 1
+.names pg35 ng4776 [5595]
+01 1
+.names pg35 ng5073 ng5077 [5597]
+101 1
+.names [7284] [28543] [28544] [31322] [5600]
+01-1 1
+0-11 1
+.names [7284] [28543] [28544] [31324] [5601]
+1--1 1
+-001 1
+.names pg35 ng2771 [5603]
+01 1
+.names pg35 ng4983 [5619]
+01 1
+.names pg35 ng2361 [5623]
+01 1
+.names ng14367 [6655] [29571] [31281] [5627]
+-1-1 1
+1-11 1
+.names ng14367 [6655] [29571] [31282] [5628]
+00-1 1
+-001 1
+.names ng26725 ng17401 ng28789 [31275] [5632]
+1-01 1
+-101 1
+.names pg35 ng1906 ng26725 ng17401 [5633]
+1100 1
+.names pg35 ng4141 ng2841 ng4082 [5638]
+110- 1
+1-01 1
+.names pg35 ng2841 ng4093 [5641]
+101 1
+.names pg35 ng2841 ng4064 ng4057 [5642]
+101- 1
+10-1 1
+.names pg35 ng4087 ng2841 [5643]
+100 1
+.names pg35 ng4125 [5644]
+01 1
+.names ng817 ng8806 [31254] [5645]
+101 1
+.names pg35 ng703 ng847 ng8806 [5648]
+110- 1
+11-1 1
+.names pg35 ng847 [5649]
+01 1
+.names ng17317 ng26694 ng9640 [31250] [5650]
+--01 1
+00-1 1
+.names ng1834 ng17317 ng26694 ng9640 [5651]
+11-1 1
+1-11 1
+.names pg35 pg11678 ng542 ng736 [5653]
+101- 1
+1-11 1
+.names pg35 pg11678 ng691 ng736 [5654]
+100- 1
+1-01 1
+.names pg35 ng6227 [5661]
+01 1
+.names ng14367 [5887] [31005] [31240] [5663]
+-1-1 1
+1-11 1
+.names ng14367 [5887] [31005] [31241] [5664]
+00-1 1
+-001 1
+.names pg35 ng2575 [5669]
+01 1
+.names ng17405 ng26737 ng11939 [31230] [5671]
+--01 1
+00-1 1
+.names pg35 ng2303 [5672]
+01 1
+.names ng26673 ng9586 ng17292 [31217] [5690]
+-0-1 1
+0-01 1
+.names ng1700 ng26673 ng9586 ng17292 [5691]
+111- 1
+1-11 1
+.names ng4108 ng4098 ng22654 [31213] [5693]
+0--1 1
+-0-1 1
+--01 1
+.names ng4108 ng4098 ng22654 [31214] [5694]
+1111 1
+.names ng25911 [7650] [7652] [31210] [5697]
+0001 1
+.names ng25911 [7650] [7652] [31211] [5698]
+1--1 1
+-1-1 1
+--11 1
+.names pg35 ng837 [5702]
+01 1
+.names pg35 ng3590 [5705]
+01 1
+.names ng14367 [7725] [28488] [31194] [5712]
+-1-1 1
+1-11 1
+.names ng14367 [7725] [28488] [31195] [5713]
+00-1 1
+-001 1
+.names ng26759 ng14438 ng9755 [31190] [5718]
+1-11 1
+-111 1
+.names ng26759 ng14438 ng9755 [31191] [5719]
+--01 1
+00-1 1
+.names pg35 ng4443 [5727]
+01 1
+.names pg35 ng5232 [5730]
+01 1
+.names pg35 ng6154 [5734]
+01 1
+.names pg35 ng4340 [5737]
+01 1
+.names pg35 ng246 [5740]
+01 1
+.names ng11915 ng17317 ng26694 [31159] [5747]
+0--1 1
+-001 1
+.names pg35 ng1744 [5748]
+01 1
+.names pg35 ng3893 [5755]
+01 1
+.names pg35 ng2495 [5759]
+01 1
+.names pg35 ng1592 ng26673 ng17292 [5766]
+1100 1
+.names pg35 ng405 [5769]
+01 1
+.names ng29503 ng27440 ng17401 [31131] [5773]
+1111 1
+.names ng29503 ng27440 ng17401 [31133] [5774]
+1111 1
+.names ng29503 ng27440 ng17401 [31134] [5775]
+0--1 1
+-0-1 1
+--01 1
+.names pg35 ng1862 [5776]
+01 1
+.names pg35 ng6641 [5782]
+01 1
+.names ng1256 ng1252 ng19140 [31123] [5783]
+0--1 1
+-0-1 1
+--01 1
+.names pg35 ng1256 [5785]
+01 1
+.names pg35 ng6251 [5788]
+01 1
+.names pg35 ng5933 [5797]
+01 1
+.names pg35 ng3921 [5800]
+01 1
+.names ng20682 ng25851 [30578] [31107] [5803]
+10-1 1
+1-01 1
+.names [7624] [7625] [28651] [31109] [5804]
+0001 1
+.names pg35 ng3476 [5809]
+01 1
+.names pg35 ng2153 ng26703 ng17321 [5811]
+1100 1
+.names pg35 ng311 [5814]
+01 1
+.names ng4785 ng4709 ng11261 [31084] [5819]
+1111 1
+.names ng10756 [28765] [28766] [31070] [5821]
+0--1 1
+-001 1
+.names ng3821 ng10756 [28765] [28766] [5822]
+111- 1
+11-1 1
+.names pg35 ng4950 [5827]
+01 1
+.names pg35 ng5808 [5831]
+01 1
+.names pg35 ng232 [5834]
+01 1
+.names ng29503 ng27494 ng14506 [31050] [5835]
+1111 1
+.names ng29503 ng27494 ng14506 [31052] [5836]
+1111 1
+.names ng29503 ng27494 ng14506 [31053] [5837]
+0--1 1
+-0-1 1
+--01 1
+.names pg35 ng2555 [5838]
+01 1
+.names pg35 ng1036 [5847]
+01 1
+.names ng1041 ng1008 [5848]
+01 1
+.names ng14367 [7030] [29111] [31030] [5856]
+-1-1 1
+1-11 1
+.names ng14367 [7030] [29111] [31033] [5859]
+00-1 1
+-001 1
+.names pg35 ng3550 [5866]
+01 1
+.names ng14367 [7030] [29111] [31023] [5868]
+00-1 1
+-001 1
+.names ng2319 ng14367 [7030] [29111] [5869]
+1-1- 1
+11-1 1
+.names pg35 ng3139 [5878]
+01 1
+.names ng14367 [5887] [31005] [31008] [5883]
+00-1 1
+-001 1
+.names ng2587 ng14367 [5887] [31005] [5884]
+1-1- 1
+11-1 1
+.names ng2715 ng2724 ng2729 ng2719 [5887]
+11-1 1
+1-11 1
+.names [30977] [30978] [31001] [31002] [5888]
+1--1 1
+-1-1 1
+--11 1
+.names [7624] [7625] [28651] [31003] [5889]
+0001 1
+.names ng14367 [6319] [30342] [30926] [5925]
+-1-1 1
+1-11 1
+.names ng14367 [6319] [30342] [30929] [5926]
+-1-1 1
+1-11 1
+.names ng14367 [6319] [30342] [30931] [5927]
+-1-1 1
+1-11 1
+.names ng14367 [6319] [30342] [30932] [5928]
+-1-1 1
+1-11 1
+.names ng14367 [6319] [30342] [30933] [5929]
+00-1 1
+-001 1
+.names pg35 ng2060 [5931]
+01 1
+.names pg35 ng3841 [5941]
+01 1
+.names ng23978 [28796] [28801] [30914] [5942]
+1--1 1
+-0-1 1
+--11 1
+.names ng23978 [28796] [28801] [30915] [5943]
+0101 1
+.names pg35 ng2122 [5948]
+01 1
+.names pg35 ng1882 [5952]
+01 1
+.names pg35 ng6573 [5955]
+01 1
+.names pg35 ng1854 [5959]
+01 1
+.names ng26703 ng17321 ng28768 [30888] [5963]
+1-01 1
+-101 1
+.names pg35 ng2197 ng26703 ng17321 [5964]
+1100 1
+.names ng28739 ng26673 ng17292 [30881] [5968]
+01-1 1
+0-11 1
+.names pg35 ng1636 ng26673 ng17292 [5969]
+1100 1
+.names [30848] [30849] [30872] [30874] [5979]
+1--1 1
+-1-1 1
+--11 1
+.names [30848] [30849] [30872] [30876] [5980]
+0001 1
+.names [6832] [6833] [29346] [30877] [5981]
+0001 1
+.names pg35 ng5467 [5982]
+01 1
+.names ng8806 ng11185 [30776] [30809] [6009]
+1--1 1
+-0-1 1
+--01 1
+.names ng8806 ng11185 [30776] [30810] [6010]
+0111 1
+.names ng8806 ng11185 [30776] [30811] [6011]
+0111 1
+.names pg35 ng728 [6012]
+01 1
+.names pg35 ng676 [6015]
+01 1
+.names ng4375 ng4411 [29326] [30769] [6028]
+1--1 1
+-1-1 1
+--01 1
+.names pg35 [29325] [29326] [30770] [6029]
+1111 1
+.names pg35 ng1811 [6033]
+01 1
+.names pg35 ng599 [6036]
+01 1
+.names pg35 ng4975 [6042]
+01 1
+.names pg35 ng6741 [6047]
+01 1
+.names ng925 ng918 ng25888 [30742] [6048]
+1101 1
+.names ng925 ng918 ng25888 [30743] [6049]
+0--1 1
+-0-1 1
+--11 1
+.names ng14367 [7725] [28488] [30733] [6055]
+00-1 1
+-001 1
+.names ng14367 [7725] [28488] [30735] [6057]
+-1-1 1
+1-11 1
+.names ng4975 ng4899 ng11283 [30728] [6064]
+1111 1
+.names pg35 ng6637 [6067]
+01 1
+.names ng26770 ng17424 ng9762 [30709] [6068]
+1-11 1
+-111 1
+.names ng26770 ng17424 ng9762 [30710] [6069]
+--01 1
+00-1 1
+.names [30659] [30660] [30683] [30685] [6093]
+0001 1
+.names [30659] [30660] [30683] [30687] [6094]
+1--1 1
+-1-1 1
+--11 1
+.names [7046] [7047] [29091] [30688] [6095]
+0001 1
+.names pg35 ng6505 [6096]
+01 1
+.names ng29503 ng27421 ng17321 [30619] [6125]
+1111 1
+.names ng29503 ng27421 ng17321 [30621] [6126]
+1111 1
+.names ng29503 ng27421 ng17321 [30622] [6127]
+0--1 1
+-0-1 1
+--01 1
+.names pg35 ng2153 [6128]
+01 1
+.names ng4785 ng4709 ng11261 [30609] [6133]
+1011 1
+.names pg35 ng255 [6148]
+01 1
+.names pg35 ng5357 [6151]
+01 1
+.names pg35 ng6263 [6157]
+01 1
+.names pg35 ng5033 [6160]
+01 1
+.names pg35 ng6291 [6163]
+01 1
+.names pg35 ng6187 [6167]
+01 1
+.names ng2715 ng2724 ng2729 ng2719 [6172]
+01-0 1
+0-10 1
+.names [30497] [30498] [30499] [6173]
+111 1
+.names ng4983 ng4878 [30505] [30506] [6174]
+0011 1
+.names ng4983 ng4878 [30512] [30513] [6175]
+0011 1
+.names [30515] [30516] [30534] [30535] [6178]
+1-11 1
+-111 1
+.names ng4871 ng4836 ng11283 [30539] [6179]
+0011 1
+.names pg35 ng4836 ng5011 [6180]
+111 1
+.names pg35 ng4871 ng3684 [6181]
+111 1
+.names pg35 ng4035 ng4878 [6182]
+101 1
+.names pg35 ng3333 ng4864 [6183]
+101 1
+.names pg35 ng3522 [6197]
+01 1
+.names pg35 ng1862 ng26725 ng17401 [6205]
+1100 1
+.names pg35 ng5256 [6208]
+01 1
+.names pg35 ng3227 [6211]
+01 1
+.names pg35 ng3195 [6217]
+01 1
+.names pg35 ng3255 [6223]
+01 1
+.names pg35 ng3247 [6236]
+01 1
+.names ng29503 ng17424 ng27474 [30441] [6237]
+1111 1
+.names ng29503 ng17424 ng27474 [30443] [6238]
+1111 1
+.names ng29503 ng17424 ng27474 [30444] [6239]
+0--1 1
+-0-1 1
+--01 1
+.names pg35 ng2421 [6240]
+01 1
+.names pg35 ng3243 [6245]
+01 1
+.names pg35 ng5957 [6248]
+01 1
+.names pg35 ng6645 [6251]
+01 1
+.names pg35 ng3191 [6254]
+01 1
+.names pg35 ng1521 [6260]
+01 1
+.names ng14367 [7041] [29097] [30399] [6269]
+-1-1 1
+1-11 1
+.names ng14367 [7041] [29097] [30402] [6270]
+-1-1 1
+1-11 1
+.names ng14367 [7041] [29097] [30404] [6271]
+-1-1 1
+1-11 1
+.names ng14367 [7041] [29097] [30406] [6273]
+-1-1 1
+1-11 1
+.names ng14367 [7041] [29097] [30407] [6274]
+00-1 1
+-001 1
+.names pg35 ng1657 [6276]
+01 1
+.names ng17405 ng26737 ng9700 [30394] [6277]
+1-11 1
+-111 1
+.names ng17405 ng26737 ng9700 [30395] [6278]
+--01 1
+00-1 1
+.names ng26770 ng17424 [30390] [30392] [6281]
+--11 1
+00-1 1
+.names pg35 ng2449 [6282]
+01 1
+.names pg35 ng4473 ng4462 [6283]
+110 1
+.names pg35 ng5567 [6293]
+01 1
+.names ng2040 ng26759 ng14438 ng28833 [6294]
+11-0 1
+1-10 1
+.names pg35 ng2070 ng26759 ng14438 [6295]
+1100 1
+.names pg35 ng6500 [6300]
+01 1
+.names ni27429 ng20751 [30365] [30367] [6301]
+01-1 1
+-101 1
+.names [7046] [7047] [29091] [30369] [6302]
+0001 1
+.names ng29503 ng27445 ng17405 [30359] [6304]
+1111 1
+.names ng29503 ng27445 ng17405 [30361] [6305]
+1111 1
+.names ng29503 ng27445 ng17405 [30362] [6306]
+0--1 1
+-0-1 1
+--01 1
+.names pg35 ng2287 [6307]
+01 1
+.names pg35 ng2016 [6317]
+01 1
+.names ng2715 ng2724 ng2729 ng2719 [6319]
+11-1 1
+1-11 1
+.names pg35 ng4643 [6323]
+01 1
+.names ng33851 [30331] [30332] [30334] [6324]
+0--1 1
+-1-1 1
+--01 1
+.names ng33851 [30331] [30332] [30335] [6325]
+1011 1
+.names pg35 ng772 [6329]
+01 1
+.names ng14367 [6655] [29571] [30307] [6330]
+-1-1 1
+1-11 1
+.names ng14367 [6655] [29571] [30310] [6331]
+-1-1 1
+1-11 1
+.names ng14367 [6655] [29571] [30312] [6332]
+-1-1 1
+1-11 1
+.names ng14367 [6655] [29571] [30313] [6333]
+-1-1 1
+1-11 1
+.names ng14367 [6655] [29571] [30316] [6335]
+00-1 1
+-001 1
+.names pg35 ng1926 [6336]
+01 1
+.names ng1263 ng1270 ng25895 [30300] [6341]
+1101 1
+.names pg35 ng822 [6348]
+01 1
+.names ng1636 ng28739 ng26673 ng17292 [6361]
+101- 1
+10-1 1
+.names pg35 ng1636 [6362]
+01 1
+.names ng1906 ng26725 ng17401 ng28789 [6363]
+11-0 1
+1-10 1
+.names pg35 ng1936 ng26725 ng17401 [6364]
+1100 1
+.names pg35 ng5220 [6368]
+01 1
+.names ng4975 ng4899 ng11283 [30265] [6373]
+1011 1
+.names ng17405 ng26737 [30249] [30251] [6389]
+--11 1
+00-1 1
+.names pg35 ng2311 [6390]
+01 1
+.names ng1256 ng1252 ng22862 ng19140 [6395]
+101- 1
+1-10 1
+.names pg35 ng1256 ng1252 ng19140 [6396]
+1011 1
+.names ng1312 ng1351 ng13242 [30241] [6398]
+0001 1
+.names pg35 ng4332 [6407]
+01 1
+.names ng10511 ng8347 [28475] [29918] [6408]
+0001 1
+.names pg35 ng6533 [6415]
+01 1
+.names pg35 ng6299 [6421]
+01 1
+.names pg35 ng1199 [6424]
+01 1
+.names pg35 ng2827 [6436]
+01 1
+.names ng13378 ng13861 [29858] [29859] [6442]
+0011 1
+.names ng13378 ng13861 [29862] [29863] [6443]
+1011 1
+.names pg35 ng3223 [6450]
+01 1
+.names pg35 ng2834 [6451]
+01 1
+.names pg35 ng4340 ng4349 ng4358 [6474]
+10-- 1
+1-0- 1
+1--0 1
+.names pg35 [29834] [29835] [29836] [6475]
+1000 1
+.names pg35 ng4633 ng4639 ng4621 [6476]
+10-- 1
+1-1- 1
+1--0 1
+.names pg135 ng4584 ng4608 ng4593 [6482]
+0010 1
+.names pg35 ng2783 [6486]
+01 1
+.names pg35 ng5937 [6491]
+01 1
+.names pg35 ng3578 [6494]
+01 1
+.names pg35 ng785 [6500]
+01 1
+.names pg17722 pg17778 ng10224 [29780] [6503]
+0111 1
+.names pg17722 pg17688 ng10224 [29785] [6504]
+0011 1
+.names pg35 ng5115 [6514]
+01 1
+.names ng17317 ng26694 ng9640 [29758] [6515]
+--01 1
+00-1 1
+.names ng1816 ng17317 ng26694 ng9640 [6516]
+11-1 1
+1-11 1
+.names pg35 ng1216 [6520]
+01 1
+.names pg35 ng5481 [6524]
+01 1
+.names pg35 ng6565 [6527]
+01 1
+.names pg35 ng6649 [6532]
+01 1
+.names pg35 ng4771 [6539]
+01 1
+.names pg35 ng3901 [6542]
+01 1
+.names ng26793 ng14506 [29723] [29725] [6544]
+--11 1
+00-1 1
+.names pg35 ng2579 [6545]
+01 1
+.names ng32212 [28816] [29718] [29720] [6548]
+0--1 1
+-1-1 1
+--01 1
+.names ng32212 [28816] [29718] [29721] [6549]
+1011 1
+.names ng26770 ng17424 [29714] [29716] [6552]
+--11 1
+00-1 1
+.names pg35 ng2429 [6553]
+01 1
+.names ng837 ng703 ng847 ng8806 [6561]
+0110 1
+.names pg35 ng5909 [6565]
+01 1
+.names pg35 ng1002 ng15737 ng7567 [6571]
+1000 1
+.names pg35 ng990 ng979 ng1002 [6572]
+1001 1
+.names pg35 ng5224 [6576]
+01 1
+.names ng969 ng1008 ng13211 [29679] [6588]
+0001 1
+.names pg35 ng294 [6592]
+01 1
+.names pg35 ng4112 [6595]
+01 1
+.names pg35 ng4628 [6598]
+01 1
+.names pg35 ng3251 [6604]
+01 1
+.names pg35 ng5527 [6612]
+01 1
+.names ng26673 ng17292 [29646] [29648] [6614]
+--11 1
+00-1 1
+.names pg35 ng1600 [6615]
+01 1
+.names [29614] [29615] [29638] [29640] [6619]
+0001 1
+.names [29614] [29615] [29638] [29642] [6620]
+1--1 1
+-1-1 1
+--11 1
+.names pg35 ng3813 [6622]
+01 1
+.names pg35 ng1988 [6653]
+01 1
+.names ng2715 ng2724 ng2729 ng2719 [6655]
+01-1 1
+0-11 1
+.names pg35 ng5046 [6660]
+01 1
+.names pg35 ng5547 [6663]
+01 1
+.names ng26759 ng14438 [29559] [29561] [6665]
+--11 1
+00-1 1
+.names pg35 ng2020 [6666]
+01 1
+.names pg35 ng504 [6669]
+01 1
+.names ng1002 ng15737 ng7567 [29542] [6674]
+--11 1
+00-1 1
+.names pg35 ng1002 [6675]
+01 1
+.names pg35 ng3945 [6678]
+01 1
+.names ng28444 [28561] [28562] [29526] [6686]
+0--1 1
+-1-1 1
+--01 1
+.names ng28444 [28561] [28562] [29527] [6687]
+1011 1
+.names ng4443 ng4452 [29521] [29523] [6690]
+0011 1
+.names pg35 ng4438 [6691]
+01 1
+.names pg35 ng5535 [6694]
+01 1
+.names ng26759 ng14438 ng9755 [29510] [6695]
+1-11 1
+-111 1
+.names ng26759 ng14438 ng9755 [29511] [6696]
+1-11 1
+-111 1
+.names ng26759 ng14438 ng9755 [29512] [6697]
+--01 1
+00-1 1
+.names pg35 ng2108 [6698]
+01 1
+.names ng24688 [28661] [29489] [6699]
+111 1
+.names ng24688 [29491] [29493] [6700]
+111 1
+.names ng24688 [29495] [29496] [6701]
+111 1
+.names ng24688 [28694] [29497] [6702]
+111 1
+.names ng24688 [29499] [29500] [6703]
+111 1
+.names ng24688 ng10887 [29502] [6704]
+111 1
+.names ng24688 ng10823 [29192] [6705]
+111 1
+.names ng24688 ng10874 [28470] [6706]
+111 1
+.names pg35 ng832 [6709]
+01 1
+.names pg35 ng5881 [6714]
+01 1
+.names [29451] [29452] [29475] [29476] [6715]
+1--1 1
+-1-1 1
+--11 1
+.names [7351] [7352] [28734] [29477] [6716]
+0001 1
+.names pg35 ng4375 [6743]
+01 1
+.names ng17405 ng26737 ng9700 [29408] [6763]
+--01 1
+00-1 1
+.names ng2393 ng17405 ng26737 ng9700 [6764]
+11-1 1
+1-11 1
+.names ng2689 ng2697 ng2704 [6770]
+101 1
+.names pg35 ng6239 [6777]
+01 1
+.names ng499 ng518 ng691 [6781]
+1-1 1
+-11 1
+.names ng411 ng691 [6784]
+10 1
+.names ng287 ng283 ng23204 [29391] [6789]
+0-11 1
+-011 1
+.names ng287 ng283 ng23204 [29393] [6790]
+1111 1
+.names pg73 pg72 ng4575 ng4581 [6804]
+0001 1
+.names ng4552 ng4581 [6805]
+00 1
+.names pg73 pg72 pg35 ng4581 [6808]
+1-11 1
+-111 1
+.names pg35 ng4572 ng4581 [6809]
+111 1
+.names ng10909 ng13336 [29362] [29363] [6816]
+0011 1
+.names ng10909 ng13336 [29366] [29367] [6817]
+0111 1
+.names pg73 pg72 pg35 ng2988 [6823]
+0011 1
+.names pg35 ng4492 [6825]
+01 1
+.names pg73 pg72 ng4581 ng59 [6826]
+0010 1
+.names ng4512 ng4581 [6827]
+00 1
+.names ng20739 ng25851 [29348] [29350] [6828]
+10-1 1
+1-01 1
+.names [6832] [6833] [29346] [29352] [6829]
+0001 1
+.names ng4801 ng4674 ng4793 ng4776 [6832]
+11-- 1
+-11- 1
+-1-0 1
+.names ng4674 ng4653 ng4669 ng4659 [6833]
+10-- 1
+1-0- 1
+1--0 1
+.names pg120 pg124 pg35 ng4146 [6838]
+-111 1
+1-10 1
+.names pg35 ng4388 ng4430 [6842]
+110 1
+.names pg35 ng4401 ng4434 [6843]
+110 1
+.names pg35 ng4401 ng4434 [6844]
+101 1
+.names pg35 ng4975 ng28349 ng13486 [6847]
+1010 1
+.names pg35 ng4966 [6849]
+01 1
+.names pg35 ng3594 [6852]
+01 1
+.names pg35 ng5893 [6872]
+01 1
+.names pg35 ng4849 [6890]
+01 1
+.names pg35 ng5228 [6899]
+01 1
+.names pg35 ng5563 [6904]
+01 1
+.names ng2465 ng26770 ng17424 ng28846 [6905]
+11-0 1
+1-10 1
+.names pg35 ng2495 ng26770 ng17424 [6906]
+1100 1
+.names ng2689 ng2697 ng2704 [6912]
+110 1
+.names ng11893 ng26673 ng17292 [29266] [6915]
+0--1 1
+-001 1
+.names pg35 ng1608 [6916]
+01 1
+.names ng2145 ng2138 ng2130 [6925]
+001 1
+.names pg35 ng2629 [6933]
+01 1
+.names pg72 ng4322 [28640] [29232] [6946]
+1111 1
+0011 1
+.names pg72 ng4322 [29233] [29234] [6947]
+1111 1
+0011 1
+.names pg72 ng4322 [29233] [29235] [6948]
+1111 1
+0011 1
+.names pg72 ng4322 [28640] [29236] [6949]
+1111 1
+0011 1
+.names pg72 ng4322 [29233] [29237] [6950]
+1111 1
+0011 1
+.names pg72 ng4322 [28640] [29238] [6951]
+1111 1
+0011 1
+.names pg72 ng4322 [28640] [29239] [6952]
+1111 1
+0011 1
+.names pg72 ng4322 [29233] [29240] [6953]
+1111 1
+0011 1
+.names pg35 ng6585 [6956]
+01 1
+.names [7137] [7138] [28996] [29224] [6959]
+0001 1
+.names [28971] [28972] [28995] [29225] [6960]
+1--1 1
+-1-1 1
+--11 1
+.names pg35 ng3457 [6965]
+01 1
+.names ng4991 ng4966 ng4871 ng4983 [6966]
+1-1- 1
+-01- 1
+--11 1
+.names ng4859 ng4849 ng4843 ng4871 [6967]
+0--1 1
+-0-1 1
+--01 1
+.names pg35 ng499 [6985]
+01 1
+.names pg35 ng5180 [6988]
+01 1
+.names pg35 ng2803 [6992]
+01 1
+.names ng29503 ng27416 ng17317 [29159] [7004]
+1111 1
+.names ng29503 ng27416 ng17317 [29161] [7005]
+1111 1
+.names ng29503 ng27416 ng17317 [29162] [7006]
+0--1 1
+-0-1 1
+--01 1
+.names pg35 ng1728 [7007]
+01 1
+.names pg17685 pg13085 ng10207 [29138] [7008]
+0011 1
+.names pg12422 pg13085 ng10207 [29143] [7009]
+1011 1
+.names pg12422 pg13085 ng10207 [29148] [7010]
+1011 1
+.names pg17685 pg12422 ng10207 [29153] [7011]
+1111 1
+.names pg35 ng424 [7024]
+01 1
+.names pg35 ng2413 [7028]
+01 1
+.names ng2715 ng2724 ng2729 ng2719 [7030]
+11-0 1
+1-10 1
+.names pg35 ng1936 [7034]
+01 1
+.names ng2715 ng2724 ng2729 ng2719 [7041]
+01-0 1
+0-10 1
+.names ng4991 ng4966 ng4836 ng4983 [7046]
+1-1- 1
+-01- 1
+--11 1
+.names ng4859 ng4849 ng4843 ng4836 [7047]
+0--1 1
+-0-1 1
+--01 1
+.names ng13378 ng13315 [29072] [29073] [7049]
+0011 1
+.names ng13378 ng13315 [29076] [29077] [7050]
+1011 1
+.names ng28880 ng26793 ng14506 [29063] [7058]
+01-1 1
+0-11 1
+.names pg35 ng2599 ng26793 ng14506 [7059]
+1100 1
+.names ng2689 ng2697 ng2704 [7065]
+111 1
+.names pg35 ng6633 [7069]
+01 1
+.names pg35 ng3905 [7077]
+01 1
+.names pg35 ng911 ng907 ng19063 [7078]
+1011 1
+.names pg35 ng3917 [7083]
+01 1
+.names ng26703 ng17321 [29028] [29030] [7096]
+--11 1
+00-1 1
+.names pg35 ng2181 [7097]
+01 1
+.names pg35 ng6259 [7100]
+01 1
+.names ng925 ng918 ng22992 ng25888 [7102]
+101- 1
+1-11 1
+.names pg35 ng3570 [7114]
+01 1
+.names ng26759 ng14438 [29011] [29013] [7116]
+--11 1
+00-1 1
+.names pg35 ng2008 [7117]
+01 1
+.names ng2145 ng2138 ng2130 [7126]
+111 1
+.names [28971] [28972] [28995] [29000] [7131]
+1--1 1
+-1-1 1
+--11 1
+.names [28971] [28972] [28995] [29002] [7132]
+0001 1
+.names [7137] [7138] [28996] [29003] [7133]
+0001 1
+.names pg35 ng3111 [7134]
+01 1
+.names ng4991 ng4864 ng4966 ng4983 [7137]
+11-- 1
+-10- 1
+-1-1 1
+.names ng4859 ng4864 ng4849 ng4843 [7138]
+01-- 1
+-10- 1
+-1-0 1
+.names pg35 ng3897 [7167]
+01 1
+.names pg35 ng5583 [7170]
+01 1
+.names pg35 ng3957 [7175]
+01 1
+.names ng26703 ng17321 [28919] [28921] [7180]
+--11 1
+00-1 1
+.names pg35 ng2165 [7181]
+01 1
+.names ng2815 ng2803 ng2724 [7186]
+000 1
+.names ng2819 ng2724 ng2729 [7187]
+011 1
+.names pg35 ng1536 [7190]
+01 1
+.names ng11869 ng7620 ng10918 [28898] [7193]
+1011 1
+.names ng14367 [7257] [28834] [28878] [7199]
+-1-1 1
+1-11 1
+.names ng14367 [7257] [28834] [28881] [7200]
+-1-1 1
+1-11 1
+.names ng14367 [7257] [28834] [28883] [7201]
+-1-1 1
+1-11 1
+.names ng14367 [7257] [28834] [28884] [7202]
+-1-1 1
+1-11 1
+.names ng14367 [7257] [28834] [28886] [7204]
+00-1 1
+-001 1
+.names pg35 ng1792 [7205]
+01 1
+.names pg35 ng6287 [7221]
+01 1
+.names pg35 ng2807 [7225]
+01 1
+.names ng14367 [7257] [28834] [28854] [7232]
+00-1 1
+-001 1
+.names ng1760 ng14367 [7257] [28834] [7233]
+1-1- 1
+11-1 1
+.names ng26703 ng17321 [28848] [28850] [7236]
+--11 1
+00-1 1
+.names pg35 ng2177 [7237]
+01 1
+.names ng4801 ng4793 ng4688 ng4776 [7248]
+1-1- 1
+-11- 1
+--10 1
+.names ng4653 ng4669 ng4688 ng4659 [7249]
+0-1- 1
+-01- 1
+--10 1
+.names pg35 ng1748 [7255]
+01 1
+.names ng2715 ng2724 ng2729 ng2719 [7257]
+11-0 1
+1-10 1
+.names ng26725 ng17401 [28829] [28831] [7259]
+--11 1
+00-1 1
+.names pg35 ng1874 [7260]
+01 1
+.names ng2145 ng2138 ng2130 [7269]
+011 1
+.names pg35 ng776 [7283]
+01 1
+.names pg12184 pg11678 [7284]
+10 1
+.names ng27629 [28803] [28804] [28806] [7286]
+0--1 1
+-1-1 1
+--01 1
+.names ng27629 [28803] [28804] [28807] [7287]
+1011 1
+.names pg35 ng586 [7291]
+01 1
+.names ng9649 ng26703 ng17321 [28786] [7298]
+11-1 1
+1-11 1
+.names ng9649 ng26703 ng17321 [28787] [7299]
+11-1 1
+1-11 1
+.names ng9649 ng26703 ng17321 [28788] [7300]
+0--1 1
+-001 1
+.names pg35 ng2265 [7301]
+01 1
+.names ng2689 ng2697 ng2704 [7306]
+100 1
+.names pg134 ng209 ng691 [7308]
+01- 1
+0-0 1
+.names pg134 ng1312 ng1351 ng1536 [7309]
+0--0 1
+000- 1
+.names pg35 ng499 ng513 [7310]
+110 1
+.names ng10756 [28765] [28766] [28769] [7321]
+11-1 1
+1-11 1
+.names ng10756 [28765] [28766] [28770] [7322]
+11-1 1
+1-11 1
+.names ng19984 ng10756 [28765] [28766] [7323]
+10-- 1
+1-00 1
+.names pg35 ng3808 [7324]
+01 1
+.names ng4955 ng4878 [7325]
+01 1
+.names ng4859 ng4849 ng4843 ng4878 [7326]
+0--1 1
+-0-1 1
+--01 1
+.names ng10939 ng13378 [28742] [28743] [7331]
+0011 1
+.names ng10939 ng13378 [28746] [28747] [7332]
+0111 1
+.names pg35 ng333 ng355 ng351 [7346]
+11-1 1
+1-11 1
+.names ng4801 ng4681 ng4793 ng4776 [7351]
+11-- 1
+-11- 1
+-1-0 1
+.names ng4681 ng4653 ng4669 ng4659 [7352]
+10-- 1
+1-0- 1
+1--0 1
+.names [29984] [29985] [30193] [30194] [7371]
+1-00 1
+-100 1
+.names pg54 pg53 ng7 [29926] [7372]
+001- 1
+-010 1
+.names ng947 ng1129 ni17529 [30000] [7373]
+0111 1
+.names ng4732 ng13156 [29957] [30045] [7374]
+1111 1
+.names ng1472 ng1291 ni18740 [30003] [7375]
+1011 1
+.names ng4922 ng13156 [29937] [30042] [7376]
+1111 1
+.names ng5853 ng13156 [29957] [29962] [7377]
+1111 1
+.names ng13156 [29957] [29978] [30190] [7378]
+0--1 1
+-0-1 1
+--01 1
+.names [29984] [29985] [30217] [7382]
+1-1 1
+-11 1
+.names ng6199 ng13156 [29957] [29962] [7390]
+1111 1
+.names pg54 pg53 ng6 [29926] [7391]
+001- 1
+-010 1
+.names ng1300 ng1291 ni18740 [30003] [7392]
+1011 1
+.names ng4917 ng13156 [29937] [30042] [7398]
+1111 1
+.names ng3853 ng13156 [29963] [29966] [7399]
+1111 1
+.names ng4727 ng13156 [29957] [30045] [7400]
+1111 1
+.names ng5160 ng13156 [29957] [29962] [7409]
+1111 1
+.names ng6545 ng13156 [29963] [29966] [7410]
+1111 1
+.names ng4912 ng13156 [29937] [30042] [7411]
+1111 1
+.names ng4722 ng13156 [29957] [30045] [7412]
+1111 1
+.names [29984] [29985] [30118] [7414]
+1-1 1
+-11 1
+.names pg54 pg53 ng9 [29926] [7424]
+001- 1
+-010 1
+.names [29984] [29985] [30162] [7426]
+1-1 1
+-11 1
+.names pg54 pg53 ng8 [29926] [7436]
+001- 1
+-010 1
+.names ng5507 ng13156 [29957] [29962] [7437]
+1111 1
+.names ng1448 ng1291 ni18740 [30003] [7438]
+1011 1
+.names ng3151 ng13156 [29963] [29966] [7445]
+1111 1
+.names ng4907 ng13156 [29937] [30042] [7446]
+1111 1
+.names ng4717 ng13156 [29957] [30045] [7447]
+1111 1
+.names [29984] [29985] [30097] [7452]
+1-1 1
+-11 1
+.names pg54 pg53 ng28 [29926] [7462]
+001- 1
+-010 1
+.names ng939 ng13156 [29937] [30000] [7463]
+1111 1
+.names ng1283 ng13156 [29957] [30003] [7464]
+1111 1
+.names [29948] [29949] [29950] [30084] [7466]
+1--1 1
+-1-1 1
+--11 1
+.names [29948] [29949] [29950] [30085] [7467]
+1--1 1
+-1-1 1
+--11 1
+.names [29948] [29949] [29950] [30086] [7468]
+1--1 1
+-1-1 1
+--11 1
+.names [29948] [29949] [29950] [30087] [7469]
+1--1 1
+-1-1 1
+--11 1
+.names [29948] [29949] [29950] [30088] [7470]
+1--1 1
+-1-1 1
+--11 1
+.names [29948] [29949] [29950] [30089] [7471]
+1--1 1
+-1-1 1
+--11 1
+.names ng2697 ng13156 [29963] [29966] [7472]
+1111 1
+.names ng4146 ng17653 [29925] [29926] [7473]
+1111 1
+.names ng2138 ng13156 [29957] [29962] [7474]
+1111 1
+.names [29984] [29985] [30063] [7475]
+1-1 1
+-11 1
+.names ng943 ng13156 [29937] [30000] [7485]
+1111 1
+.names pg54 pg53 ng31 [29926] [7486]
+001- 1
+-010 1
+.names ng1287 ng13156 [29957] [30003] [7487]
+1111 1
+.names [29948] [29949] [29950] [30055] [7489]
+1--1 1
+-1-1 1
+--11 1
+.names [29948] [29949] [29950] [30056] [7490]
+1--1 1
+-1-1 1
+--11 1
+.names [29948] [29949] [29950] [30057] [7491]
+1--1 1
+-1-1 1
+--11 1
+.names ng16486 [29948] [29949] [29950] [7492]
+11-- 1
+1-1- 1
+1--1 1
+.names ng2704 ng13156 [29963] [29966] [7493]
+1111 1
+.names ng4157 ng17653 [29925] [29926] [7494]
+1111 1
+.names ng2145 ng13156 [29957] [29962] [7495]
+1111 1
+.names [29948] [29949] [29950] [30035] [7498]
+1--1 1
+-1-1 1
+--11 1
+.names [29948] [29949] [29950] [30036] [7499]
+1--1 1
+-1-1 1
+--11 1
+.names [29948] [29949] [29950] [30037] [7500]
+1--1 1
+-1-1 1
+--11 1
+.names [29948] [29949] [29950] [30038] [7501]
+1--1 1
+-1-1 1
+--11 1
+.names [29948] [29949] [29950] [30039] [7502]
+1--1 1
+-1-1 1
+--11 1
+.names ng4300 ng13156 [29937] [29997] [7503]
+1111 1
+.names ng16486 [29948] [29949] [29950] [7504]
+11-- 1
+1-1- 1
+1--1 1
+.names ng4927 ng13156 [29937] [30042] [7505]
+0111 1
+.names ng4737 ng13156 [29957] [30045] [7506]
+0111 1
+.names ng4172 ng17653 [29925] [29926] [7507]
+1111 1
+.names [29984] [29985] [30016] [7509]
+1-1 1
+-11 1
+.names pg54 pg53 ng16 [29926] [7518]
+001- 1
+-010 1
+.names [29984] [29985] [29986] [7521]
+1-1 1
+-11 1
+.names pg54 pg53 ng19 [29926] [7531]
+001- 1
+-010 1
+.names ng952 ng13156 [29937] [30000] [7532]
+0111 1
+.names ng1296 ng13156 [29957] [30003] [7533]
+0111 1
+.names [29948] [29949] [29950] [29952] [7540]
+1--1 1
+-1-1 1
+--11 1
+.names [29948] [29949] [29950] [29953] [7541]
+1--1 1
+-1-1 1
+--11 1
+.names [29948] [29949] [29950] [29954] [7542]
+1--1 1
+-1-1 1
+--11 1
+.names [29948] [29949] [29950] [29955] [7543]
+1--1 1
+-1-1 1
+--11 1
+.names [29948] [29949] [29950] [29956] [7544]
+1--1 1
+-1-1 1
+--11 1
+.names ng4176 ng17653 [29925] [29926] [7545]
+1111 1
+.names ng2130 ng13156 [29957] [29962] [7546]
+1111 1
+.names ng2689 ng13156 [29963] [29966] [7547]
+1111 1
+.names pg35 ng6597 [7559]
+01 1
+.names pg35 ng6601 [7565]
+01 1
+.names ng1345 ng7601 ng15748 [28720] [7567]
+-1-1 1
+0-01 1
+.names pg35 ng1345 [7568]
+01 1
+.names pg35 ng157 [7581]
+01 1
+.names ng160 ng28353 [28711] [28712] [7582]
+1101 1
+.names pg35 ng160 [7583]
+01 1
+.names ng28761 ng17317 ng26694 [28689] [7595]
+01-1 1
+0-11 1
+.names pg35 ng1772 ng17317 ng26694 [7596]
+1100 1
+.names ng2145 ng2138 ng2130 [7606]
+101 1
+.names pg134 ng209 ng691 [7608]
+01- 1
+0-0 1
+.names pg134 ng969 ng1193 ng1008 [7609]
+0-0- 1
+00-0 1
+.names pg35 ng5134 [7623]
+01 1
+.names ng4801 ng4646 ng4793 ng4776 [7624]
+11-- 1
+-11- 1
+-1-0 1
+.names ng4646 ng4653 ng4669 ng4659 [7625]
+10-- 1
+1-0- 1
+1--0 1
+.names pg35 ng4793 [7634]
+01 1
+.names ng1926 ng1917 ng25357 [28614] [7639]
+0111 1
+.names ng2051 ng2060 ng25357 [28617] [7640]
+1011 1
+.names ng1783 ng1792 ng12377 ng25357 [7641]
+1011 1
+.names ng2610 ng2619 ng25357 [28622] [7642]
+1011 1
+.names ng2217 ng2208 ng25357 [28625] [7643]
+0111 1
+.names ng2485 ng2476 ng25357 [28503] [7644]
+0111 1
+.names ng2342 ng2351 ng25357 [28629] [7645]
+1011 1
+.names ng1657 ng1648 ng25357 [28632] [7646]
+0111 1
+.names pg35 ng25911 [7650] [7652] [7647]
+1010 1
+.names pg35 ng1024 [7649]
+01 1
+.names ng1030 ng15737 [7650]
+00 1
+.names ng1024 ng15737 [7652]
+00 1
+.names pg72 pg35 ng225 ng239 [7662]
+1111 1
+.names pg73 pg72 pg35 ng225 [7663]
+1111 1
+.names pg72 pg35 ng246 ng232 [7664]
+0111 1
+.names pg73 pg72 pg35 ng232 [7665]
+1011 1
+.names pg73 pg72 pg35 ng239 [7666]
+0111 1
+.names pg73 pg72 pg35 ng246 [7667]
+0011 1
+.names pg35 ng479 [7668]
+01 1
+.names pg35 ng269 [7671]
+01 1
+.names pg35 ng437 [7677]
+01 1
+.names pg35 ng4894 [7681]
+01 1
+.names pg35 ng2819 [7685]
+01 1
+.names ng28444 [28561] [28562] [28563] [7686]
+1011 1
+.names ng11676 [28525] [28526] [28530] [7690]
+0111 1
+.names ng11676 [28525] [28526] [28532] [7691]
+0111 1
+.names ng11676 [28525] [28526] [28534] [7692]
+0111 1
+.names ng11676 [28525] [28526] [28536] [7693]
+0111 1
+.names ng11676 [28525] [28526] [28538] [7694]
+0111 1
+.names ng11676 [28525] [28526] [28540] [7695]
+0111 1
+.names pg35 ng3219 [7703]
+01 1
+.names ng11846 [28514] [28515] [7709]
+111 1
+.names ng14367 [7725] [28488] [28490] [7720]
+00-1 1
+-001 1
+.names ng14367 [7725] [28488] [28491] [7721]
+-1-1 1
+1-11 1
+.names ng2715 ng2724 ng2729 ng2719 [7725]
+01-1 1
+0-11 1
+.names ng18935 ng30583 ng15591 [28476] [7734]
+0011 1
+.names ng18935 ng30583 ng15591 [28478] [7735]
+1011 1
+.names ng4087 ng4098 ng4093 [28470]
+101 1
+.names pg35 ng6215 ng6209 ng6203 [28473]
+1011 1
+.names ng4322 ng4332 [28475]
+0- 1
+-0 1
+.names ng4332 pg35 [28476]
+11 1
+.names ng4332 pg35 [28478]
+01 1
+.names ng1094 ng1135 [28482]
+10 1
+.names ng1135 pg35 [28483]
+11 1
+.names pg35 ng1135 ng1094 [28484]
+0-1 1
+110 1
+.names ng10929 ng13846 [28482] [28484] [28485]
+---1 1
+001- 1
+.names ng2815 ng2715 ng2719 [28488]
+001 1
+.names ng2485 pg35 [28490]
+11 1
+.names ng2476 pg35 [28491]
+11 1
+.names ng2756 ng2741 ng2748 [28503]
+101 1
+.names pg35 ng14367 [7725] [28488] [28505]
+1-1- 1
+11-1 1
+.names ng27903 [7721] [28505] [28507]
+-1- 1
+0-1 1
+.names pg7916 ng990 ng979 [28514]
+11- 1
+1-1 1
+.names ng979 ng1178 ng1189 ng996 [28515]
+1101 1
+.names pg7916 ng969 ng1008 ng10893 [28519]
+11-1 1
+1-11 1
+.names pg35 ng4284 ng4180 [28521]
+11- 1
+1-0 1
+.names ng3235 pg35 [28522]
+11 1
+.names ng528 ng482 [28525]
+00 1
+.names ng499 ng518 ng490 [28526]
+000 1
+.names ng718 ng655 ng753 ng554 [28530]
+1-00 1
+-100 1
+.names ng718 ng655 ng753 ng807 [28532]
+1-00 1
+-100 1
+.names ng718 ng655 ng753 ng554 [28534]
+10-0 1
+-010 1
+.names ng718 ng655 ng753 ng554 [28536]
+01-0 1
+0-10 1
+.names ng718 ng655 ng753 ng807 [28538]
+10-0 1
+-010 1
+.names ng718 ng655 ng753 ng807 [28540]
+01-0 1
+0-10 1
+.names [7695] [7694] [28543]
+1- 1
+-1 1
+.names [7690] [7691] [7692] [7693] [28544]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng246 ng232 ng239 [28548]
+111 1
+.names ng262 ng225 ng255 ng269 [28549]
+0100 1
+.names ng691 ng278 [28548] [28549] [28551]
+1111 1
+.names ng246 ng232 ng239 [28555]
+000 1
+.names ng262 ng225 ng255 ng269 [28556]
+1011 1
+.names ng691 ng278 [28555] [28556] [28558]
+1011 1
+.names ng23204 ng294 [28561]
+0- 1
+-0 1
+.names ng23204 ng298 [28562]
+11 1
+.names ng142 pg35 [28563]
+11 1
+.names ng2729 ng2724 [28567]
+0- 1
+-1 1
+.names ng2823 pg35 [28568]
+01 1
+.names ng2724 ng2729 ng11405 [28568] [28569]
+0101 1
+.names ng111 ng29503 ng11405 [28567] [28571]
+0-00 1
+-000 1
+.names ng2815 pg35 [28572]
+11 1
+.names ng11405 [7685] [28567] [28572] [28573]
+-1-- 1
+1--1 1
+--11 1
+.names ng111 ng29503 [28569] [28573] [28574]
+---1 1
+0-1- 1
+-01- 1
+.names ng4818 [1421] [28575]
+1- 1
+-1 1
+.names [1421] ng4894 ng4818 ng24374 [28577]
+11-- 1
+-11- 1
+-1-0 1
+.names pg35 ng4888 ng29676 ng30590 [28581]
+110- 1
+1-11 1
+.names ng269 pg35 [28583]
+11 1
+.names ng433 pg35 [28584]
+11 1
+.names ng246 pg35 [28587]
+11 1
+.names pg14167 pg35 [28588]
+11 1
+.names [7663] [7664] [7665] [7666] [28606]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng1030 ng1018 ng1008 [28607]
+111 1
+.names ng979 ng1046 ng996 ng1008 [28609]
+011- 1
+110- 1
+0-10 1
+1-00 1
+.names ng1030 pg35 [28611]
+11 1
+.names ng25911 [7649] [7652] [28611] [28612]
+-1-- 1
+1--1 1
+--11 1
+.names ng2756 ng2741 ng2748 [28614]
+001 1
+.names ng2756 ng2741 ng2748 [28617]
+011 1
+.names ng2756 ng2741 ng2748 [28622]
+111 1
+.names ng2756 ng2741 ng2748 [28625]
+100 1
+.names ng2756 ng2741 ng2748 [28629]
+110 1
+.names ng2756 ng2741 ng2748 [28632]
+000 1
+.names [7639] [7640] [7641] [7642] [28637]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [7643] [7644] [7645] [7646] [28638]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg73 ng4332 ng4311 [28640]
+110 1
+000 1
+.names pg35 ng4801 ng4793 ng10831 [28643]
+1011 1
+.names pg35 ng4801 ng4793 ng10831 [28645]
+110- 1
+11-0 1
+.names ng28336 ng13464 [7634] [28643] [28646]
+--1- 1
+11-1 1
+.names ng4646 ng4785 ng4698 ng4709 [28651]
+11-- 1
+1-0- 1
+1--1 1
+.names pg35 ng5128 ng5134 [28655]
+100 1
+.names ng5138 pg35 [28657]
+11 1
+.names ng5128 ng5134 ng23590 [28657] [28659]
+--11 1
+110- 1
+.names ng4087 ng4098 ng4093 [28661]
+111 1
+.names pg35 pg8344 pg8398 ng3802 [28670]
+0--1 1
+1100 1
+.names pg17316 ng979 ng1061 [28673]
+10- 1
+1-0 1
+.names ng504 ng518 ng528 [28687]
+100 1
+.names ng1728 pg35 [28689]
+11 1
+.names ng4087 ng4098 ng4093 [28694]
+110 1
+.names ng168 ng182 ng691 ng174 [28706]
+0010 1
+.names ng513 ng518 ng691 ng203 [28707]
+1-1- 1
+-01- 1
+--10 1
+.names ng513 ng518 ng203 ng146 [28708]
+0111 1
+.names ng23042 ng153 [28711]
+0- 1
+-0 1
+.names ng23042 ng157 [28712]
+11 1
+.names ng23042 ng160 [28713]
+11 1
+.names [7581] [7582] [7583] [28713] [28715]
+1--- 1
+-001 1
+.names ng1361 ng1351 ng1373 [28716]
+111 1
+.names ng1322 ng1389 ng1351 ng1339 [28718]
+01-1 1
+0-01 1
+11-0 1
+1-00 1
+.names pg35 ng1345 ng7601 ng15748 [28719]
+110- 1
+1-01 1
+.names ng1361 pg35 [28720]
+11 1
+.names pg35 ng4284 ng4180 [28722]
+11- 1
+1-0 1
+.names ng6621 pg35 [28723]
+11 1
+.names pg35 ng4284 ng4180 [28731]
+11- 1
+1-0 1
+.names ng6593 pg35 [28732]
+11 1
+.names ng12632 ng12716 [7559] [28731] [28733]
+--1- 1
+11-1 1
+.names ng4681 ng4785 ng4754 ng4709 [28734]
+11-- 1
+1-0- 1
+1--0 1
+.names pg35 ng74 ng355 ng351 [28741]
+0-1- 1
+11-0 1
+.names ng1484 pg35 [28742]
+11 1
+.names ng1300 ng1442 ng1489 [28743]
+11- 1
+1-1 1
+.names ng1484 pg35 [28746]
+11 1
+.names ng1300 ng1442 ng1489 [28747]
+01- 1
+0-1 1
+.names pg35 ng1300 ng1442 ng1489 [28751]
+1100 1
+.names pg35 ng1300 ng1442 ng1489 [28754]
+1000 1
+.names pg35 ng1484 ng1472 ng10939 [28757]
+0-1- 1
+11-1 1
+.names ng10939 ng13378 [28751] [28754] [28758]
+001- 1
+01-1 1
+.names ng4955 ng4878 [7326] [28765]
+--1 1
+01- 1
+.names ng4975 ng4899 ng11173 ng10862 [28766]
+0--1 1
+-0-1 1
+--11 1
+.names pg35 ng3808 ng3813 [28769]
+101 1
+.names ng3813 ng3808 [28770]
+01 1
+.names ng499 pg35 [28775]
+11 1
+.names pg35 ng667 ng686 [28776]
+110 1
+.names pg35 ng518 ng11607 [28776] [28779]
+--11 1
+101- 1
+.names pg17320 ng1322 ng1404 [28783]
+10- 1
+1-0 1
+.names pg35 ng2259 ng2265 [28786]
+100 1
+.names ng2265 ng2259 [28787]
+11 1
+.names ng2269 pg35 [28788]
+11 1
+.names pg35 pg44 ng2927 [28792]
+10- 1
+1-1 1
+.names pg9048 ng559 ng562 [28793]
+--0 1
+10- 1
+.names pg9048 ng568 ng559 [28794]
+01- 1
+-11 1
+.names pg9048 ng559 ng572 [28795]
+--0 1
+10- 1
+.names pg9048 ng559 ng586 [28796]
+0-1 1
+-11 1
+.names pg35 pg9048 ng577 ng559 [28798]
+101- 1
+1-11 1
+.names ng577 pg35 [28799]
+01 1
+.names ng23978 [7291] [28796] [28798] [28800]
+-1-- 1
+1--1 1
+--01 1
+.names pg9048 ng577 ng559 [28801]
+-0- 1
+1-0 1
+.names pg9048 ng582 ng559 [28802]
+01- 1
+-11 1
+.names pg9048 ng590 ng559 [28803]
+-0- 1
+1-0 1
+.names pg9048 ng559 ng595 [28804]
+0-1 1
+-11 1
+.names pg35 pg9048 ng599 ng559 [28806]
+101- 1
+1-11 1
+.names ng599 pg35 [28807]
+01 1
+.names pg11678 ng739 ng736 [28809]
+01- 1
+-11 1
+.names pg11678 ng744 ng736 [28810]
+-0- 1
+1-0 1
+.names pg11678 ng736 ng749 [28811]
+0-1 1
+-11 1
+.names pg11678 ng758 ng736 [28812]
+-0- 1
+1-0 1
+.names pg11678 ng763 ng736 [28813]
+01- 1
+-11 1
+.names pg11678 ng736 ng767 [28814]
+--0 1
+10- 1
+.names pg11678 ng736 ng772 [28815]
+0-1 1
+-11 1
+.names pg11678 ng776 ng736 [28816]
+-0- 1
+1-0 1
+.names pg35 pg11678 ng781 ng736 [28818]
+101- 1
+1-11 1
+.names ng781 pg35 [28819]
+01 1
+.names ng32212 [7283] [28816] [28818] [28820]
+-1-- 1
+0--1 1
+--11 1
+.names ng2759 pg35 [28821]
+01 1
+.names ng2759 pg35 [28822]
+11 1
+.names pg35 ng2841 ng2756 [28823]
+10- 1
+0-1 1
+.names ng2756 ng25317 [28821] [28823] [28824]
+---1 1
+111- 1
+.names pg17400 ng979 ng1061 [28827]
+10- 1
+1-0 1
+.names ng1906 ng1862 [28829]
+1- 1
+-0 1
+.names pg35 ng26725 ng17401 [28829] [28830]
+11-0 1
+1-10 1
+.names ng1870 pg35 [28831]
+11 1
+.names ng2715 ng2775 ng2719 [28834]
+100 1
+.names ng1792 ng1783 [28836]
+1- 1
+-0 1
+.names ng1728 pg35 [28837]
+11 1
+.names pg35 ng1772 ng1768 ng25385 [28841]
+1-11 1
+10-0 1
+.names ng4765 ng4785 ng4688 ng4709 [28843]
+0-1- 1
+-01- 1
+--10 1
+.names ng2227 ng2153 [28848]
+0- 1
+-0 1
+.names pg35 ng26703 ng17321 [28848] [28849]
+11-0 1
+1-10 1
+.names ng2173 pg35 [28850]
+11 1
+.names pg35 ng14367 [7257] [28834] [28853]
+1-1- 1
+11-1 1
+.names ng1783 pg35 [28854]
+11 1
+.names ng27775 [7233] [28853] [28856]
+-1- 1
+0-1 1
+.names pg35 ng341 ng329 [28858]
+101 1
+.names ng111 ng29503 ng12026 ng11405 [28860]
+0-10 1
+-010 1
+.names ng2799 pg35 [28861]
+01 1
+.names ng2724 ng2729 ng11405 [28861] [28862]
+0001 1
+.names ng2803 pg35 [28863]
+11 1
+.names ng12026 ng11405 [7225] [28863] [28864]
+--1- 1
+0--1 1
+-1-1 1
+.names ng111 ng29503 [28862] [28864] [28865]
+---1 1
+0-1- 1
+-01- 1
+.names pg35 ng4284 ng4180 [28866]
+11- 1
+1-0 1
+.names ng6303 pg35 [28867]
+11 1
+.names pg35 ng667 ng528 ng686 [28874]
+0-1- 1
+11-0 1
+.names pg35 ng1748 ng1792 ng1760 [28878]
+1100 1
+.names pg35 ng1783 ng1752 ng1760 [28881]
+1011 1
+.names pg35 ng1783 ng1760 ng1736 [28883]
+1101 1
+.names ng1783 ng1792 ng1744 [28884]
+011 1
+.names ng1756 pg35 [28885]
+11 1
+.names ng1811 pg35 [28886]
+11 1
+.names ng1760 ng1792 [28887]
+0- 1
+-0 1
+.names ng1740 ng25385 ng25300 [28885] [28891]
+1-0- 1
+-0-1 1
+.names [7199] [7200] [7201] [7205] [28892]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg7946 ng1514 ng1526 [28896]
+101 1
+.names pg7946 ng1322 ng1333 [28898]
+11- 1
+1-1 1
+.names pg7946 ng1312 ng1351 ng10918 [28903]
+11-1 1
+1-11 1
+.names pg35 ng1542 ng10918 [28896] [28905]
+111- 1
+11-0 1
+.names pg35 ng1542 ng10918 [28896] [28907]
+1001 1
+.names ng2819 ng2724 ng2729 ng2807 [28915]
+01-0 1
+-100 1
+.names ng2815 ng2803 ng2724 ng2729 [28916]
+0-01 1
+-000 1
+.names ng2153 ng2197 [28919]
+0- 1
+-1 1
+.names pg35 ng26703 ng17321 [28919] [28920]
+11-0 1
+1-10 1
+.names ng2161 pg35 [28921]
+11 1
+.names pg35 ng4284 ng4180 [28924]
+11- 1
+1-0 1
+.names ng3913 pg35 [28925]
+11 1
+.names pg35 ng4284 ng4180 [28927]
+11- 1
+1-0 1
+.names ng5599 pg35 [28928]
+11 1
+.names pg35 ng4284 ng4180 [28931]
+11- 1
+1-0 1
+.names ng3893 pg35 [28932]
+11 1
+.names ng11626 ng11763 [7167] [28931] [28933]
+--1- 1
+11-1 1
+.names ng4141 ng4064 ng4057 [28935]
+011 1
+.names ng4141 ng4064 ng4057 [28937]
+10- 1
+1-0 1
+.names pg35 ng2841 ng4057 [28935] [28938]
+0-1- 1
+11-1 1
+.names pg16718 ng3235 ng3352 ng3288 [28940]
+1111 1
+.names ng3338 pg16686 [28941]
+11 1
+.names ng3352 ng3288 ng3247 [28942]
+111 1
+.names ng3223 pg16874 [28943]
+11 1
+.names ng3352 ng3338 ng3288 [28944]
+101 1
+.names ng3338 pg16874 [28945]
+11 1
+.names ng3352 ng3215 ng3288 [28946]
+110 1
+.names ng3191 pg11349 [28947]
+11 1
+.names ng3203 pg16624 [28949]
+11 1
+.names pg13895 ng3219 ng3352 ng3288 [28952]
+1101 1
+.names ng3231 pg13865 [28953]
+11 1
+.names ng3352 ng3338 ng3288 [28954]
+011 1
+.names ng3338 pg14421 [28955]
+01 1
+.names ng3352 ng3288 ng3199 [28956]
+011 1
+.names pg16603 ng3352 ng3251 ng3288 [28958]
+1010 1
+.names ng3329 ng3195 [28959]
+11 1
+.names ng3187 pg14421 [28961]
+11 1
+.names ng11350 [28940] [28941] [28942] [28963]
+01-- 1
+--11 1
+.names [28943] [28944] [28945] [28946] [28964]
+11-- 1
+--11 1
+.names ng3338 ng13700 [28947] [28949] [28965]
+111- 1
+01-1 1
+.names ng11350 [28952] [28953] [28954] [28966]
+01-- 1
+--11 1
+.names ng11350 [28955] [28956] [28958] [28967]
+-11- 1
+0--1 1
+.names ng3338 ng11194 [28959] [28961] [28968]
+111- 1
+11-1 1
+.names [28968] [28967] [28971]
+1- 1
+-1 1
+.names [28963] [28964] [28965] [28966] [28972]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng3207 pg11349 [28973]
+11 1
+.names ng3263 pg16624 [28975]
+11 1
+.names pg16718 ng3243 ng3352 ng3288 [28978]
+1110 1
+.names ng3255 pg16686 [28979]
+11 1
+.names ng3352 ng3338 ng3288 [28980]
+100 1
+.names pg16603 ng3259 ng3352 ng3288 [28982]
+1101 1
+.names ng3329 ng3211 [28983]
+11 1
+.names ng3352 ng3338 ng3288 [28984]
+001 1
+.names pg13895 ng3352 ng3227 ng3288 [28986]
+1010 1
+.names ng3239 pg13865 [28987]
+11 1
+.names ng3352 ng3338 ng3288 [28988]
+000 1
+.names ng3338 ng13765 [28973] [28975] [28989]
+011- 1
+11-1 1
+.names ng11350 [28978] [28979] [28980] [28990]
+11-- 1
+--11 1
+.names ng11350 [28982] [28983] [28984] [28991]
+11-- 1
+--11 1
+.names ng11350 [28986] [28987] [28988] [28992]
+11-- 1
+--11 1
+.names [28989] [28990] [28991] [28992] [28995]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng4975 ng4899 ng4864 ng4933 [28996]
+0-1- 1
+-11- 1
+--10 1
+.names pg35 ng3106 ng20887 ng10721 [29000]
+101- 1
+1-11 1
+.names pg35 ng3106 ng20887 ng10721 [29002]
+1110 1
+.names ng3106 pg35 [29003]
+11 1
+.names ng979 ng1061 ng1087 [29009]
+0-1 1
+-01 1
+.names ng2040 ng1996 [29011]
+1- 1
+-0 1
+.names pg35 ng26759 ng14438 [29011] [29012]
+11-0 1
+1-10 1
+.names ng2004 pg35 [29013]
+11 1
+.names pg35 ng4284 ng4180 [29015]
+11- 1
+1-0 1
+.names ng3586 pg35 [29016]
+11 1
+.names pg35 ng925 ng918 ng25888 [29023]
+0-1- 1
+1010 1
+.names pg35 ng4284 ng4180 [29025]
+11- 1
+1-0 1
+.names ng6255 pg35 [29026]
+11 1
+.names ng12622 ng12667 [7100] [29025] [29027]
+--1- 1
+11-1 1
+.names ng2153 ng2197 [29028]
+1- 1
+-0 1
+.names pg35 ng26703 ng17321 [29028] [29029]
+11-0 1
+1-10 1
+.names ng2177 pg35 [29030]
+11 1
+.names pg72 pg35 ng4578 ng4581 [29039]
+11-1 1
+-111 1
+.names pg73 pg35 ng4581 ng4540 [29040]
+-0-1 1
+--01 1
+011- 1
+.names pg35 ng4284 ng4180 [29043]
+11- 1
+1-0 1
+.names ng3933 pg35 [29044]
+11 1
+.names pg35 pg12919 ng911 [29047]
+111 1
+.names pg35 ng907 ng19063 [29047] [29048]
+01-- 1
+-0-1 1
+--01 1
+.names pg35 ng4284 ng4180 [29049]
+11- 1
+1-0 1
+.names ng3901 pg35 [29050]
+11 1
+.names ng11626 ng11537 [7077] [29049] [29051]
+--1- 1
+11-1 1
+.names pg35 ng4284 ng4180 [29054]
+11- 1
+1-0 1
+.names ng6649 pg35 [29055]
+11 1
+.names ng1322 ng1404 ng1430 [29058]
+0-1 1
+-01 1
+.names ng504 ng518 ng528 [29061]
+011 1
+.names ng2555 pg35 [29063]
+11 1
+.names pg35 ng4087 ng2841 [29068]
+111 1
+.names pg35 ng4087 ng2841 [29070]
+101 1
+.names pg35 ng4076 ng13217 [29068] [29071]
+01-- 1
+-0-1 1
+--11 1
+.names ng1467 pg35 [29072]
+11 1
+.names ng1472 ng1442 ng1489 [29073]
+11- 1
+1-1 1
+.names ng1467 pg35 [29076]
+11 1
+.names ng1472 ng1442 ng1489 [29077]
+01- 1
+0-1 1
+.names pg35 ng1472 ng1442 ng1489 [29081]
+1100 1
+.names pg35 ng1472 ng1442 ng1489 [29084]
+1000 1
+.names pg35 ng1467 ng1448 ng13315 [29087]
+0-1- 1
+11-1 1
+.names ng13378 ng13315 [29081] [29084] [29088]
+001- 1
+10-1 1
+.names ng4888 ng4975 ng4899 ng4836 [29091]
+0--1 1
+-1-1 1
+--11 1
+.names ng2715 ng2719 ng2771 [29097]
+000 1
+.names ng1657 ng1624 [29099]
+0- 1
+-0 1
+.names pg35 ng1950 ng1936 ng1862 [29103]
+10-- 1
+1-00 1
+.names ng26725 ng17401 [29103] [29104]
+1-1 1
+-11 1
+.names pg35 ng1950 ng1936 ng1862 [29105]
+111- 1
+11-1 1
+.names ng26725 ng17401 [29105] [29106]
+1-1 1
+-11 1
+.names ng1950 pg35 [29107]
+11 1
+.names ng26725 ng17401 [7034] [29107] [29108]
+--1- 1
+00-1 1
+.names ng2715 ng2719 ng2807 [29111]
+100 1
+.names ng2351 ng2319 [29113]
+0- 1
+-0 1
+.names pg35 ng2407 ng2413 [29115]
+100 1
+.names ng2417 pg35 [29117]
+11 1
+.names ng2407 ng2413 ng25349 [29117] [29119]
+--11 1
+110- 1
+.names ng246 pg35 [29120]
+11 1
+.names ng475 pg35 [29121]
+11 1
+.names ng305 ng319 ng311 [29124]
+000 1
+.names pg35 ng336 ng311 [29126]
+101 1
+.names pg35 ng336 ng305 [29128]
+111 1
+.names ng319 pg35 [29129]
+11 1
+.names pg35 ng329 [29124] [29130]
+01- 1
+101 1
+.names ng13385 [29126] [29128] [29131]
+11- 1
+1-1 1
+.names pg35 pg17760 pg14779 pg17649 [29138]
+1000 1
+.names pg35 pg17760 pg14779 pg17685 [29143]
+1110 1
+.names pg35 pg17760 pg17649 pg17685 [29148]
+1000 1
+.names pg35 pg17760 pg14779 pg17649 [29153]
+1111 1
+.names pg35 ng1772 ng112 ng1802 [29159]
+1001 1
+.names pg35 ng1772 ng112 ng1802 [29161]
+111- 1
+1-10 1
+.names ng1779 pg35 [29162]
+11 1
+.names pg35 ng2715 ng2370 [29168]
+111 1
+.names pg35 ng2715 ng2236 [29171]
+101 1
+.names pg35 ng2715 ng2807 [29175]
+110 1
+.names pg35 ng2715 ng2803 [29178]
+100 1
+.names ng2719 pg35 [29180]
+11 1
+.names pg35 ng2719 ng23553 [29183]
+110 1
+.names ng21277 ng23657 [29168] [29171] [29184]
+001- 1
+00-1 1
+.names ng21277 ng23553 [29175] [29178] [29185]
+101- 1
+10-1 1
+.names ng21277 ng23657 [29180] [29183] [29186]
+1--1 1
+001- 1
+.names ng4087 ng4098 ng4093 [29192]
+000 1
+.names pg35 ng5188 ng5176 ng5180 [29195]
+1011 1
+.names pg35 ng5188 ng5176 ng5180 [29196]
+110- 1
+11-0 1
+.names ng504 pg35 [29198]
+11 1
+.names pg35 ng667 ng686 [29199]
+110 1
+.names pg35 ng499 ng11607 [29199] [29202]
+--11 1
+111- 1
+.names pg19334 pg7916 ng990 [29209]
+1-- 1
+-1- 1
+--1 1
+.names ng1008 ng969 [29210]
+1- 1
+-1 1
+.names ng4975 ng4899 ng4944 ng4871 [29216]
+1--1 1
+-0-1 1
+--01 1
+.names pg35 ng3462 ng3457 [29220]
+110 1
+.names ng3457 ng3462 [29221]
+10 1
+.names pg35 ng3466 ng23112 [29221] [29223]
+--01 1
+111- 1
+.names ng3333 pg35 [29224]
+11 1
+.names pg35 [7137] [7138] [28996] [29225]
+11-- 1
+1-1- 1
+1--1 1
+.names pg35 ng4284 ng4180 [29227]
+11- 1
+1-0 1
+.names ng6613 pg35 [29228]
+11 1
+.names ng5703 ng4349 ng5644 ng4358 [29232]
+1110 1
+.names pg73 ng4332 ng4311 [29233]
+111 1
+001 1
+.names ng4349 ng3352 ng3288 ng4358 [29234]
+1110 1
+.names ng6741 ng6682 ng4349 ng4358 [29235]
+1100 1
+.names ng4349 ng6336 ng6395 ng4358 [29236]
+1111 1
+.names ng4349 ng4054 ng3990 ng4358 [29237]
+1111 1
+.names ng4349 ng5990 ng6049 ng4358 [29238]
+0111 1
+.names ng5297 ng5357 ng4349 ng4358 [29239]
+1100 1
+.names ng4349 ng3703 ng3639 ng4358 [29240]
+0111 1
+.names [6946] [6947] [6948] [6949] [29245]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [6950] [6951] [6952] [6953] [29246]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng1478 pg35 [29247]
+11 1
+.names ng1437 ng1478 [29248]
+10 1
+.names pg35 ng1478 ng1437 [29250]
+0-1 1
+110 1
+.names ng10961 ng13861 [29247] [29250] [29251]
+---1 1
+1-1- 1
+-11- 1
+.names ng4785 ng4709 ng11261 ng10831 [29253]
+1111 1
+.names ng4975 ng4899 ng11283 ng10862 [29254]
+1111 1
+.names pg35 ng2643 ng2555 ng2629 [29255]
+111- 1
+11-1 1
+.names ng26793 ng14506 [29255] [29256]
+1-1 1
+-11 1
+.names pg35 ng2643 ng2555 ng2629 [29257]
+10-- 1
+1-00 1
+.names ng26793 ng14506 [29257] [29258]
+1-1 1
+-11 1
+.names ng2643 pg35 [29259]
+11 1
+.names ng26793 ng14506 [6933] [29259] [29260]
+--1- 1
+00-1 1
+.names pg17291 ng979 ng1061 [29263]
+10- 1
+1-0 1
+.names pg35 ng11893 ng26673 ng17292 [29265]
+111- 1
+11-1 1
+.names ng1620 pg35 [29266]
+11 1
+.names pg17423 ng1322 ng1404 [29269]
+10- 1
+1-0 1
+.names ng504 ng518 ng528 [29272]
+111 1
+.names pg35 ng4284 ng4180 [29277]
+11- 1
+1-0 1
+.names ng5583 pg35 [29278]
+11 1
+.names pg35 ng4284 ng4180 [29280]
+11- 1
+1-0 1
+.names ng5244 pg35 [29281]
+11 1
+.names pg35 pg12919 ng904 ng921 [29283]
+1111 1
+.names pg35 pg12919 ng936 [29284]
+111 1
+.names pg35 ng921 ng15674 [29284] [29285]
+01-- 1
+--11 1
+.names pg35 ng4854 ng11012 [29290]
+101 1
+.names pg35 ng4854 ng11012 [29292]
+110 1
+.names ng31009 ng10862 [6890] [29290] [29293]
+--1- 1
+10-1 1
+.names ng1632 pg35 [29300]
+01 1
+.names pg35 ng2767 ng2763 ng12377 [29303]
+0-1- 1
+11-0 1
+.names pg35 ng4284 ng4180 [29304]
+11- 1
+1-0 1
+.names ng5921 pg35 [29305]
+11 1
+.names ng2783 ng2724 [29308]
+00 1
+.names ng2787 ng2724 [29309]
+01 1
+.names ng5046 ng5052 [29312]
+00 1
+.names pg84 ng5022 ng5057 [29313]
+011 1
+.names ng5046 ng5041 [29315]
+00 1
+.names pg84 ng5022 ng5057 [29316]
+111 1
+.names pg35 ng5052 ng5046 [29313] [29317]
+11-- 1
+1-1- 1
+1--0 1
+.names pg35 ng979 ng1061 [29320]
+101 1
+.names pg35 ng979 ng1061 [29322]
+100 1
+.names pg35 ng1052 ng13121 [29320] [29323]
+01-- 1
+-0-1 1
+--11 1
+.names pg7257 pg7243 [29324]
+00 1
+.names ng4411 ng4375 [29325]
+00 1
+.names pg7243 pg7257 ng4405 [29326]
+000 1
+.names pg35 ng4392 ng4388 [29328]
+101 1
+.names pg35 ng4284 ng4180 [29329]
+11- 1
+1-0 1
+.names ng3610 pg35 [29330]
+11 1
+.names ng4975 pg35 [29335]
+11 1
+.names ng28349 ng13486 [6849] [29335] [29336]
+--1- 1
+11-1 1
+.names pg35 ng4388 ng4430 [29340]
+0-1 1
+-01 1
+.names ng4674 ng4785 ng4743 ng4709 [29346]
+10-- 1
+1-0- 1
+1--1 1
+.names ng93 ng4349 ng4358 ng29503 [29348]
+1101 1
+.names ng5703 pg35 [29350]
+01 1
+.names ng5703 pg35 [29352]
+11 1
+.names pg73 pg72 pg35 [29355]
+1-1 1
+-11 1
+.names pg73 pg72 pg35 [29359]
+001 1
+.names ng12228 [6823] [6825] [29359] [29361]
+-1-- 1
+--1- 1
+1--1 1
+.names ng1141 pg35 [29362]
+11 1
+.names ng956 ng1146 ng1099 [29363]
+11- 1
+1-1 1
+.names ng1141 pg35 [29366]
+11 1
+.names ng956 ng1146 ng1099 [29367]
+01- 1
+0-1 1
+.names pg35 ng956 ng1146 ng1099 [29371]
+1100 1
+.names pg35 ng956 ng1146 ng1099 [29374]
+1000 1
+.names pg35 ng1141 ng1129 ng10909 [29377]
+0-1- 1
+11-1 1
+.names ng10909 ng13336 [29371] [29374] [29378]
+001- 1
+01-1 1
+.names pg35 ng4504 ng4581 [29383]
+01- 1
+-10 1
+.names ng291 pg35 [29391]
+11 1
+.names ng291 pg35 [29393]
+01 1
+.names ng424 ng691 ng417 [29397]
+10- 1
+-00 1
+.names pg35 ng4284 ng4180 [29402]
+11- 1
+1-0 1
+.names ng6267 pg35 [29403]
+11 1
+.names pg17404 ng1322 ng1404 [29405]
+10- 1
+1-0 1
+.names ng2399 pg35 [29408]
+11 1
+.names ng20841 ng19968 ng20014 ng19919 [29414]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng2898 ng2864 [29415]
+11- 1
+0-1 1
+.names ng4392 pg35 [29416]
+11 1
+.names ng4382 ng4375 [29417]
+11 1
+.names [6743] [29325] [29326] [29416] [29418]
+1--- 1
+-111 1
+.names ng5897 ng6035 [29419]
+11 1
+.names ng5990 ng6049 ng6031 [29420]
+001 1
+.names pg17607 ng5953 ng5990 ng6049 [29422]
+1100 1
+.names ng5889 pg13068 [29423]
+11 1
+.names ng6035 ng5990 ng6049 [29424]
+100 1
+.names ng6035 pg17819 [29425]
+01 1
+.names ng5990 ng6049 ng5925 [29426]
+111 1
+.names pg17739 ng5937 ng5990 ng6049 [29428]
+1111 1
+.names ng5949 pg17715 [29429]
+11 1
+.names ng6035 ng5990 ng6049 [29430]
+111 1
+.names ng6035 pg14673 [29431]
+11 1
+.names ng5990 ng6049 ng5933 [29432]
+101 1
+.names ng6035 pg12350 [29433]
+11 1
+.names ng5990 ng5893 ng6049 [29434]
+011 1
+.names pg14738 ng5921 ng5990 ng6049 [29436]
+1110 1
+.names ng6035 pg13068 [29437]
+01 1
+.names ng5901 ng5990 ng6049 [29438]
+110 1
+.names ng6035 pg17646 [29439]
+01 1
+.names ng5990 ng6049 ng5905 [29440]
+011 1
+.names ng5917 pg17819 [29441]
+11 1
+.names ng6035 ng5990 ng6049 [29442]
+101 1
+.names ng12351 [29419] [29420] [29422] [29443]
+-11- 1
+0--1 1
+.names [29423] [29424] [29425] [29426] [29444]
+11-- 1
+--11 1
+.names ng12351 [29428] [29429] [29430] [29445]
+01-- 1
+--11 1
+.names [29431] [29432] [29433] [29434] [29446]
+11-- 1
+--11 1
+.names ng12351 [29436] [29437] [29438] [29447]
+01-- 1
+--11 1
+.names [29439] [29440] [29441] [29442] [29448]
+11-- 1
+--11 1
+.names [29448] [29447] [29451]
+1- 1
+-1 1
+.names [29443] [29444] [29445] [29446] [29452]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng6035 pg14673 [29453]
+01 1
+.names ng5941 ng5990 ng6049 [29454]
+100 1
+.names pg14738 ng5929 ng5990 ng6049 [29456]
+1100 1
+.names ng6035 pg12350 [29457]
+01 1
+.names ng5990 ng6049 ng5909 [29458]
+111 1
+.names ng6035 pg17646 [29459]
+11 1
+.names ng5990 ng6049 ng5965 [29460]
+111 1
+.names ng6035 ng5913 [29461]
+01 1
+.names ng5990 ng6049 ng6031 [29462]
+101 1
+.names pg17607 ng5990 ng6049 ng5961 [29464]
+1101 1
+.names pg17739 ng5990 ng6049 ng5945 [29466]
+1011 1
+.names ng6035 pg17715 [29467]
+01 1
+.names ng5990 ng6049 ng5957 [29468]
+011 1
+.names ng12351 [29453] [29454] [29456] [29469]
+-11- 1
+1--1 1
+.names [29457] [29458] [29459] [29460] [29470]
+11-- 1
+--11 1
+.names ng12351 [29461] [29462] [29464] [29471]
+-11- 1
+1--1 1
+.names ng12351 [29466] [29467] [29468] [29472]
+11-- 1
+--11 1
+.names [29469] [29470] [29471] [29472] [29475]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 [7351] [7352] [28734] [29476]
+11-- 1
+1-1- 1
+1--1 1
+.names ng4831 pg35 [29477]
+11 1
+.names pg35 ng4284 ng4180 [29480]
+11- 1
+1-0 1
+.names ng5889 pg35 [29481]
+11 1
+.names ng10312 ng12609 [6714] [29480] [29482]
+--1- 1
+11-1 1
+.names pg35 ng822 ng14279 [29484]
+100 1
+.names pg35 ng822 ng14279 [29486]
+110 1
+.names ng3873 ng3881 ng3869 [29489]
+111 1
+.names ng4087 ng4098 ng4093 [29491]
+001 1
+.names ng5869 ng5881 ng5873 [29493]
+111 1
+.names ng4087 ng4098 ng4093 [29495]
+100 1
+.names ng5535 ng5523 ng5527 [29496]
+111 1
+.names ng3171 ng3179 ng3167 [29497]
+111 1
+.names ng4087 ng4098 ng4093 [29499]
+011 1
+.names ng3530 ng3518 ng3522 [29500]
+111 1
+.names ng4087 ng4098 ng4093 [29502]
+010 1
+.names [6699] [6700] [6701] [6702] [29507]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [6703] [6704] [6705] [6706] [29508]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng2102 ng2108 [29510]
+100 1
+.names ng2108 ng2102 [29511]
+11 1
+.names ng2112 pg35 [29512]
+11 1
+.names pg35 ng4284 ng4180 [29516]
+11- 1
+1-0 1
+.names ng5543 pg35 [29517]
+11 1
+.names ng10281 ng12558 [6694] [29516] [29518]
+--1- 1
+11-1 1
+.names ng4452 ng4443 [29520]
+00 1
+.names pg7260 pg7245 ng4438 [29521]
+000 1
+.names ng4438 ng4382 [29522]
+11 1
+.names ng4392 pg35 [29523]
+11 1
+.names [6691] [29520] [29521] [29522] [29524]
+1--- 1
+-0-1 1
+--01 1
+.names pg35 ng142 ng23204 [29526]
+111 1
+.names ng142 pg35 [29527]
+01 1
+.names pg35 pg9497 pg9553 ng5112 [29532]
+0--1 1
+1010 1
+.names ng1454 ng1448 [29534]
+10 1
+.names ng1448 pg35 [29535]
+11 1
+.names pg35 ng1448 ng1454 [29536]
+0-1 1
+110 1
+.names ng13273 ng10961 [29534] [29536] [29537]
+---1 1
+001- 1
+.names pg35 ng4284 ng4180 [29538]
+11- 1
+1-0 1
+.names ng3961 pg35 [29539]
+11 1
+.names pg35 ng1002 ng15737 ng7567 [29541]
+11-0 1
+1-10 1
+.names ng1018 pg35 [29542]
+11 1
+.names ng5046 ng5062 [29545]
+11 1
+.names pg84 ng5052 ng5057 [29546]
+010 1
+.names ng5046 ng5041 [29548]
+11 1
+.names pg84 ng5062 ng5057 [29549]
+110 1
+.names [29545] [29546] [29548] [29549] [29550]
+11-- 1
+--11 1
+.names [29312] [29313] [29315] [29316] [29551]
+11-- 1
+--11 1
+.names pg35 ng5029 ng12933 [29553]
+110 1
+.names pg35 ng5029 ng5016 ng12933 [29555]
+0-1- 1
+10-1 1
+.names ng513 pg35 [29556]
+11 1
+.names ng504 ng667 ng686 [29557]
+10- 1
+1-1 1
+.names ng1996 ng2070 [29559]
+0- 1
+-0 1
+.names pg35 ng26759 ng14438 [29559] [29560]
+11-0 1
+1-10 1
+.names ng2016 pg35 [29561]
+11 1
+.names pg35 ng4284 ng4180 [29563]
+11- 1
+1-0 1
+.names ng5575 pg35 [29564]
+11 1
+.names pg35 ng5052 [29550] [29551] [29567]
+1100 1
+.names ng5052 pg35 [29568]
+01 1
+.names ng2715 ng2719 ng2783 [29571]
+010 1
+.names ng1894 ng1926 [29573]
+0- 1
+-0 1
+.names pg35 ng1988 ng1982 [29575]
+100 1
+.names ng1992 pg35 [29577]
+11 1
+.names ng1988 ng1982 ng25341 [29577] [29579]
+--11 1
+110- 1
+.names pg35 ng2902 ng209 ng691 [29581]
+11-- 1
+1-1- 1
+1--0 1
+.names ng4040 pg16693 [29582]
+01 1
+.names ng4054 ng3990 ng3905 [29583]
+101 1
+.names ng3917 pg16955 [29584]
+11 1
+.names ng4040 ng4054 ng3990 [29585]
+110 1
+.names ng3893 pg11418 [29586]
+11 1
+.names ng4040 ng4054 ng3990 [29587]
+110 1
+.names pg16659 ng4054 ng3953 ng3990 [29589]
+1010 1
+.names ng4040 pg14518 [29590]
+11 1
+.names ng3889 ng4054 ng3990 [29591]
+100 1
+.names ng4040 ng4031 [29592]
+11 1
+.names ng3897 ng4054 ng3990 [29593]
+100 1
+.names pg16775 ng3937 ng4054 ng3990 [29595]
+1111 1
+.names ng3925 pg16955 [29596]
+11 1
+.names ng4040 ng4054 ng3990 [29597]
+011 1
+.names ng3949 pg16748 [29598]
+11 1
+.names ng4040 ng4054 ng3990 [29599]
+111 1
+.names pg13966 ng3921 ng4054 ng3990 [29601]
+1101 1
+.names ng3933 pg13906 [29602]
+11 1
+.names ng3901 pg14518 [29604]
+11 1
+.names [29582] [29583] [29584] [29585] [29606]
+11-- 1
+--11 1
+.names ng11419 [29586] [29587] [29589] [29607]
+-11- 1
+0--1 1
+.names [29590] [29591] [29592] [29593] [29608]
+11-- 1
+--11 1
+.names ng11419 [29595] [29596] [29597] [29609]
+01-- 1
+--11 1
+.names ng11419 [29598] [29599] [29601] [29610]
+-11- 1
+0--1 1
+.names ng4040 ng11255 [29602] [29604] [29611]
+111- 1
+01-1 1
+.names [29611] [29610] [29614]
+1- 1
+-1 1
+.names [29606] [29607] [29608] [29609] [29615]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg16775 ng4054 ng3990 ng3945 [29617]
+1101 1
+.names ng4040 pg16748 [29618]
+01 1
+.names ng4054 ng3957 ng3990 [29619]
+110 1
+.names ng4040 pg13906 [29620]
+01 1
+.names ng4054 ng3990 ng3941 [29621]
+001 1
+.names pg13966 ng3929 ng4054 ng3990 [29623]
+1100 1
+.names ng4040 pg16693 [29624]
+11 1
+.names ng4054 ng3965 ng3990 [29625]
+111 1
+.names ng4040 pg11418 [29626]
+01 1
+.names ng4054 ng3990 ng3909 [29627]
+111 1
+.names pg16659 ng3961 ng4054 ng3990 [29629]
+1101 1
+.names ng3913 ng4031 [29630]
+11 1
+.names ng4040 ng4054 ng3990 [29631]
+001 1
+.names ng11419 [29617] [29618] [29619] [29632]
+11-- 1
+--11 1
+.names ng11419 [29620] [29621] [29623] [29633]
+-11- 1
+1--1 1
+.names [29624] [29625] [29626] [29627] [29634]
+11-- 1
+--11 1
+.names ng11419 [29629] [29630] [29631] [29635]
+11-- 1
+--11 1
+.names [29632] [29633] [29634] [29635] [29638]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng3808 ng10756 [29639]
+110 1
+.names [7325] [7326] [28766] [29639] [29640]
+1--1 1
+-1-1 1
+--11 1
+.names pg35 ng3808 ng10756 [29641]
+10- 1
+1-1 1
+.names [7325] [7326] [28766] [29641] [29642]
+1--1 1
+-1-1 1
+--11 1
+.names ng3808 pg35 [29643]
+11 1
+.names [6622] [28765] [28766] [29643] [29644]
+1--- 1
+-001 1
+.names ng1636 ng1668 [29646]
+0- 1
+-1 1
+.names pg35 ng26673 ng17292 [29646] [29647]
+11-0 1
+1-10 1
+.names ng1608 pg35 [29648]
+11 1
+.names pg35 ng5535 ng5523 ng5527 [29652]
+1011 1
+.names pg35 ng5535 ng5523 ng5527 [29653]
+110- 1
+11-0 1
+.names pg35 ng4284 ng4180 [29657]
+11- 1
+1-0 1
+.names ng3203 pg35 [29658]
+11 1
+.names pg35 ng4633 ng12911 [29663]
+100 1
+.names pg35 ng4633 ng12911 [29665]
+111 1
+.names ng4141 ng4064 ng4057 ng4082 [29669]
+1--- 1
+-0-- 1
+--1- 1
+---1 1
+.names ng4145 pg35 [29670]
+11 1
+.names ng4116 pg35 [29671]
+11 1
+.names ng13806 [6595] [29669] [29670] [29672]
+-1-- 1
+1-01 1
+.names pg35 ng298 ng23204 [29674]
+111 1
+.names ng298 pg35 [29675]
+01 1
+.names ng28444 [6592] [28561] [29674] [29676]
+-1-- 1
+0--1 1
+--11 1
+.names pg35 pg17291 pg17316 pg17400 [29679]
+1000 1
+.names pg35 pg17291 pg17316 pg17400 [29683]
+1000 1
+.names pg72 pg35 ng4572 ng4581 [29688]
+01-1 1
+-111 1
+.names pg73 pg35 ng4581 ng4498 [29689]
+-0-1 1
+--01 1
+111- 1
+.names pg35 ng4284 ng4180 [29693]
+11- 1
+1-0 1
+.names ng5240 pg35 [29694]
+11 1
+.names pg35 ng4284 ng4180 [29702]
+11- 1
+1-0 1
+.names ng5929 pg35 [29703]
+11 1
+.names pg35 ng837 ng832 [29706]
+110 1
+.names pg35 ng837 ng827 [29708]
+110 1
+.names ng837 pg35 [29709]
+11 1
+.names pg35 ng703 ng14279 [29706] [29711]
+01-- 1
+--01 1
+.names ng8806 ng14279 [29708] [29709] [29712]
+-01- 1
+1--1 1
+.names ng2465 ng2495 [29714]
+0- 1
+-1 1
+.names pg35 ng26770 ng17424 [29714] [29715]
+11-0 1
+1-10 1
+.names ng2437 pg35 [29716]
+11 1
+.names pg11678 ng781 ng736 [29718]
+01- 1
+-11 1
+.names pg35 pg11678 ng785 ng736 [29720]
+101- 1
+1-11 1
+.names ng785 pg35 [29721]
+01 1
+.names ng2629 ng2555 [29723]
+0- 1
+-0 1
+.names pg35 ng26793 ng14506 [29723] [29724]
+11-0 1
+1-10 1
+.names ng2575 pg35 [29725]
+11 1
+.names pg35 ng4284 ng4180 [29727]
+11- 1
+1-0 1
+.names ng3925 pg35 [29728]
+11 1
+.names ng4818 [1421] [29730]
+1- 1
+-1 1
+.names [1421] ng4771 ng4818 ng24374 [29731]
+11-- 1
+-11- 1
+-1-0 1
+.names pg35 ng101 ng24374 [29730] [29733]
+1110 1
+.names pg35 ng4765 ng29719 [29733] [29735]
+--11 1
+110- 1
+.names pg35 ng4284 ng4180 [29737]
+11- 1
+1-0 1
+.names ng6605 pg35 [29738]
+11 1
+.names pg35 ng6573 ng6561 ng6565 [29742]
+1011 1
+.names pg35 ng6573 ng6561 ng6565 [29743]
+110- 1
+11-0 1
+.names pg35 ng5481 ng5475 [29747]
+100 1
+.names pg35 ng5481 ng5475 [29749]
+111 1
+.names pg35 ng5485 ng23630 [29749] [29752]
+--01 1
+111- 1
+.names ng1211 pg35 [29753]
+01 1
+.names ng1211 pg35 [29755]
+11 1
+.names ng11148 ng13570 [6520] [29753] [29757]
+--1- 1
+00-1 1
+.names ng1821 pg35 [29758]
+11 1
+.names pg35 ng5120 ng5115 [29761]
+110 1
+.names ng5115 ng5120 [29762]
+10 1
+.names pg35 ng5124 ng23590 [29762] [29764]
+--01 1
+111- 1
+.names pg35 pg13099 pg14828 pg17722 [29770]
+1000 1
+.names pg17778 pg17688 [29771]
+00 1
+.names pg35 pg14828 pg12470 pg17722 [29775]
+1111 1
+.names pg14828 pg12470 pg17778 pg17688 [29776]
+0-11 1
+-011 1
+.names pg35 pg13099 pg14828 pg12470 [29780]
+1011 1
+.names pg35 pg13099 pg14828 pg12470 [29785]
+1011 1
+.names [29770] [29771] [29775] [29776] [29787]
+11-- 1
+--11 1
+.names pg11678 ng785 ng736 [29789]
+-0- 1
+1-0 1
+.names pg35 pg11678 ng790 ng736 [29791]
+101- 1
+1-11 1
+.names ng790 pg35 [29792]
+01 1
+.names pg35 ng4284 ng4180 [29797]
+11- 1
+1-0 1
+.names ng3594 pg35 [29798]
+11 1
+.names pg35 ng4284 ng4180 [29800]
+11- 1
+1-0 1
+.names ng5953 pg35 [29801]
+11 1
+.names pg35 ng6561 ng6555 ng6549 [29804]
+1011 1
+.names ng2729 ng2724 [29805]
+1- 1
+-0 1
+.names ng2779 pg35 [29806]
+01 1
+.names ng2724 ng2729 ng11405 [29806] [29807]
+1001 1
+.names ng85 ng29503 ng11405 [29805] [29809]
+0-00 1
+-000 1
+.names ng2775 pg35 [29810]
+11 1
+.names ng11405 [6486] [29805] [29810] [29811]
+-1-- 1
+1--1 1
+--11 1
+.names ng85 ng29503 [29807] [29811] [29812]
+---1 1
+0-1- 1
+-01- 1
+.names pg135 ng4584 ng4616 ng4601 [29816]
+0000 1
+.names pg135 ng4584 ng4616 ng4601 [29820]
+0100 1
+.names pg135 ng4584 ng4616 ng4601 [29824]
+0001 1
+.names ng4593 ng4608 [29827]
+11 1
+.names pg135 ng4584 ng4616 ng4601 [29828]
+0101 1
+.names ng4608 ng4601 [29830]
+00 1
+.names pg135 ng4584 ng4593 [29831]
+011 1
+.names ng4608 ng4593 [6482] [29816] [29834]
+--1- 1
+00-1 1
+.names ng4608 ng4593 [29820] [29824] [29835]
+101- 1
+01-1 1
+.names [29827] [29828] [29830] [29831] [29836]
+11-- 1
+--11 1
+.names pg35 ng5022 ng5016 ng5062 [29841]
+110- 1
+1-01 1
+.names pg35 ng5022 ng5016 ng5062 [29843]
+01-- 1
+1010 1
+.names pg120 pg124 pg35 ng4146 [29848]
+-111 1
+1-10 1
+.names pg120 pg124 pg35 ng4146 [29849]
+001- 1
+-011 1
+0-10 1
+.names pg116 pg114 pg35 ng4157 [29850]
+1-11 1
+-110 1
+.names pg116 pg114 pg35 ng4157 [29851]
+001- 1
+0-11 1
+-010 1
+.names pg35 ng4122 ng26212 [29848] [29852]
+01-- 1
+--01 1
+.names ng26256 ng26212 [29849] [29850] [29853]
+-11- 1
+0--1 1
+.names pg35 ng4284 ng4180 [29855]
+11- 1
+1-0 1
+.names ng3239 pg35 [29856]
+11 1
+.names ng1478 pg35 [29858]
+11 1
+.names ng1437 ng1442 ng1489 [29859]
+11- 1
+1-1 1
+.names ng1478 pg35 [29862]
+01 1
+.names ng1437 ng1442 ng1489 [29863]
+11- 1
+1-1 1
+.names pg35 ng1478 ng1442 ng1489 [29867]
+1100 1
+.names pg35 ng1478 ng1442 ng1489 [29870]
+1000 1
+.names pg35 ng1437 ng1442 ng13861 [29873]
+0-1- 1
+11-1 1
+.names ng13378 ng13861 [29867] [29870] [29874]
+001- 1
+10-1 1
+.names ng2729 ng2724 [29883]
+0- 1
+-0 1
+.names ng2827 pg35 [29884]
+01 1
+.names ng2724 ng2729 ng11405 [29884] [29885]
+1101 1
+.names ng111 ng29503 ng11405 [29883] [29887]
+0-00 1
+-000 1
+.names ng2819 pg35 [29888]
+11 1
+.names ng11405 [6436] [29883] [29888] [29889]
+-1-- 1
+1--1 1
+--11 1
+.names ng111 ng29503 [29885] [29889] [29890]
+---1 1
+0-1- 1
+-01- 1
+.names pg35 pg8215 pg8277 ng3100 [29894]
+0--1 1
+1100 1
+.names pg72 pg35 ng4572 ng4581 [29899]
+11-1 1
+-111 1
+.names pg73 pg35 ng4581 ng4480 [29900]
+-0-1 1
+--01 1
+011- 1
+.names pg7916 ng1171 ng1183 [29901]
+101 1
+.names ng1070 pg35 [29902]
+01 1
+.names ng1199 ng10893 [29901] [29902] [29903]
+1011 1
+.names ng1070 pg35 [29904]
+11 1
+.names ng1199 ng10893 [29901] [29904] [29905]
+0--1 1
+-1-1 1
+--01 1
+.names pg35 ng4284 ng4180 [29907]
+11- 1
+1-0 1
+.names ng6251 pg35 [29908]
+11 1
+.names pg35 ng6533 ng6527 [29912]
+100 1
+.names pg35 ng6533 ng6527 [29914]
+111 1
+.names pg35 ng6537 ng10887 [29914] [29917]
+--11 1
+110- 1
+.names ng4616 ng4584 [29918]
+11 1
+.names ng4584 pg35 [29919]
+11 1
+.names ng10511 ng8347 [28475] [29919] [29920]
+1--1 1
+-1-1 1
+--11 1
+.names ng4584 pg35 [29921]
+01 1
+.names ng10511 ng8347 [28475] [29921] [29922]
+0001 1
+.names ng30583 [6407] [6408] [29920] [29923]
+-1-- 1
+0-01 1
+.names pg53 pg54 [29925]
+01 1
+.names pg56 pg57 ng34 [29926]
+000 1
+.names ng28 ng31 [29928]
+10 1
+.names ng9 ng19 ng16 [29930]
+110 1
+.names ng28 ng31 [29932]
+11 1
+.names ng9 ng19 ng16 [29934]
+001 1
+.names ng9 ng19 ng16 [29936]
+100 1
+.names ng28 ng31 [29937]
+10 1
+.names ng9 ng19 ng16 [29939]
+100 1
+.names ng9 ng19 ng16 [29941]
+001 1
+.names ng28 ng31 [29942]
+00 1
+.names ng9 ng19 ng16 [29944]
+101 1
+.names ng9 ng19 ng16 [29946]
+100 1
+.names ng17725 ng16283 [29925] [29926] [29948]
+1-11 1
+-111 1
+.names ng16194 ng16539 [29925] [29926] [29949]
+1-11 1
+-111 1
+.names ng27511 ng16244 ng16205 ng16486 [29950]
+11-- 1
+1-1- 1
+1--1 1
+.names ng94 ng13156 [29932] [29934] [29952]
+1111 1
+.names ng2965 ng14988 [29942] [29946] [29953]
+1111 1
+.names ng2960 ng14988 [29928] [29936] [29954]
+1111 1
+.names ng2878 ng13156 [29937] [29939] [29955]
+1111 1
+.names ng2873 ng13156 [29937] [29941] [29956]
+1111 1
+.names ng28 ng31 [29957]
+00 1
+.names ng9 ng19 ng16 [29959]
+100 1
+.names ng9 ng19 ng16 [29961]
+110 1
+.names pg54 pg53 [29926] [29961] [29962]
+1011 1
+.names ng28 ng31 [29963]
+01 1
+.names ng9 ng19 ng16 [29965]
+110 1
+.names pg54 pg53 [29926] [29965] [29966]
+1011 1
+.names [7545] [7546] [7547] [29968]
+1-- 1
+-1- 1
+--1 1
+.names [7544] [7543] [29971]
+1- 1
+-1 1
+.names [7540] [7541] [7542] [29968] [29972]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng9 ng19 ng16 [29974]
+000 1
+.names ng9 ng19 ng16 [29976]
+000 1
+.names ng9 ng19 ng16 [29978]
+010 1
+.names ng9 ng19 ng16 [29980]
+000 1
+.names ng9 ng19 ng16 [29982]
+010 1
+.names ng17613 ng17747 [29925] [29926] [29984]
+1-11 1
+-111 1
+.names ng27511 ng17766 ng17724 ng17690 [29985]
+11-- 1
+1-1- 1
+1--1 1
+.names ng790 ng13156 [29937] [29974] [29986]
+1111 1
+.names pg35 ng13156 [29937] [29974] [29987]
+0111 1
+.names ng572 ng13156 [29963] [29982] [29988]
+1111 1
+.names ng749 ng13156 [29932] [29976] [29989]
+1111 1
+.names pg35 ng13156 [29932] [29976] [29990]
+0111 1
+.names ng550 ng13156 [29957] [29980] [29991]
+0111 1
+.names ng608 ng13156 [29957] [29978] [29992]
+1111 1
+.names pg35 ng13156 [29957] [29978] [29993]
+0111 1
+.names pg35 ng13156 [29963] [29982] [29994]
+0111 1
+.names ng9 ng19 ng16 [29996]
+110 1
+.names pg54 pg53 [29926] [29996] [29997]
+1011 1
+.names ng9 ng19 ng16 [29999]
+010 1
+.names pg54 pg53 [29926] [29999] [30000]
+1011 1
+.names ng9 ng19 ng16 [30002]
+001 1
+.names pg54 pg53 [29926] [30002] [30003]
+1011 1
+.names ng4253 ni17529 [7531] [29997] [30004]
+--1- 1
+11-1 1
+.names [7532] [7533] [30004] [30006]
+1-- 1
+-1- 1
+--1 1
+.names [29984] [29985] [29987] [29988] [30008]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [29989] [29990] [30009]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [29991] [29992] [30010]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [29993] [29994] [30011]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [30010] [30009] [30013]
+1- 1
+-1 1
+.names [7521] [30006] [30008] [30011] [30014]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng794 ng13156 [29937] [29974] [30016]
+1111 1
+.names pg35 ng13156 [29937] [29974] [30017]
+0111 1
+.names ng534 ng13156 [29957] [29980] [30018]
+1111 1
+.names ng758 ng13156 [29932] [29976] [30019]
+1111 1
+.names pg35 ng13156 [29932] [29976] [30020]
+0111 1
+.names ng586 ng13156 [29963] [29982] [30021]
+1111 1
+.names ng613 ng13156 [29957] [29978] [30022]
+1111 1
+.names pg35 ng13156 [29957] [29978] [30023]
+0111 1
+.names pg35 ng13156 [29963] [29982] [30024]
+0111 1
+.names ng947 ni17529 [7518] [30000] [30025]
+--1- 1
+11-1 1
+.names ng1291 ni18740 [30003] [30025] [30026]
+---1 1
+111- 1
+.names [29984] [29985] [30017] [30018] [30028]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [30019] [30020] [30029]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [30021] [30022] [30030]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [30023] [30024] [30031]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [30030] [30029] [30033]
+1- 1
+-1 1
+.names [7509] [30026] [30028] [30031] [30034]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng37 ng13156 [29932] [29934] [30035]
+1111 1
+.names ng2950 ng14988 [29928] [29936] [30036]
+1111 1
+.names ng2882 ng13156 [29937] [29939] [30037]
+1111 1
+.names ng2868 ng13156 [29937] [29941] [30038]
+1111 1
+.names ng2955 ng14988 [29942] [29946] [30039]
+1111 1
+.names ng9 ng19 ng16 [30041]
+011 1
+.names pg54 pg53 [29926] [30041] [30042]
+1011 1
+.names ng9 ng19 ng16 [30044]
+011 1
+.names pg54 pg53 [29926] [30044] [30045]
+1011 1
+.names [7503] [7505] [7506] [7507] [30048]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [7498] [7504] [30048] [30052]
+1-- 1
+-1- 1
+--1 1
+.names [7499] [7500] [7501] [7502] [30053]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg100 ng13156 [29932] [29934] [30055]
+1111 1
+.names ng2890 ng13156 [29937] [29941] [30056]
+1111 1
+.names ng2984 ng14988 [29942] [29944] [30057]
+1111 1
+.names [7493] [7494] [7495] [30059]
+1-- 1
+-1- 1
+--1 1
+.names [7491] [7490] [30061]
+1- 1
+-1 1
+.names [7489] [7492] [30059] [30062]
+1-- 1
+-1- 1
+--1 1
+.names ng781 ng13156 [29937] [29974] [30063]
+1111 1
+.names pg35 ng13156 [29937] [29974] [30064]
+0111 1
+.names ng562 ng13156 [29963] [29982] [30065]
+1111 1
+.names ng739 ng13156 [29932] [29976] [30066]
+1111 1
+.names pg35 ng13156 [29932] [29976] [30067]
+0111 1
+.names ng199 ng13156 [29957] [29980] [30068]
+1111 1
+.names ng599 ng13156 [29957] [29978] [30069]
+1111 1
+.names pg35 ng13156 [29957] [29978] [30070]
+0111 1
+.names pg35 ng13156 [29963] [29982] [30071]
+0111 1
+.names ng4245 ni17529 [7486] [29997] [30072]
+--1- 1
+11-1 1
+.names [7485] [7487] [30072] [30074]
+1-- 1
+-1- 1
+--1 1
+.names [29984] [29985] [30064] [30065] [30076]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [30066] [30067] [30077]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [30068] [30069] [30078]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [30070] [30071] [30079]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [30078] [30077] [30081]
+1- 1
+-1 1
+.names [7475] [30074] [30076] [30079] [30082]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng2886 ng13156 [29937] [29939] [30084]
+1111 1
+.names pg92 ng13156 [29932] [29934] [30085]
+1111 1
+.names ng2970 ng14988 [29928] [29936] [30086]
+1111 1
+.names pg127 ng13156 [29937] [29941] [30087]
+1111 1
+.names ng2980 ng14988 [29942] [29944] [30088]
+1111 1
+.names ng2975 ng14988 [29942] [29946] [30089]
+1111 1
+.names [7472] [7473] [7474] [30091]
+1-- 1
+-1- 1
+--1 1
+.names [7466] [7471] [30091] [30095]
+1-- 1
+-1- 1
+--1 1
+.names [7467] [7468] [7469] [7470] [30096]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng785 ng13156 [29937] [29974] [30097]
+1111 1
+.names pg35 ng13156 [29937] [29974] [30098]
+0111 1
+.names ng744 ng13156 [29932] [29976] [30099]
+1111 1
+.names pg35 ng13156 [29932] [29976] [30100]
+0111 1
+.names ng568 ng13156 [29963] [29982] [30101]
+1111 1
+.names ng604 ng13156 [29957] [29978] [30102]
+1111 1
+.names pg35 ng13156 [29957] [29978] [30103]
+0111 1
+.names ng136 ng13156 [29957] [29980] [30104]
+1111 1
+.names pg35 ng13156 [29963] [29982] [30105]
+0111 1
+.names ng4249 ni17529 [7462] [29997] [30106]
+--1- 1
+11-1 1
+.names [7463] [7464] [30106] [30108]
+1-- 1
+-1- 1
+--1 1
+.names [29984] [29985] [30098] [30099] [30110]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [30100] [30101] [30111]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [30102] [30103] [30112]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [30104] [30105] [30113]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [30112] [30111] [30115]
+1- 1
+-1 1
+.names [7452] [30108] [30110] [30113] [30116]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng807 ng13156 [29937] [29974] [30118]
+1111 1
+.names pg35 ng13156 [29937] [29974] [30119]
+0111 1
+.names ng763 ng13156 [29932] [29976] [30120]
+1111 1
+.names pg35 ng13156 [29932] [29976] [30121]
+0111 1
+.names ng542 ng13156 [29957] [29980] [30122]
+1111 1
+.names ng617 ng13156 [29957] [29978] [30123]
+1111 1
+.names pg35 ng13156 [29957] [29978] [30124]
+0111 1
+.names ng577 ng13156 [29963] [29982] [30125]
+1111 1
+.names pg35 ng13156 [29963] [29982] [30126]
+0111 1
+.names ni18740 ng10948 [7424] [30003] [30127]
+--1- 1
+11-1 1
+.names ni17529 ng10878 [30000] [30127] [30128]
+---1 1
+111- 1
+.names [29984] [29985] [30119] [30120] [30130]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [30121] [30122] [30131]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [30123] [30124] [30132]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [30125] [30126] [30133]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [30132] [30131] [30135]
+1- 1
+-1 1
+.names [7414] [30128] [30130] [30133] [30136]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng2936 ng14988 [29928] [29936] [30137]
+1111 1
+.names ng2894 ng13156 [29957] [29959] [30138]
+1111 1
+.names ng2988 ng13156 [29937] [29941] [30139]
+1111 1
+.names ng2898 ng13156 [29937] [29939] [30140]
+1111 1
+.names ng2941 ng14988 [29942] [29946] [30141]
+1111 1
+.names [7409] [7410] [7411] [7412] [30144]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng31070 [30138] [30139] [30146]
+11- 1
+1-1 1
+.names ng31070 [30140] [30141] [30147]
+11- 1
+1-1 1
+.names ng31070 ng16486 [30137] [30144] [30148]
+---1 1
+11-- 1
+1-1- 1
+.names [30146] [30147] [30148] [30150]
+1-- 1
+-1- 1
+--1 1
+.names ng2860 ng13156 [29957] [29959] [30151]
+1111 1
+.names ng2864 ng13156 [29937] [29939] [30152]
+1111 1
+.names ng2922 ng14988 [29928] [29936] [30153]
+1111 1
+.names ng2994 ng13156 [29937] [29941] [30154]
+0111 1
+.names ng2927 ng14988 [29942] [29946] [30155]
+1111 1
+.names [7445] [7446] [7447] [30157]
+1-- 1
+-1- 1
+--1 1
+.names ng31070 [30151] [30157] [30158]
+--1 1
+11- 1
+.names ng31070 [30152] [30153] [30159]
+11- 1
+1-1 1
+.names ng31070 [30154] [30155] [30160]
+11- 1
+1-1 1
+.names ng554 ng13156 [29937] [29974] [30162]
+1111 1
+.names pg35 ng13156 [29937] [29974] [30163]
+0111 1
+.names ng767 ng13156 [29932] [29976] [30164]
+1111 1
+.names pg35 ng13156 [29932] [29976] [30165]
+0111 1
+.names ng622 ng13156 [29957] [29978] [30166]
+1111 1
+.names pg35 ng13156 [29957] [29978] [30167]
+0111 1
+.names ng582 ng13156 [29963] [29982] [30168]
+1111 1
+.names ng546 ng13156 [29957] [29980] [30169]
+1111 1
+.names pg35 ng13156 [29963] [29982] [30170]
+0111 1
+.names ni17529 ng10890 [7436] [30000] [30171]
+--1- 1
+11-1 1
+.names [7437] [7438] [30171] [30173]
+1-- 1
+-1- 1
+--1 1
+.names [29984] [29985] [30163] [30164] [30175]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [30165] [30166] [30176]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [30167] [30168] [30177]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [30169] [30170] [30178]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [30177] [30176] [30180]
+1- 1
+-1 1
+.names [7426] [30173] [30175] [30178] [30181]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [30176] [30177] [30181] [30182]
+1-- 1
+-1- 1
+--1 1
+.names ng2917 ng14988 [29942] [29946] [30183]
+1111 1
+.names ng772 ng13156 [29932] [29976] [30184]
+1111 1
+.names pg35 ng13156 [29932] [29976] [30185]
+0111 1
+.names ng2852 ng13156 [29957] [29959] [30186]
+1111 1
+.names ng2912 ng14988 [29928] [29936] [30187]
+1111 1
+.names ng2856 ng13156 [29937] [29939] [30188]
+1111 1
+.names ng2999 ng13156 [29937] [29941] [30189]
+1111 1
+.names ng590 pg35 [30190]
+01 1
+.names pg35 ng626 ng590 [7378] [30193]
+---1 1
+100- 1
+.names pg35 ng626 ng17766 ng17747 [30194]
+--00 1
+100- 1
+.names ng3502 ni18785 [7372] [29966] [30195]
+--1- 1
+11-1 1
+.names [7373] [7374] [7375] [7376] [30199]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [29984] [29985] [30184] [30185] [30201]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [7371] [7377] [30195] [30199] [30202]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng31070 [30183] [30186] [30203]
+11- 1
+1-1 1
+.names ng31070 [30187] [30188] [30204]
+11- 1
+1-1 1
+.names ng31070 [30189] [30201] [30205]
+--1 1
+11- 1
+.names ng2848 ng13156 [29937] [29939] [30208]
+1111 1
+.names ng2844 ng13156 [29957] [29959] [30209]
+1111 1
+.names ng2907 ng14988 [29928] [29936] [30210]
+1111 1
+.names ng2902 ng14988 [29942] [29946] [30211]
+1111 1
+.names [7398] [7399] [7400] [30213]
+1-- 1
+-1- 1
+--1 1
+.names ng31070 [30209] [30210] [30215]
+11- 1
+1-1 1
+.names ng31070 [30208] [30211] [30213] [30216]
+---1 1
+11-- 1
+1-1- 1
+.names ng776 ng13156 [29932] [29976] [30217]
+1111 1
+.names pg35 ng13156 [29932] [29976] [30218]
+0111 1
+.names ng632 ng13156 [29957] [29978] [30219]
+1111 1
+.names ng595 ng13156 [29963] [29982] [30220]
+1111 1
+.names ng538 ng13156 [29957] [29980] [30221]
+1111 1
+.names pg35 ng13156 [29957] [29978] [30222]
+0111 1
+.names pg35 ng13156 [29963] [29982] [30223]
+0111 1
+.names ng10925 ni17529 [7391] [30000] [30224]
+--1- 1
+11-1 1
+.names [7390] [7392] [30224] [30226]
+1-- 1
+-1- 1
+--1 1
+.names [29984] [29985] [30218] [30219] [30228]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [30220] [30221] [30229]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [29984] [29985] [30222] [30223] [30230]
+1-1- 1
+-11- 1
+1--1 1
+-1-1 1
+.names [7382] [30226] [30228] [30231]
+1-- 1
+-1- 1
+--1 1
+.names [30230] [30229] [30232]
+1- 1
+-1 1
+.names pg56 pg54 pg35 pg53 [30236]
+0010 1
+.names pg35 ng2984 ng2980 [30237]
+11- 1
+0-1 1
+.names ng1351 ng1312 [30238]
+1- 1
+-1 1
+.names pg35 pg17320 pg17423 pg17404 [30241]
+1000 1
+.names pg35 pg17320 pg17423 pg17404 [30245]
+1000 1
+.names ng2287 ng2361 [30249]
+0- 1
+-0 1
+.names pg35 ng17405 ng26737 [30249] [30250]
+11-0 1
+1-10 1
+.names ng2307 pg35 [30251]
+11 1
+.names pg35 ng3703 ng3639 ng3698 [30254]
+1100 1
+.names ng4975 ng4899 ng11283 [30254] [30255]
+1011 1
+.names pg35 ng3703 ng3694 ng3639 [30257]
+1000 1
+.names ng4975 ng4899 ng11283 [30257] [30258]
+1011 1
+.names pg35 ng3703 ng3639 ng3698 [30260]
+1111 1
+.names ng4975 ng4899 ng11283 [30260] [30261]
+1011 1
+.names pg35 ng3703 ng3694 ng3639 [30263]
+1011 1
+.names ng4975 ng4899 ng11283 [30263] [30264]
+1011 1
+.names ng4950 pg35 [30265]
+11 1
+.names ng21024 [6373] [30258] [30267]
+-1- 1
+1-1 1
+.names pg35 ng4950 ng21024 [30264] [30268]
+--11 1
+110- 1
+.names ng23309 [30255] [30261] [30269]
+01- 1
+0-1 1
+.names pg35 ng4284 ng4180 [30272]
+11- 1
+1-0 1
+.names ng5216 pg35 [30273]
+11 1
+.names ng12443 ng12492 [6368] [30272] [30274]
+--1- 1
+11-1 1
+.names ng504 ng518 ng528 [30276]
+110 1
+.names ng1668 pg35 [30281]
+11 1
+.names ng504 ng518 ng528 [30283]
+000 1
+.names ng26673 ng17292 [6362] [30281] [30286]
+--1- 1
+00-1 1
+.names pg35 ng827 ng14279 [30293]
+100 1
+.names pg35 ng827 ng14279 [30295]
+110 1
+.names ng1312 ng1274 ng1351 ng1536 [30300]
+-1-0 1
+010- 1
+.names ng2193 pg35 [30301]
+01 1
+.names pg35 ng2799 ng121 ng12377 [30304]
+0-1- 1
+11-0 1
+.names pg35 ng1926 ng1882 ng1894 [30307]
+1010 1
+.names pg35 ng1917 ng1894 ng1886 [30310]
+1011 1
+.names pg35 ng1870 ng1917 ng1894 [30312]
+1110 1
+.names ng1926 ng1878 ng1917 [30313]
+110 1
+.names ng1917 ng1926 [30314]
+0- 1
+-1 1
+.names ng1890 pg35 [30315]
+11 1
+.names ng1945 pg35 [30316]
+11 1
+.names ng1874 ng25429 ng25341 [30315] [30320]
+1-0- 1
+-0-1 1
+.names [6330] [6331] [6332] [6336] [30321]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 pg11678 ng776 ng736 [30324]
+101- 1
+1-11 1
+.names ng776 pg35 [30325]
+01 1
+.names pg9048 ng599 ng559 [30327]
+-0- 1
+1-0 1
+.names pg9048 ng604 ng559 [30328]
+01- 1
+-11 1
+.names pg9048 ng559 ng608 [30329]
+--0 1
+10- 1
+.names pg9048 ng559 ng613 [30330]
+0-1 1
+-11 1
+.names pg9048 ng559 ng617 [30331]
+--0 1
+10- 1
+.names pg9048 ng559 ng622 [30332]
+0-1 1
+-11 1
+.names pg35 pg9048 ng626 ng559 [30334]
+101- 1
+1-11 1
+.names ng626 pg35 [30335]
+01 1
+.names ng4340 pg35 [30337]
+01 1
+.names pg35 ng65 ng29503 ng27972 [30339]
+111- 1
+11-1 1
+.names pg35 ng4340 ng31971 [30339] [30341]
+--11 1
+110- 1
+.names ng2715 ng2719 ng2787 [30342]
+110 1
+.names ng2060 ng2051 [30343]
+1- 1
+-0 1
+.names ng2040 pg35 [30344]
+01 1
+.names pg35 ng2036 ng1996 ng25470 [30348]
+11-1 1
+1-10 1
+.names ng2028 ng2060 [30349]
+0- 1
+-0 1
+.names ng504 ng518 ng528 [30356]
+101 1
+.names pg35 ng2361 ng112 ng2331 [30359]
+1100 1
+.names pg35 ng2361 ng112 ng2331 [30361]
+101- 1
+1-11 1
+.names ng2338 pg35 [30362]
+11 1
+.names ng4349 ng4358 ng24380 [29233] [30365]
+0001 1
+.names ng6741 pg35 [30367]
+01 1
+.names ng6741 pg35 [30369]
+11 1
+.names pg35 ng6500 ng6505 [30372]
+101 1
+.names ng6505 ng6500 [30373]
+01 1
+.names pg35 ng6509 ng23733 [30373] [30375]
+--01 1
+111- 1
+.names ng504 ng518 ng528 [30377]
+010 1
+.names pg35 ng4284 ng4180 [30382]
+11- 1
+1-0 1
+.names ng5563 pg35 [30383]
+11 1
+.names ng12505 ng12558 [6293] [30382] [30384]
+--1- 1
+11-1 1
+.names ng4474 ng4477 [30386]
+0- 1
+-1 1
+.names pg35 ng4459 ng4369 [30388]
+11- 1
+0-1 1
+.names ng2465 ng2421 [30390]
+0- 1
+-1 1
+.names pg35 ng26770 ng17424 [30390] [30391]
+11-0 1
+1-10 1
+.names ng2445 pg35 [30392]
+11 1
+.names ng2407 pg35 [30394]
+01 1
+.names ng2407 pg35 [30395]
+11 1
+.names pg35 ng1624 ng1657 ng1612 [30399]
+1001 1
+.names pg35 ng1624 ng1616 ng1648 [30402]
+1110 1
+.names pg35 ng1624 ng1648 ng1600 [30404]
+1011 1
+.names ng1620 pg35 [30405]
+11 1
+.names ng1608 ng1657 ng1648 [30406]
+110 1
+.names ng1677 pg35 [30407]
+11 1
+.names ng1604 ng25275 ng25337 [30405] [30411]
+10-- 1
+--01 1
+.names [6269] [6270] [6271] [6276] [30412]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng2595 pg35 [30417]
+01 1
+.names pg35 ng2827 ng2823 ng12377 [30420]
+0-1- 1
+11-0 1
+.names ng1339 pg35 [30421]
+11 1
+.names ng1306 pg35 [30422]
+11 1
+.names pg35 ng4284 ng4180 [30427]
+11- 1
+1-0 1
+.names ng3219 pg35 [30428]
+11 1
+.names pg35 ng4284 ng4180 [30430]
+11- 1
+1-0 1
+.names ng6597 pg35 [30431]
+11 1
+.names pg35 ng4284 ng4180 [30433]
+11- 1
+1-0 1
+.names ng5913 pg35 [30434]
+11 1
+.names pg35 ng4284 ng4180 [30436]
+11- 1
+1-0 1
+.names ng3259 pg35 [30437]
+11 1
+.names pg35 ng2495 ng112 ng2465 [30441]
+1100 1
+.names pg35 ng2495 ng112 ng2465 [30443]
+101- 1
+1-11 1
+.names ng2472 pg35 [30444]
+11 1
+.names pg35 ng4284 ng4180 [30447]
+11- 1
+1-0 1
+.names ng3195 pg35 [30448]
+11 1
+.names pg35 pg8342 pg8279 ng3451 [30453]
+0--1 1
+1010 1
+.names pg35 ng4284 ng4180 [30457]
+11- 1
+1-0 1
+.names ng3211 pg35 [30458]
+11 1
+.names pg35 ng4284 ng4180 [30464]
+11- 1
+1-0 1
+.names ng3191 pg35 [30465]
+11 1
+.names ng11514 ng11729 [6217] [30464] [30466]
+--1- 1
+11-1 1
+.names ng2453 ng2485 [30467]
+0- 1
+-0 1
+.names pg35 ng4284 ng4180 [30471]
+11- 1
+1-0 1
+.names ng3243 pg35 [30472]
+11 1
+.names pg35 ng4284 ng4180 [30474]
+11- 1
+1-0 1
+.names ng5204 pg35 [30475]
+11 1
+.names ng1906 ng1862 [30477]
+0- 1
+-1 1
+.names ng1936 pg35 [30478]
+01 1
+.names ng26725 ng17401 ng28789 [30478] [30480]
+1-01 1
+-101 1
+.names pg35 pg7916 ng1178 ng1183 [30484]
+0--1 1
+101- 1
+.names pg35 ng3530 ng3518 ng3522 [30487]
+1011 1
+.names pg35 ng3530 ng3518 ng3522 [30488]
+110- 1
+11-0 1
+.names ng4975 ng4899 ng4878 [30497]
+110 1
+.names pg35 ng4927 ng4991 ng4864 [30498]
+1000 1
+.names ng4966 ng4871 ng4836 ng4983 [30499]
+0000 1
+.names pg35 ng4975 ng4899 ng4991 [30505]
+1100 1
+.names ng4864 ng4966 ng4871 ng4836 [30506]
+0000 1
+.names pg35 ng4975 ng4899 ng4991 [30512]
+1010 1
+.names ng4864 ng4966 ng4871 ng4836 [30513]
+0000 1
+.names ng4975 ng4899 ng4955 ng4933 [30515]
+111- 1
+10-1 1
+.names ng4888 ng4975 ng4899 ng4944 [30516]
+100- 1
+-011 1
+.names ng4975 ng4899 ng4907 ng4917 [30517]
+101- 1
+11-1 1
+.names ng4922 ng4975 ng4899 ng4912 [30518]
+101- 1
+-001 1
+.names pg35 ng4864 ng4878 [30521]
+100 1
+.names ng4871 ng4836 ng11173 [30521] [30523]
+0001 1
+.names pg35 ng4864 ng4878 [30527]
+100 1
+.names ng4871 ng4836 ng11173 [30527] [30529]
+0001 1
+.names pg35 ng4864 ng4878 [30534]
+100 1
+.names ng4966 ng4871 ng4836 ng4983 [30535]
+0001 1
+.names pg35 ng4864 ng4878 [30539]
+100 1
+.names [6180] [6181] [6182] [6183] [30547]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [6178] [30547] [30550]
+1- 1
+-1 1
+.names [6173] [6174] [6175] [6179] [30551]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng16696 ng16757 [30523] [30529] [30552]
+101- 1
+01-1 1
+.names ng2715 ng2803 ng2719 [30555]
+000 1
+.names ng2217 ng2185 [30557]
+0- 1
+-0 1
+.names pg35 ng6181 ng6187 [30562]
+100 1
+.names ng6191 pg35 [30564]
+11 1
+.names ng6181 ng6187 ng10874 [30564] [30566]
+--01 1
+111- 1
+.names pg35 ng4284 ng4180 [30567]
+11- 1
+1-0 1
+.names ng6307 pg35 [30568]
+11 1
+.names ng4639 pg35 [30570]
+01 1
+.names pg35 ng5037 ng17217 ng14317 [30572]
+1111 1
+.names ng5037 pg35 [30573]
+01 1
+.names ng17217 ng14317 [6160] [30573] [30574]
+--1- 1
+0--1 1
+-0-1 1
+.names pg35 ng4284 ng4180 [30575]
+11- 1
+1-0 1
+.names ng6279 pg35 [30576]
+11 1
+.names ng93 ng4349 ng4358 ng29503 [30578]
+1001 1
+.names pg35 ng5297 ng23890 [30581]
+100 1
+.names pg35 ng5297 ng23890 [30583]
+111 1
+.names ng232 pg35 [30585]
+11 1
+.names pg14217 pg35 [30586]
+11 1
+.names ng1472 ng1467 [30592]
+01 1
+.names ng1472 pg35 [30593]
+11 1
+.names pg35 ng1467 ng1472 [30595]
+01- 1
+101 1
+.names ng13315 ng10961 [30592] [30595] [30596]
+---1 1
+001- 1
+.names pg35 ng5990 ng6049 ng6040 [30598]
+1000 1
+.names ng4785 ng4709 ng11261 [30598] [30599]
+1011 1
+.names pg35 ng6044 ng5990 ng6049 [30601]
+1111 1
+.names ng4785 ng4709 ng11261 [30601] [30602]
+1011 1
+.names pg35 ng5990 ng6049 ng6040 [30604]
+1101 1
+.names ng4785 ng4709 ng11261 [30604] [30605]
+1011 1
+.names pg35 ng6044 ng5990 ng6049 [30607]
+1001 1
+.names ng4785 ng4709 ng11261 [30607] [30608]
+1011 1
+.names ng4760 pg35 [30609]
+11 1
+.names ng20875 [6133] [30599] [30611]
+-1- 1
+1-1 1
+.names pg35 ng4760 ng20875 [30605] [30612]
+--11 1
+110- 1
+.names ng23932 [30602] [30608] [30613]
+01- 1
+0-1 1
+.names ng504 ng518 ng528 [30616]
+001 1
+.names pg35 ng2197 ng2227 ng112 [30619]
+1010 1
+.names pg35 ng2197 ng2227 ng112 [30621]
+11-1 1
+1-01 1
+.names ng2204 pg35 [30622]
+11 1
+.names pg17778 ng6741 ng6682 ng6629 [30628]
+1111 1
+.names ng6727 pg17764 [30629]
+11 1
+.names ng6741 ng6682 ng6641 [30630]
+111 1
+.names ng6727 pg17871 [30631]
+01 1
+.names ng6741 ng6682 ng6617 [30632]
+111 1
+.names pg17688 ng6741 ng6682 ng6645 [30634]
+1001 1
+.names ng6581 pg13099 [30635]
+11 1
+.names ng6741 ng6682 ng6727 [30636]
+001 1
+.names ng6589 ng6727 [30637]
+11 1
+.names ng6741 ng6682 ng6723 [30638]
+001 1
+.names ng6727 pg14749 [30639]
+11 1
+.names ng6741 ng6682 ng6625 [30640]
+011 1
+.names pg14828 ng6613 ng6741 ng6682 [30642]
+1101 1
+.names ng6593 pg13099 [30643]
+11 1
+.names ng6741 ng6682 ng6727 [30644]
+010 1
+.names ng6597 pg17722 [30645]
+11 1
+.names ng6741 ng6682 ng6727 [30646]
+100 1
+.names ng6727 pg12470 [30647]
+11 1
+.names ng6741 ng6682 ng6585 [30648]
+101 1
+.names ng6727 pg17871 [30649]
+11 1
+.names ng6741 ng6682 ng6609 [30650]
+101 1
+.names ng12471 [30628] [30629] [30630] [30651]
+01-- 1
+--11 1
+.names ng12471 [30631] [30632] [30634] [30652]
+-11- 1
+0--1 1
+.names [30635] [30636] [30637] [30638] [30653]
+11-- 1
+--11 1
+.names ng12471 [30639] [30640] [30642] [30654]
+-11- 1
+0--1 1
+.names [30643] [30644] [30645] [30646] [30655]
+11-- 1
+--11 1
+.names [30647] [30648] [30649] [30650] [30656]
+11-- 1
+--11 1
+.names [30656] [30655] [30659]
+1- 1
+-1 1
+.names [30651] [30652] [30653] [30654] [30660]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng6727 pg17722 [30661]
+11 1
+.names ng6741 ng6682 ng6657 [30662]
+111 1
+.names ng6727 pg12470 [30663]
+01 1
+.names ng6741 ng6682 ng6601 [30664]
+111 1
+.names ng6727 pg14749 [30665]
+01 1
+.names ng6741 ng6682 ng6633 [30666]
+001 1
+.names pg14828 ng6621 ng6741 ng6682 [30668]
+1100 1
+.names pg17688 ng6741 ng6653 ng6682 [30670]
+1011 1
+.names ng6727 ng6605 [30671]
+01 1
+.names ng6741 ng6682 ng6723 [30672]
+011 1
+.names pg17778 ng6741 ng6682 ng6637 [30674]
+1101 1
+.names ng6649 pg17764 [30675]
+11 1
+.names ng6741 ng6682 ng6727 [30676]
+100 1
+.names [30661] [30662] [30663] [30664] [30677]
+11-- 1
+--11 1
+.names ng12471 [30665] [30666] [30668] [30678]
+-11- 1
+1--1 1
+.names ng12471 [30670] [30671] [30672] [30679]
+11-- 1
+--11 1
+.names ng12471 [30674] [30675] [30676] [30680]
+11-- 1
+--11 1
+.names [30677] [30678] [30679] [30680] [30683]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng6500 ng20751 ng11178 [30685]
+1110 1
+.names pg35 ng6500 ng20751 ng11178 [30687]
+101- 1
+1-11 1
+.names ng6500 pg35 [30688]
+11 1
+.names ng2715 ng2724 ng2719 [30692]
+101 1
+.names ng2715 ng2724 ng2719 [30694]
+01- 1
+-10 1
+.names pg35 ng2841 ng2719 [30692] [30695]
+0-1- 1
+11-1 1
+.names pg35 ng1644 ng2047 [30696]
+11- 1
+1-1 1
+.names pg35 ng2066 ng1932 [30697]
+11- 1
+1-1 1
+.names pg35 ng1913 ng1664 [30698]
+11- 1
+1-1 1
+.names pg35 ng1779 ng1798 [30699]
+11- 1
+1-1 1
+.names pg35 ng2223 ng2357 [30702]
+11- 1
+1-1 1
+.names pg35 ng2491 ng2625 [30703]
+11- 1
+1-1 1
+.names pg35 ng2472 ng2606 [30704]
+11- 1
+1-1 1
+.names pg35 ng2338 ng2204 [30705]
+11- 1
+1-1 1
+.names pg35 ng2898 ng2882 [30708]
+01- 1
+1-1 1
+.names ng2541 pg35 [30709]
+01 1
+.names ng2541 pg35 [30710]
+11 1
+.names pg35 ng4284 ng4180 [30712]
+11- 1
+1-0 1
+.names ng6653 pg35 [30713]
+11 1
+.names pg35 ng6741 ng6736 ng6682 [30716]
+1111 1
+.names ng4975 ng4899 ng11283 [30716] [30717]
+1111 1
+.names pg35 ng6741 ng6682 ng6732 [30719]
+1000 1
+.names ng4975 ng4899 ng11283 [30719] [30720]
+1111 1
+.names pg35 ng6741 ng6682 ng6732 [30722]
+1011 1
+.names ng4975 ng4899 ng11283 [30722] [30723]
+1111 1
+.names pg35 ng6741 ng6736 ng6682 [30725]
+1100 1
+.names ng4975 ng4899 ng11283 [30725] [30726]
+1111 1
+.names ng4894 pg35 [30728]
+11 1
+.names ng20751 [6064] [30720] [30729]
+-1- 1
+1-1 1
+.names pg35 ng4894 ng20751 [30723] [30730]
+--11 1
+110- 1
+.names ng23972 [30717] [30726] [30731]
+01- 1
+0-1 1
+.names ng2476 pg35 [30733]
+11 1
+.names pg35 ng14367 [7725] [28488] [30734]
+1-1- 1
+11-1 1
+.names ng2453 pg35 [30735]
+11 1
+.names ng27903 [6057] [30734] [30737]
+-1- 1
+0-1 1
+.names pg35 ng2841 ng2724 [30740]
+10- 1
+0-1 1
+.names ng930 pg35 [30742]
+01 1
+.names pg35 pg12919 ng930 [30743]
+111 1
+.names pg35 ng6682 ng23972 [30746]
+100 1
+.names pg35 ng6682 ng23972 [30748]
+111 1
+.names ng4899 pg35 [30750]
+01 1
+.names ng4899 pg35 [30752]
+11 1
+.names ng16187 ng28349 [6042] [30750] [30754]
+--1- 1
+01-1 1
+.names pg35 pg9048 ng604 ng559 [30759]
+101- 1
+1-11 1
+.names ng604 pg35 [30760]
+01 1
+.names pg35 ng1811 ng14640 [30763]
+110 1
+.names pg35 ng1811 ng14640 [30765]
+101 1
+.names pg35 ng1825 ng22369 [30765] [30768]
+--11 1
+110- 1
+.names ng4392 pg35 [30769]
+11 1
+.names ng4392 ng4417 [30770]
+00 1
+.names ng504 ng499 [30776]
+01 1
+.names ng718 ng655 ng650 ng699 [30782]
+0001 1
+.names ng661 ng728 ng681 ng645 [30783]
+0010 1
+.names ng718 ng655 ng650 ng699 [30788]
+0001 1
+.names ng661 ng728 ng681 ng645 [30789]
+1110 1
+.names ng718 ng655 ng650 ng699 [30794]
+1101 1
+.names ng661 ng728 ng681 ng645 [30795]
+0010 1
+.names ng718 ng655 ng650 ng699 [30800]
+1101 1
+.names ng661 ng728 ng681 ng645 [30801]
+1110 1
+.names [30782] [30783] [30788] [30789] [30802]
+11-- 1
+--11 1
+.names [30794] [30795] [30800] [30801] [30803]
+11-- 1
+--11 1
+.names pg35 ng714 ng676 ng20375 [30805]
+1011 1
+.names pg35 ng714 ng676 ng20375 [30807]
+110- 1
+11-0 1
+.names ng79 pg35 [30809]
+11 1
+.names ng728 pg35 [30810]
+11 1
+.names ng661 pg35 [30811]
+11 1
+.names pg17711 ng5703 ng5644 ng5591 [30817]
+1111 1
+.names pg17580 ng5703 ng5644 ng5607 [30819]
+1001 1
+.names pg14694 ng5703 ng5575 ng5644 [30821]
+1011 1
+.names ng5703 ng5644 ng5547 [30823]
+101 1
+.names ng5689 pg17604 [30824]
+01 1
+.names ng5703 ng5644 ng5559 [30825]
+101 1
+.names ng5689 pg17813 [30826]
+11 1
+.names ng5703 ng5571 ng5644 [30827]
+110 1
+.names ng5685 ng5689 [30828]
+11 1
+.names ng5703 ng5551 ng5644 [30829]
+010 1
+.names ng5689 pg13049 [30830]
+11 1
+.names ng5703 ng5543 ng5644 [30831]
+010 1
+.names ng5689 pg14635 [30832]
+11 1
+.names ng5703 ng5644 ng5587 [30833]
+011 1
+.names ng5689 pg13049 [30834]
+01 1
+.names ng5703 ng5555 ng5644 [30835]
+011 1
+.names ng5689 pg17678 [30836]
+11 1
+.names ng5703 ng5603 ng5644 [30837]
+111 1
+.names ng5689 pg17813 [30838]
+01 1
+.names ng5703 ng5579 ng5644 [30839]
+111 1
+.names pg12300 ng5689 [30817] [30819] [30840]
+111- 1
+001- 1
+11-1 1
+00-1 1
+.names pg12300 ng5689 [30821] [30823] [30841]
+111- 1
+001- 1
+11-1 1
+.names [30824] [30825] [30826] [30827] [30842]
+11-- 1
+--11 1
+.names [30828] [30829] [30830] [30831] [30843]
+11-- 1
+--11 1
+.names [30832] [30833] [30834] [30835] [30844]
+11-- 1
+--11 1
+.names [30836] [30837] [30838] [30839] [30845]
+11-- 1
+--11 1
+.names [30845] [30844] [30848]
+1- 1
+-1 1
+.names [30840] [30841] [30842] [30843] [30849]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg17711 ng5599 ng5703 ng5644 [30851]
+1110 1
+.names pg17580 ng5703 ng5644 ng5615 [30853]
+1011 1
+.names pg14694 ng5583 ng5703 ng5644 [30855]
+1100 1
+.names ng5689 pg17678 [30856]
+01 1
+.names ng5703 ng5644 ng5611 [30857]
+101 1
+.names ng5689 pg14635 [30858]
+01 1
+.names ng5703 ng5644 ng5595 [30859]
+001 1
+.names ng5685 ng5689 [30860]
+10 1
+.names ng5703 ng5567 ng5644 [30861]
+011 1
+.names ng5689 pg17604 [30862]
+11 1
+.names ng5703 ng5619 ng5644 [30863]
+111 1
+.names ng5689 pg12300 [30864]
+01 1
+.names ng5703 ng5563 ng5644 [30865]
+111 1
+.names pg12300 ng5689 [30851] [30853] [30866]
+011- 1
+101- 1
+01-1 1
+10-1 1
+.names ng12301 [30855] [30856] [30857] [30867]
+11-- 1
+--11 1
+.names [30858] [30859] [30860] [30861] [30868]
+11-- 1
+--11 1
+.names [30862] [30863] [30864] [30865] [30869]
+11-- 1
+--11 1
+.names [30866] [30867] [30868] [30869] [30872]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng5462 ng20739 ng11123 [30874]
+101- 1
+1-11 1
+.names pg35 ng5462 ng20739 ng11123 [30876]
+1110 1
+.names ng5462 pg35 [30877]
+11 1
+.names pg35 ng5062 ng5046 [29546] [30880]
+10-- 1
+1-0- 1
+1--0 1
+.names ng1592 pg35 [30881]
+11 1
+.names ng2153 pg35 [30888]
+11 1
+.names pg35 ng1854 ng1848 [30893]
+100 1
+.names pg35 ng1854 ng1848 [30895]
+111 1
+.names pg35 ng1858 ng25300 [30895] [30898]
+--01 1
+111- 1
+.names pg35 ng4284 ng4180 [30899]
+11- 1
+1-0 1
+.names ng6581 pg35 [30900]
+11 1
+.names ng7142 ng12716 [5955] [30899] [30901]
+--1- 1
+11-1 1
+.names ng1906 pg35 [30902]
+01 1
+.names pg35 ng1862 ng1902 ng25429 [30906]
+1-11 1
+11-0 1
+.names pg35 ng2116 ng2122 [30908]
+100 1
+.names ng2126 pg35 [30910]
+11 1
+.names ng2116 ng2122 ng25389 [30910] [30912]
+--11 1
+110- 1
+.names pg35 pg9048 ng582 ng559 [30914]
+101- 1
+1-11 1
+.names ng582 pg35 [30915]
+01 1
+.names pg35 ng3841 ng3835 [30918]
+100 1
+.names pg35 ng3841 ng3835 [30920]
+111 1
+.names pg35 ng3845 ng12735 [30920] [30923]
+--11 1
+110- 1
+.names pg35 ng2016 ng2060 ng2028 [30926]
+1100 1
+.names pg35 ng2051 ng2020 ng2028 [30929]
+1011 1
+.names pg35 ng2004 ng2051 ng2028 [30931]
+1110 1
+.names ng2012 ng2051 ng2060 [30932]
+101 1
+.names ng2079 pg35 [30933]
+11 1
+.names ng2024 pg35 [30934]
+11 1
+.names ng2008 ng25470 ng25389 [30934] [30938]
+1-0- 1
+-0-1 1
+.names [5925] [5926] [5927] [5931] [30939]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng5343 pg17577 [30945]
+01 1
+.names ng5297 ng5357 ng5212 [30946]
+011 1
+.names pg17519 ng5297 ng5357 ng5260 [30948]
+1001 1
+.names ng5343 ng5204 [30949]
+11 1
+.names ng5297 ng5357 ng5339 [30950]
+001 1
+.names ng5343 pg13039 [30951]
+11 1
+.names ng5297 ng5357 ng5196 [30952]
+001 1
+.names pg14662 ng5297 ng5357 ng5228 [30954]
+1101 1
+.names pg17674 ng5244 ng5297 ng5357 [30956]
+1111 1
+.names ng5343 pg13039 [30957]
+01 1
+.names ng5297 ng5357 ng5208 [30958]
+101 1
+.names ng5240 pg14597 [30959]
+11 1
+.names ng5297 ng5357 ng5343 [30960]
+101 1
+.names ng5343 pg17787 [30961]
+11 1
+.names ng5297 ng5357 ng5224 [30962]
+011 1
+.names ng5200 pg12238 [30963]
+11 1
+.names ng5297 ng5357 ng5343 [30964]
+011 1
+.names ng5343 pg17787 [30965]
+01 1
+.names ng5297 ng5357 ng5232 [30966]
+111 1
+.names ng5256 pg17639 [30967]
+11 1
+.names ng5297 ng5357 ng5343 [30968]
+111 1
+.names ng12239 [30945] [30946] [30948] [30969]
+-11- 1
+0--1 1
+.names [30949] [30950] [30951] [30952] [30970]
+11-- 1
+--11 1
+.names pg12238 ng5343 [30954] [30956] [30971]
+111- 1
+001- 1
+11-1 1
+00-1 1
+.names [30957] [30958] [30959] [30960] [30972]
+11-- 1
+--11 1
+.names [30961] [30962] [30963] [30964] [30973]
+11-- 1
+--11 1
+.names [30965] [30966] [30967] [30968] [30974]
+11-- 1
+--11 1
+.names [30974] [30973] [30977]
+1- 1
+-1 1
+.names [30969] [30970] [30971] [30972] [30978]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg14662 ng5297 ng5357 ng5236 [30980]
+1001 1
+.names ng5248 pg14597 [30981]
+11 1
+.names ng5297 ng5357 ng5343 [30982]
+000 1
+.names pg17519 ng5297 ng5357 ng5268 [30984]
+1101 1
+.names pg17674 ng5297 ng5357 ng5252 [30986]
+1011 1
+.names ng5339 ng5343 [30987]
+10 1
+.names ng5297 ng5357 ng5220 [30988]
+101 1
+.names ng5343 pg17639 [30989]
+01 1
+.names ng5297 ng5357 ng5264 [30990]
+011 1
+.names ng5343 pg17577 [30991]
+11 1
+.names ng5297 ng5357 ng5272 [30992]
+111 1
+.names ng5216 pg12238 [30993]
+11 1
+.names ng5297 ng5357 ng5343 [30994]
+110 1
+.names ng12239 [30980] [30981] [30982] [30995]
+11-- 1
+--11 1
+.names pg12238 ng5343 [30984] [30986] [30996]
+011- 1
+101- 1
+01-1 1
+10-1 1
+.names [30987] [30988] [30989] [30990] [30997]
+11-- 1
+--11 1
+.names [30991] [30992] [30993] [30994] [30998]
+11-- 1
+--11 1
+.names [30995] [30996] [30997] [30998] [31001]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 [7624] [7625] [28651] [31002]
+11-- 1
+1-1- 1
+1--1 1
+.names ng128 pg35 [31003]
+11 1
+.names ng2715 ng2819 ng2719 [31005]
+101 1
+.names pg35 ng14367 [5887] [31005] [31007]
+1-1- 1
+11-1 1
+.names ng2610 pg35 [31008]
+11 1
+.names ng27933 [5884] [31007] [31010]
+-1- 1
+0-1 1
+.names pg35 ng3139 ng3133 [31015]
+100 1
+.names pg35 ng3139 ng3133 [31017]
+111 1
+.names pg35 ng3143 ng12641 [31017] [31020]
+--11 1
+110- 1
+.names pg35 ng14367 [7030] [29111] [31022]
+1-1- 1
+11-1 1
+.names ng2342 pg35 [31023]
+11 1
+.names ng27854 [5869] [31022] [31025]
+-1- 1
+0-1 1
+.names pg35 ng4284 ng4180 [31026]
+11- 1
+1-0 1
+.names ng3574 pg35 [31027]
+11 1
+.names pg35 ng2342 ng2351 [31030]
+100 1
+.names pg35 ng14367 [7030] [29111] [31031]
+1-1- 1
+11-1 1
+.names ng2319 pg35 [31033]
+11 1
+.names pg35 ng2319 ng2327 ng2351 [31034]
+0-1- 1
+11-0 1
+.names ng27854 [5859] [31031] [31036]
+-1- 1
+0-1 1
+.names pg35 pg9617 pg9680 ng5802 [31040]
+0--1 1
+1100 1
+.names ng1041 pg35 [31041]
+11 1
+.names ng13211 [5847] [5848] [31041] [31043]
+-1-- 1
+1--1 1
+--11 1
+.names pg35 ng4473 ng4467 ng4462 [31045]
+0--- 1
+---1 1
+-11- 1
+.names pg35 ng2599 ng112 ng2629 [31050]
+111- 1
+1-10 1
+.names pg35 ng2599 ng112 ng2629 [31052]
+1001 1
+.names ng2606 pg35 [31053]
+11 1
+.names ng262 pg35 [31056]
+11 1
+.names pg14096 pg35 [31057]
+11 1
+.names pg35 ng5808 ng5813 [31060]
+101 1
+.names ng5813 ng5808 [31061]
+01 1
+.names pg35 ng5817 ng23666 [31061] [31063]
+--01 1
+111- 1
+.names ng4950 pg35 [31064]
+11 1
+.names [1421] ng4818 ng24374 [31064] [31065]
+1--1 1
+-1-1 1
+--01 1
+.names pg35 ng71 ng24374 [28575] [31067]
+1110 1
+.names pg35 ng4944 ng29722 [31067] [31069]
+--11 1
+110- 1
+.names ng3827 pg35 [31070]
+11 1
+.names pg35 ng5297 ng5357 ng5348 [31073]
+1000 1
+.names ng4785 ng4709 ng11261 [31073] [31074]
+1111 1
+.names pg35 ng5297 ng5357 ng5348 [31076]
+1101 1
+.names ng4785 ng4709 ng11261 [31076] [31077]
+1111 1
+.names pg35 ng5297 ng5357 ng5352 [31079]
+1010 1
+.names ng4785 ng4709 ng11261 [31079] [31080]
+1111 1
+.names pg35 ng5297 ng5357 ng5352 [31082]
+1111 1
+.names ng4785 ng4709 ng11261 [31082] [31083]
+1111 1
+.names ng4704 pg35 [31084]
+11 1
+.names ng20682 [5819] [31074] [31086]
+-1- 1
+1-1 1
+.names pg35 ng4704 ng20682 [31077] [31087]
+--11 1
+110- 1
+.names ng23890 [31080] [31083] [31088]
+01- 1
+0-1 1
+.names ng336 pg35 [31090]
+11 1
+.names ng305 pg35 [31091]
+11 1
+.names ng2227 pg35 [31093]
+01 1
+.names ng26703 ng17321 ng28768 [31093] [31095]
+1-01 1
+-101 1
+.names pg35 ng3470 ng3476 [31098]
+100 1
+.names ng3480 pg35 [31100]
+11 1
+.names ng3470 ng3476 ng23112 [31100] [31102]
+--11 1
+110- 1
+.names pg35 ng4674 ng4681 ng4646 [31105]
+1000 1
+.names ng5357 pg35 [31107]
+01 1
+.names ng5357 pg35 [31109]
+11 1
+.names pg35 ng4284 ng4180 [31111]
+11- 1
+1-0 1
+.names ng3937 pg35 [31112]
+11 1
+.names pg35 ng4284 ng4180 [31114]
+11- 1
+1-0 1
+.names ng5949 pg35 [31115]
+11 1
+.names pg35 ng4284 ng4180 [31120]
+11- 1
+1-0 1
+.names ng6247 pg35 [31121]
+11 1
+.names ng12581 ng12667 [5788] [31120] [31122]
+--1- 1
+11-1 1
+.names pg35 pg12923 ng1259 [31123]
+111 1
+.names pg35 ng1256 ng1252 ng19140 [31124]
+1111 1
+.names pg35 ng4284 ng4180 [31126]
+11- 1
+1-0 1
+.names ng6589 pg35 [31127]
+11 1
+.names pg35 ng1936 ng1906 ng112 [31131]
+1100 1
+.names pg35 ng1936 ng1906 ng112 [31133]
+10-1 1
+1-11 1
+.names ng1913 pg35 [31134]
+11 1
+.names ng446 pg35 [31140]
+11 1
+.names ng182 pg35 [31141]
+11 1
+.names ng1592 ng1636 [31143]
+1- 1
+-0 1
+.names ng1668 pg35 [31144]
+01 1
+.names ng28739 ng26673 ng17292 [31144] [31146]
+01-1 1
+0-11 1
+.names pg35 ng2495 ng2509 ng2421 [31148]
+111- 1
+1-11 1
+.names ng26770 ng17424 [31148] [31149]
+1-1 1
+-11 1
+.names pg35 ng2495 ng2509 ng2421 [31150]
+1-0- 1
+10-0 1
+.names ng26770 ng17424 [31150] [31151]
+1-1 1
+-11 1
+.names ng2509 pg35 [31152]
+11 1
+.names ng26770 ng17424 [5759] [31152] [31153]
+--1- 1
+00-1 1
+.names pg35 ng4284 ng4180 [31155]
+11- 1
+1-0 1
+.names ng3921 pg35 [31156]
+11 1
+.names pg35 ng11915 ng17317 ng26694 [31158]
+111- 1
+11-1 1
+.names ng1756 pg35 [31159]
+11 1
+.names ng872 pg35 [31161]
+11 1
+.names ng446 pg35 [31162]
+11 1
+.names pg35 ng4349 ng12925 [31165]
+100 1
+.names pg35 ng4349 ng12925 [31167]
+111 1
+.names pg35 ng6159 ng6154 [31170]
+110 1
+.names ng6154 ng6159 [31171]
+10 1
+.names pg35 ng6163 ng23699 [31171] [31173]
+--01 1
+111- 1
+.names pg35 ng4284 ng4180 [31174]
+11- 1
+1-0 1
+.names ng5248 pg35 [31175]
+11 1
+.names ng4392 pg35 [31177]
+01 1
+.names [5727] [29520] [29521] [31177] [31178]
+1--- 1
+-111 1
+.names pg11447 pg8789 [31182]
+00 1
+.names pg35 pg8783 ng4180 [31183]
+100 1
+.names pg8784 pg8785 pg8787 pg8788 [31184]
+0000 1
+.names pg35 pg8786 ng2946 ng4180 [31189]
+0-1- 1
+10-1 1
+11-0 1
+.names ng2116 pg35 [31190]
+01 1
+.names ng2116 pg35 [31191]
+11 1
+.names pg35 ng2485 ng2476 ng2453 [31194]
+100- 1
+10-1 1
+.names ng2453 pg35 [31195]
+11 1
+.names pg35 ng14367 [7725] [28488] [31196]
+1-1- 1
+11-1 1
+.names ng27903 [5713] [31196] [31198]
+-1- 1
+0-1 1
+.names pg35 ng4284 ng4180 [31201]
+11- 1
+1-0 1
+.names ng3606 pg35 [31202]
+11 1
+.names ng843 ng837 [31204]
+01 1
+.names ng843 ng837 [31205]
+11 1
+.names ng847 ng8806 [5702] [31204] [31206]
+--1- 1
+10-1 1
+.names pg35 ng1036 ng15737 [31210]
+100 1
+.names ng1036 pg35 [31211]
+11 1
+.names ng4104 pg35 [31213]
+11 1
+.names ng4104 pg35 [31214]
+01 1
+.names pg35 ng2841 ng4108 [31215]
+10- 1
+0-1 1
+.names ng1706 pg35 [31217]
+11 1
+.names pg35 ng5523 ng5511 ng5517 [31220]
+1011 1
+.names pg35 ng1306 ng962 [31226]
+10- 1
+1-0 1
+.names pg35 ng17405 ng26737 ng11939 [31229]
+11-1 1
+1-11 1
+.names ng2315 pg35 [31230]
+11 1
+.names ng2619 ng2610 [31232]
+1- 1
+-0 1
+.names ng2555 pg35 [31233]
+11 1
+.names pg35 ng2599 ng2595 ng25498 [31237]
+1-11 1
+10-0 1
+.names ng2610 ng2652 ng2587 ng2638 [31240]
+-0-1 1
+1-01 1
+.names ng2652 pg35 [31241]
+11 1
+.names pg35 ng2638 ng22498 ng14752 [31242]
+01-- 1
+1011 1
+.names pg35 ng4284 ng4180 [31244]
+11- 1
+1-0 1
+.names ng6235 pg35 [31245]
+11 1
+.names ng10341 ng12667 [5661] [31244] [31246]
+--1- 1
+11-1 1
+.names ng1840 pg35 [31250]
+11 1
+.names pg35 ng822 ng723 ng847 [31254]
+1110 1
+.names ng703 pg35 [31255]
+11 1
+.names ng703 ng837 [31256]
+10 1
+.names ng14279 [5649] [31255] [31256] [31259]
+-1-- 1
+0-1- 1
+1--1 1
+.names pg35 ng2841 ng4098 ng4076 [31268]
+100- 1
+10-0 1
+.names [5641] [5642] [31268] [31271]
+1-- 1
+-1- 1
+--1 1
+.names ng1862 pg35 [31275]
+11 1
+.names ng1945 ng1959 ng1917 ng1894 [31281]
+10-- 1
+1-10 1
+.names ng1959 pg35 [31282]
+11 1
+.names pg35 ng1945 ng22417 ng14678 [31283]
+01-- 1
+1011 1
+.names pg35 ng2375 ng2361 ng2287 [31287]
+111- 1
+11-1 1
+.names ng17405 ng26737 [31287] [31288]
+1-1 1
+-11 1
+.names pg35 ng2375 ng2361 ng2287 [31289]
+10-- 1
+1-00 1
+.names ng17405 ng26737 [31289] [31290]
+1-1 1
+-11 1
+.names ng2375 pg35 [31291]
+11 1
+.names ng17405 ng26737 [5623] [31291] [31292]
+--1- 1
+00-1 1
+.names pg35 ng4991 ng4983 ng10862 [31295]
+1011 1
+.names pg35 ng4991 ng4983 ng10862 [31297]
+110- 1
+11-0 1
+.names ng28349 ng13486 [5619] [31295] [31298]
+--1- 1
+11-1 1
+.names pg35 ng2715 ng2771 [31301]
+100 1
+.names pg35 ng2715 ng2775 [31304]
+110 1
+.names pg35 ng2715 ng1677 [31308]
+101 1
+.names pg35 ng2715 ng1811 [31311]
+111 1
+.names ng2719 pg35 [31313]
+11 1
+.names pg35 ng2719 ng23618 [31316]
+110 1
+.names ng21277 ng23532 [31301] [31304] [31317]
+101- 1
+10-1 1
+.names ng21277 ng23618 [31308] [31311] [31318]
+001- 1
+00-1 1
+.names ng21277 ng23532 [31313] [31316] [31319]
+0--1 1
+101- 1
+.names pg35 pg11678 ng739 ng736 [31322]
+100- 1
+1-01 1
+.names pg35 pg11678 ng739 ng736 [31324]
+101- 1
+1-11 1
+.names ng5084 pg35 [31326]
+01 1
+.names ng5069 ng5077 ng5080 [31327]
+1-0 1
+-00 1
+.names pg35 ng5084 ng5080 [31328]
+0-1 1
+-11 1
+.names ng4785 pg35 [31332]
+11 1
+.names ng28336 ng13464 [5595] [31332] [31333]
+--1- 1
+11-1 1
+.names ng1902 pg35 [31334]
+01 1
+.names pg35 ng2791 ng2779 ng12377 [31337]
+0-1- 1
+11-0 1
+.names pg35 ng4284 ng4180 [31338]
+11- 1
+1-0 1
+.names ng6609 pg35 [31339]
+11 1
+.names pg35 ng2093 ng2089 [31342]
+101 1
+.names ng2098 pg35 [31344]
+11 1
+.names ng2093 ng2089 ng25492 [31344] [31346]
+--11 1
+100- 1
+.names pg35 ng4284 ng4180 [31347]
+11- 1
+1-0 1
+.names ng3546 pg35 [31348]
+11 1
+.names pg35 ng2185 ng2217 ng2208 [31351]
+110- 1
+1-00 1
+.names pg35 ng14367 [6172] [30555] [31353]
+1-1- 1
+11-1 1
+.names ng2185 pg35 [31354]
+11 1
+.names ng27796 [5576] [31353] [31356]
+-1- 1
+0-1 1
+.names ng29503 ng14367 [7725] [28488] [31357]
+1-1- 1
+11-1 1
+.names pg35 ng2485 ng110 ng2476 [31359]
+101- 1
+1-11 1
+.names pg35 ng2485 ng110 ng2476 [31361]
+1100 1
+.names ng2491 pg35 [31362]
+11 1
+.names ng26218 [5573] [31357] [31359] [31363]
+-1-- 1
+1-11 1
+.names ng26218 [31357] [31361] [31362] [31364]
+0--1 1
+-0-1 1
+111- 1
+.names pg35 ng1322 ng1351 ng1333 [31366]
+110- 1
+1-01 1
+.names ng1345 ng1367 ng1379 [31366] [31367]
+1111 1
+.names ng1389 pg35 [31368]
+01 1
+.names ng1361 ng1351 ng1373 [31369]
+111 1
+.names pg35 ng1322 ng1333 ng1339 [31372]
+11-1 1
+1010 1
+.names ng1312 pg35 [31373]
+11 1
+.names ng13242 [31368] [31369] [31373] [31374]
+1--1 1
+011- 1
+.names ng1124 ng1129 [31377]
+10 1
+.names ng1129 pg35 [31378]
+11 1
+.names pg35 ng1129 ng1124 [31379]
+0-1 1
+110 1
+.names ng13307 ng10929 [31377] [31379] [31380]
+---1 1
+001- 1
+.names pg35 ng1624 ng1657 ng1648 [31385]
+110- 1
+1-00 1
+.names pg35 ng14367 [7041] [29097] [31387]
+1-1- 1
+11-1 1
+.names ng1624 pg35 [31388]
+11 1
+.names ng27738 [5557] [31387] [31390]
+-1- 1
+0-1 1
+.names ng1848 pg35 [31391]
+01 1
+.names ng1848 pg35 [31392]
+11 1
+.names pg35 ng4859 ng13346 [31395]
+100 1
+.names pg35 ng4859 ng13346 [31397]
+111 1
+.names ng31009 ng10862 [5551] [31395] [31398]
+--1- 1
+10-1 1
+.names ng956 pg35 [31399]
+11 1
+.names ng956 ng1141 [31400]
+01 1
+.names pg35 ng1141 ng956 [31402]
+01- 1
+101 1
+.names ng10929 ng10909 [31399] [31402] [31403]
+---1 1
+1-1- 1
+-11- 1
+.names ng2495 pg35 [31404]
+01 1
+.names ng26770 ng17424 ng28846 [31404] [31406]
+1-01 1
+-101 1
+.names pg35 ng9694 ng26725 ng17401 [31414]
+111- 1
+11-1 1
+.names ng1874 pg35 [31415]
+11 1
+.names ng2351 ng2342 [31424]
+1- 1
+-0 1
+.names ng2287 pg35 [31425]
+11 1
+.names pg35 ng2327 ng2331 ng25435 [31429]
+11-1 1
+1-00 1
+.names pg35 ng723 ng14279 [31431]
+100 1
+.names pg35 ng723 ng14279 [31433]
+110 1
+.names pg35 ng827 ng20905 [31431] [31434]
+01-- 1
+-101 1
+.names ng4349 ng4358 ng24380 [29233] [31435]
+0101 1
+.names ng3703 pg35 [31437]
+01 1
+.names ng3703 pg35 [31439]
+11 1
+.names pg72 pg35 ng4575 ng4581 [31445]
+01-1 1
+-111 1
+.names pg73 pg35 ng4546 ng4581 [31446]
+-01- 1
+--10 1
+11-1 1
+.names ng1917 pg35 [31447]
+11 1
+.names pg35 ng14367 [6655] [29571] [31449]
+1-1- 1
+11-1 1
+.names ng1926 pg35 [31450]
+11 1
+.names ng27833 [5505] [31449] [31452]
+-1- 1
+0-1 1
+.names pg35 ng676 ng20375 [31454]
+101 1
+.names pg35 ng676 ng20375 [31456]
+110 1
+.names pg35 pg7946 ng1306 ng1532 [31460]
+0-1- 1
+10-1 1
+.names pg35 ng1389 ng1351 [31462]
+101 1
+.names ng1389 pg35 [31463]
+11 1
+.names ng13242 [5490] [5491] [31462] [31464]
+-1-- 1
+0-01 1
+.names pg35 ng2250 ng2246 [31466]
+101 1
+.names ng2255 pg35 [31468]
+11 1
+.names ng2250 ng2246 ng25432 [31468] [31470]
+--11 1
+100- 1
+.names pg35 ng5489 ng5495 [31472]
+100 1
+.names pg35 ng5489 ng5495 [31474]
+111 1
+.names pg35 ng5499 ng10838 [31474] [31477]
+--11 1
+110- 1
+.names pg35 ng4284 ng4180 [31478]
+11- 1
+1-0 1
+.names ng5917 pg35 [31479]
+11 1
+.names pg35 ng4284 ng4180 [31484]
+11- 1
+1-0 1
+.names ng3917 pg35 [31485]
+11 1
+.names pg35 ng2527 ng2533 [31488]
+100 1
+.names pg35 ng2527 ng2533 [31490]
+111 1
+.names ng2537 pg35 [31491]
+11 1
+.names pg35 ng4284 ng4180 [31494]
+11- 1
+1-0 1
+.names ng5268 pg35 [31495]
+11 1
+.names pg35 ng3873 ng3881 ng3869 [31498]
+1101 1
+.names pg35 ng3873 ng3881 ng3869 [31499]
+101- 1
+1-10 1
+.names pg35 ng4284 ng4180 [31501]
+11- 1
+1-0 1
+.names ng5256 pg35 [31502]
+11 1
+.names ng930 ng969 ng1193 ng1008 [31505]
+1-0- 1
+10-0 1
+.names pg35 ng14367 [7041] [29097] [31508]
+1-1- 1
+11-1 1
+.names ng1648 pg35 [31509]
+11 1
+.names ng1657 pg35 [31510]
+11 1
+.names ng27738 [5431] [31508] [31512]
+-1- 1
+0-1 1
+.names ng4035 pg35 [31513]
+11 1
+.names pg35 [7325] [7326] [28766] [31514]
+11-- 1
+1-1- 1
+1--1 1
+.names [5428] [28765] [28766] [31513] [31515]
+1--- 1
+-001 1
+.names pg35 ng4284 ng4180 [31521]
+11- 1
+1-0 1
+.names ng5603 pg35 [31522]
+11 1
+.names pg35 ng4284 ng4180 [31527]
+11- 1
+1-0 1
+.names ng3949 pg35 [31528]
+11 1
+.names pg35 pg8291 ng218 [31530]
+111 1
+.names ng4473 ng4462 ng4643 [31533]
+10- 1
+1-0 1
+.names pg35 ng4473 ng4467 [31534]
+01- 1
+111 1
+.names pg35 ng4284 ng4180 [31536]
+11- 1
+1-0 1
+.names ng5236 pg35 [31537]
+11 1
+.names pg35 ng4849 ng4843 ng4878 [31540]
+1011 1
+.names pg35 ng4849 ng4843 ng4878 [31542]
+110- 1
+11-0 1
+.names ng31009 ng10862 [5394] [31540] [31543]
+--1- 1
+10-1 1
+.names ng2227 pg35 [31544]
+11 1
+.names ng26703 ng17321 [5391] [31544] [31546]
+--1- 1
+00-1 1
+.names pg35 pg9497 pg9553 ng5109 [31550]
+0--1 1
+1100 1
+.names pg35 pg12923 ng1280 [31553]
+111 1
+.names pg35 ng1266 ng1280 ng15695 [31555]
+01-- 1
+1-00 1
+.names ng681 pg35 [31556]
+11 1
+.names ng650 pg35 [31557]
+11 1
+.names pg35 ng26703 ng17321 ng11916 [31559]
+11-1 1
+1-11 1
+.names ng2181 pg35 [31560]
+11 1
+.names pg35 ng1046 ng1008 [31563]
+101 1
+.names ng1046 pg35 [31564]
+11 1
+.names ng13211 [5370] [5848] [31563] [31565]
+-1-- 1
+0-01 1
+.names ng2421 ng2495 [31570]
+0- 1
+-0 1
+.names pg35 ng26770 ng17424 [31570] [31571]
+11-0 1
+1-10 1
+.names ng2441 pg35 [31572]
+11 1
+.names ng4821 pg35 [31574]
+11 1
+.names pg35 [6832] [6833] [29346] [31575]
+11-- 1
+1-1- 1
+1--1 1
+.names ng1768 pg35 [31578]
+01 1
+.names pg35 ng2767 ng2779 ng12377 [31581]
+01-- 1
+1-10 1
+.names pg35 ng936 ng907 ng15674 [31587]
+01-- 1
+1100 1
+.names pg35 ng699 ng681 ng8806 [31589]
+0-1- 1
+11-1 1
+.names pg35 ng3119 ng3125 [31591]
+100 1
+.names ng3129 pg35 [31593]
+11 1
+.names ng3119 ng3125 ng23067 [31593] [31595]
+--11 1
+110- 1
+.names ng4698 pg35 [31596]
+11 1
+.names [1421] ng4704 ng4818 ng24374 [31597]
+11-- 1
+-11- 1
+-1-0 1
+.names pg35 ng29657 ng30576 [31597] [31600]
+-1-1 1
+111- 1
+.names pg35 ng4473 ng4507 ng4459 [31604]
+0--- 1
+-01- 1
+--11 1
+.names pg35 ng4284 ng4180 [31608]
+11- 1
+1-0 1
+.names ng5555 pg35 [31609]
+11 1
+.names ng12453 ng12558 [5322] [31608] [31610]
+--1- 1
+11-1 1
+.names pg35 pg9048 ng590 ng559 [31612]
+101- 1
+1-11 1
+.names ng590 pg35 [31613]
+01 1
+.names ng1728 ng1772 [31615]
+1- 1
+-0 1
+.names pg35 ng17317 ng26694 [31615] [31616]
+11-0 1
+1-10 1
+.names ng1752 pg35 [31617]
+11 1
+.names pg35 ng4375 ng4382 [31621]
+101 1
+.names pg35 ng4375 ng4382 [31622]
+110 1
+.names [5310] [29325] [29326] [31621] [31623]
+1--- 1
+-0-1 1
+--01 1
+.names ng1802 pg35 [31629]
+01 1
+.names ng28761 ng17317 ng26694 [31629] [31631]
+01-1 1
+0-11 1
+.names pg35 ng990 ng979 ng1008 [31634]
+11-0 1
+1-10 1
+.names ng990 ng979 ng1008 [31637]
+1-1 1
+-11 1
+.names pg35 ng1030 ng1018 ng1046 [31638]
+1110 1
+.names pg35 ng990 ng979 ng996 [31640]
+1-11 1
+1100 1
+.names [5302] [31637] [31638] [31642]
+1-- 1
+-11 1
+.names ng225 pg35 [31645]
+11 1
+.names pg14189 pg35 [31646]
+11 1
+.names pg35 ng5869 ng5857 ng5863 [31650]
+1011 1
+.names pg35 ng153 ng23042 [31652]
+111 1
+.names ng153 pg35 [31653]
+01 1
+.names ng2327 pg35 [31655]
+01 1
+.names pg35 ng2799 ng2811 ng12377 [31658]
+01-- 1
+1-10 1
+.names ng4108 pg35 [31659]
+01 1
+.names ng4108 pg35 [31660]
+11 1
+.names pg35 ng2841 ng4098 [31661]
+10- 1
+0-1 1
+.names ng4098 ng22654 [31659] [31661] [31662]
+---1 1
+111- 1
+.names pg35 ng5869 ng5881 ng5873 [31664]
+1101 1
+.names pg35 ng5869 ng5881 ng5873 [31665]
+101- 1
+1-10 1
+.names ng1099 pg35 [31667]
+01 1
+.names ng1146 pg35 [31668]
+11 1
+.names ng513 ng667 ng686 [31671]
+10- 1
+1-1 1
+.names ng518 pg35 [31672]
+11 1
+.names pg35 ng4332 ng4349 ng4358 [31677]
+1000 1
+.names ng4340 ng4322 ng4311 ng4643 [31678]
+0001 1
+.names ng5041 pg35 [31679]
+11 1
+.names ng5041 pg35 [31681]
+01 1
+.names pg35 pg7946 ng1514 ng1526 [31686]
+0-1- 1
+10-1 1
+1-01 1
+1110 1
+.names pg35 pg9048 ng568 ng559 [31688]
+101- 1
+1-11 1
+.names ng568 pg35 [31689]
+01 1
+.names ng14708 [5251] [28793] [31688] [31690]
+-1-- 1
+0--1 1
+--11 1
+.names pg72 pg35 ng4578 ng4581 [31696]
+01-1 1
+-111 1
+.names pg73 pg35 ng4581 ng4567 [31697]
+-0-1 1
+--01 1
+111- 1
+.names pg35 pg9741 pg9682 ng6148 [31701]
+0--1 1
+1010 1
+.names pg35 ng4284 ng4180 [31702]
+11- 1
+1-0 1
+.names ng6283 pg35 [31703]
+11 1
+.names ng4322 pg35 [31711]
+01 1
+.names ng4311 ng10511 ng8347 [31711] [31712]
+1001 1
+.names ng4322 pg35 [31713]
+11 1
+.names ng4311 ng10511 ng8347 [31713] [31714]
+0--1 1
+-1-1 1
+--11 1
+.names ng30583 ng15591 [5217] [31712] [31715]
+--1- 1
+01-1 1
+.names pg35 ng4284 ng4180 [31716]
+11- 1
+1-0 1
+.names ng5252 pg35 [31717]
+11 1
+.names ng1274 pg35 [31719]
+01 1
+.names pg35 pg12923 ng1274 [31720]
+111 1
+.names [5201] [5202] [5203] [5204] [31726]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [5205] [5206] [5207] [5208] [31727]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng5033 ng15585 [31729]
+111 1
+.names pg35 ng5029 ng5033 ng15585 [31731]
+01-- 1
+1-00 1
+.names pg35 ng3352 ng3288 ng3347 [31733]
+1111 1
+.names ng4975 ng4899 ng11283 [31733] [31734]
+0011 1
+.names pg35 ng3352 ng3288 ng3347 [31736]
+1100 1
+.names ng4975 ng4899 ng11283 [31736] [31737]
+0011 1
+.names pg35 ng3343 ng3352 ng3288 [31739]
+1101 1
+.names ng4975 ng4899 ng11283 [31739] [31740]
+0011 1
+.names pg35 ng3343 ng3352 ng3288 [31742]
+1000 1
+.names ng4975 ng4899 ng11283 [31742] [31743]
+0011 1
+.names ng4939 pg35 [31744]
+11 1
+.names ng20887 [5196] [31740] [31746]
+-1- 1
+1-1 1
+.names pg35 ng4939 ng20887 [31743] [31747]
+--11 1
+110- 1
+.names ng23286 [31734] [31737] [31748]
+01- 1
+0-1 1
+.names pg35 ng4284 ng4180 [31754]
+11- 1
+1-0 1
+.names ng5200 pg35 [31755]
+11 1
+.names ng12772 ng12492 [5183] [31754] [31756]
+--1- 1
+11-1 1
+.names ng4349 ng4358 ng24380 [29233] [31757]
+1001 1
+.names ng3352 pg35 [31759]
+01 1
+.names ng3352 pg35 [31761]
+11 1
+.names ng1906 ng1936 [31770]
+0- 1
+-1 1
+.names pg35 ng26725 ng17401 [31770] [31771]
+11-0 1
+1-10 1
+.names ng1878 pg35 [31772]
+11 1
+.names pg35 ng4284 ng4180 [31779]
+11- 1
+1-0 1
+.names ng5567 pg35 [31780]
+11 1
+.names pg35 pg17400 pg10500 ng1246 [31783]
+0--1 1
+101- 1
+.names ng753 pg35 [31784]
+11 1
+.names pg35 ng3171 ng3179 ng3167 [31788]
+1101 1
+.names pg35 ng3171 ng3179 ng3167 [31789]
+101- 1
+1-10 1
+.names ng2811 pg35 [31791]
+01 1
+.names ng2724 ng2729 ng11405 [31791] [31792]
+1001 1
+.names ng111 ng29503 ng11405 [29805] [31794]
+0-00 1
+-000 1
+.names ng2807 pg35 [31795]
+11 1
+.names ng11405 [5142] [29805] [31795] [31796]
+-1-- 1
+1--1 1
+--11 1
+.names ng111 ng29503 [31792] [31796] [31797]
+---1 1
+0-1- 1
+-01- 1
+.names pg35 ng1668 ng1592 ng1682 [31798]
+11-1 1
+1-11 1
+.names ng26673 ng17292 [31798] [31799]
+1-1 1
+-11 1
+.names pg35 ng1668 ng1592 ng1682 [31800]
+1--0 1
+100- 1
+.names ng26673 ng17292 [31800] [31801]
+1-1 1
+-11 1
+.names ng1682 pg35 [31802]
+11 1
+.names ng26673 ng17292 [5136] [31802] [31803]
+--1- 1
+00-1 1
+.names pg35 ng5827 ng5821 [31806]
+100 1
+.names pg35 ng5827 ng5821 [31808]
+111 1
+.names pg35 ng5831 ng23666 [31808] [31811]
+--01 1
+111- 1
+.names pg35 ng4284 ng4180 [31812]
+11- 1
+1-0 1
+.names ng3231 pg35 [31813]
+11 1
+.names pg35 ng4284 ng4180 [31815]
+11- 1
+1-0 1
+.names ng5579 pg35 [31816]
+11 1
+.names pg35 ng4284 ng4180 [31818]
+11- 1
+1-0 1
+.names ng6625 pg35 [31819]
+11 1
+.names ng4392 ng4401 [31821]
+11 1
+.names pg35 ng4401 ng4411 [31822]
+01- 1
+1-1 1
+.names ng29503 ng14367 [5887] [31005] [31823]
+1-1- 1
+11-1 1
+.names pg35 ng110 ng2610 ng2619 [31825]
+111- 1
+11-0 1
+.names pg35 ng110 ng2610 ng2619 [31827]
+1001 1
+.names ng2625 pg35 [31828]
+11 1
+.names ng26236 [5107] [31823] [31825] [31829]
+-1-- 1
+1-11 1
+.names ng26236 [31823] [31827] [31828] [31830]
+0--1 1
+-0-1 1
+111- 1
+.names pg35 ng4284 ng4180 [31831]
+11- 1
+1-0 1
+.names ng3897 pg35 [31832]
+11 1
+.names pg35 ng4284 ng4180 [31834]
+11- 1
+1-0 1
+.names ng6641 pg35 [31835]
+11 1
+.names pg35 ng4284 ng4180 [31838]
+11- 1
+1-0 1
+.names ng3538 pg35 [31839]
+11 1
+.names ng8906 ng11571 [5092] [31838] [31840]
+--1- 1
+11-1 1
+.names pg35 ng6519 ng6513 [31842]
+100 1
+.names pg35 ng6519 ng6513 [31844]
+111 1
+.names pg35 ng6523 ng23733 [31844] [31847]
+--01 1
+111- 1
+.names pg35 ng4284 ng4180 [31848]
+11- 1
+1-0 1
+.names ng3263 pg35 [31849]
+11 1
+.names pg35 ng4284 ng4180 [31851]
+11- 1
+1-0 1
+.names ng3562 pg35 [31852]
+11 1
+.names pg35 ng4284 ng4180 [31854]
+11- 1
+1-0 1
+.names ng5937 pg35 [31855]
+11 1
+.names pg35 ng6336 ng6395 ng6390 [31858]
+1111 1
+.names ng4785 ng4709 ng11261 [31858] [31859]
+0111 1
+.names pg35 ng6386 ng6336 ng6395 [31861]
+1000 1
+.names ng4785 ng4709 ng11261 [31861] [31862]
+0111 1
+.names pg35 ng6336 ng6395 ng6390 [31864]
+1010 1
+.names ng4785 ng4709 ng11261 [31864] [31865]
+0111 1
+.names pg35 ng6386 ng6336 ng6395 [31867]
+1110 1
+.names ng4785 ng4709 ng11261 [31867] [31868]
+0111 1
+.names ng4771 pg35 [31870]
+11 1
+.names ng21012 [5076] [31862] [31871]
+-1- 1
+1-1 1
+.names pg35 ng4771 ng21012 [31868] [31872]
+--11 1
+110- 1
+.names ng23949 [31859] [31865] [31873]
+01- 1
+0-1 1
+.names ng4966 pg35 [31875]
+01 1
+.names ng4991 ng4983 ng10862 [31875] [31876]
+1111 1
+.names ng4966 pg35 [31877]
+11 1
+.names ng4991 ng4983 ng10862 [31877] [31878]
+0--1 1
+-0-1 1
+--01 1
+.names ng28349 ng13486 [5070] [31876] [31879]
+--1- 1
+11-1 1
+.names pg35 ng1199 ng10893 [29901] [31881]
+1001 1
+.names pg35 ng1199 ng10893 [29901] [31883]
+111- 1
+11-0 1
+.names pg35 ng4284 ng4180 [31885]
+11- 1
+1-0 1
+.names ng5941 pg35 [31886]
+11 1
+.names pg35 ng1844 ng1710 [31890]
+11- 1
+1-1 1
+.names pg35 ng1858 ng1724 [31891]
+11- 1
+1-1 1
+.names pg35 ng2126 ng1978 [31892]
+11- 1
+1-1 1
+.names pg35 ng2112 ng1992 [31893]
+11- 1
+1-1 1
+.names pg35 ng2403 ng2283 [31896]
+11- 1
+1-1 1
+.names pg35 ng2537 ng2685 [31897]
+11- 1
+1-1 1
+.names pg35 ng2417 ng2551 [31898]
+11- 1
+1-1 1
+.names pg35 ng2269 ng2671 [31899]
+11- 1
+1-1 1
+.names pg35 ng2856 ng2848 [31902]
+11- 1
+0-1 1
+.names pg35 ng1959 ng1955 [31906]
+101 1
+.names ng1964 pg35 [31908]
+11 1
+.names ng1959 ng1955 ng25467 [31908] [31910]
+--11 1
+100- 1
+.names ng1559 pg35 [31913]
+01 1
+.names ng1559 pg35 [31915]
+11 1
+.names ng11171 ng11149 [5024] [31913] [31917]
+--1- 1
+00-1 1
+.names pg35 ng4843 ng4878 [31919]
+110 1
+.names ng4878 ng4843 [31920]
+10 1
+.names ng31009 ng10862 [5021] [31919] [31921]
+--1- 1
+10-1 1
+.names pg35 ng4284 ng4180 [31922]
+11- 1
+1-0 1
+.names ng6657 pg35 [31923]
+11 1
+.names pg35 ng4311 ng10511 ng8347 [31926]
+111- 1
+11-1 1
+.names pg35 ng4311 ng10511 ng8347 [31928]
+1000 1
+.names pg35 ng4284 ng4180 [31929]
+11- 1
+1-0 1
+.names ng3223 pg35 [31930]
+11 1
+.names pg35 ng4284 ng4180 [31932]
+11- 1
+1-0 1
+.names ng3251 pg35 [31933]
+11 1
+.names pg35 ng4284 ng4180 [31935]
+11- 1
+1-0 1
+.names ng5619 pg35 [31936]
+11 1
+.names pg11678 ng790 ng736 [31938]
+01- 1
+-11 1
+.names pg11678 ng794 ng736 [31939]
+-0- 1
+1-0 1
+.names pg11678 ng736 ng807 [31940]
+0-1 1
+-11 1
+.names pg35 pg11678 ng554 ng736 [31942]
+101- 1
+1-11 1
+.names ng554 pg35 [31943]
+01 1
+.names ng29503 ng14367 [7257] [28834] [31945]
+1-1- 1
+11-1 1
+.names pg35 ng110 ng1783 ng1792 [31947]
+111- 1
+11-0 1
+.names pg35 ng110 ng1783 ng1792 [31949]
+1001 1
+.names ng1798 pg35 [31950]
+11 1
+.names ng26166 [4999] [31945] [31947] [31951]
+-1-- 1
+1-11 1
+.names ng26166 [31945] [31949] [31950] [31952]
+0--1 1
+-0-1 1
+111- 1
+.names pg35 ng4284 ng4180 [31954]
+11- 1
+1-0 1
+.names ng5901 pg35 [31955]
+11 1
+.names ng12609 ng12515 [4988] [31954] [31956]
+--1- 1
+11-1 1
+.names pg35 ng182 ng174 [31958]
+111 1
+.names pg35 ng168 ng174 [31960]
+111 1
+.names pg35 ng168 ng182 [31962]
+111 1
+.names pg35 ng4653 ng4688 [31965]
+110 1
+.names ng4688 ng4653 [31966]
+10 1
+.names ng31003 ng10831 [4982] [31965] [31967]
+--1- 1
+10-1 1
+.names ng1111 ng1105 [31968]
+10 1
+.names ng1105 pg35 [31970]
+11 1
+.names pg35 ng1105 ng1111 [31971]
+0-1 1
+110 1
+.names ng10929 ng13260 [31968] [31971] [31972]
+---1 1
+001- 1
+.names ng3889 pg35 [31973]
+11 1
+.names pg35 ng4284 ng4180 [31974]
+11- 1
+1-0 1
+.names ng11626 ng8958 [4972] [31973] [31975]
+--1- 1
+0--1 1
+-0-1 1
+.names pg35 ng2841 ng4093 [31978]
+10- 1
+0-1 1
+.names pg72 pg35 ng4581 ng59 [31984]
+011- 1
+-111 1
+.names pg73 pg35 ng4501 ng4581 [31985]
+-01- 1
+--10 1
+11-1 1
+.names ng93 ng4349 ng4358 ng29503 [31986]
+1011 1
+.names pg35 ng5990 ng23932 [31989]
+100 1
+.names pg35 ng5990 ng23932 [31991]
+111 1
+.names pg35 ng4284 ng4180 [31993]
+11- 1
+1-0 1
+.names ng6275 pg35 [31994]
+11 1
+.names pg35 ng4284 ng4180 [31996]
+11- 1
+1-0 1
+.names ng6239 pg35 [31997]
+11 1
+.names ng10421 ng12667 [4952] [31996] [31998]
+--1- 1
+11-1 1
+.names pg35 pg9555 pg9615 ng5456 [32002]
+0--1 1
+1100 1
+.names ng150 pg35 [32003]
+11 1
+.names ng150 pg35 [32005]
+01 1
+.names [1421] ng4818 ng4749 ng24374 [32007]
+1-1- 1
+-11- 1
+--10 1
+.names pg35 ng4743 ng29672 ng30576 [32011]
+110- 1
+1-11 1
+.names pg35 ng4284 ng4180 [32012]
+11- 1
+1-0 1
+.names ng5571 pg35 [32013]
+11 1
+.names pg35 ng4284 ng4180 [32015]
+11- 1
+1-0 1
+.names ng5196 pg35 [32016]
+11 1
+.names ng10266 ng12492 [4934] [32015] [32017]
+--1- 1
+11-1 1
+.names pg35 ng14367 [7030] [29111] [32018]
+1-1- 1
+11-1 1
+.names ng2351 pg35 [32019]
+11 1
+.names ng2342 pg35 [32020]
+11 1
+.names ng27854 [4930] [32018] [32022]
+-1- 1
+0-1 1
+.names pg35 ng4392 ng4430 [32024]
+101 1
+.names ng405 ng437 ng392 [32031]
+011 1
+110 1
+.names ng405 ng424 ng401 ng392 [32032]
+1-11 1
+01-0 1
+.names ng182 ng411 ng392 [32035]
+100 1
+.names ng441 ng182 ng392 [32039]
+011 1
+.names ng182 ng411 ng392 [32043]
+000 1
+.names ng441 ng182 ng392 [32047]
+001 1
+.names [4913] [4914] [4915] [4916] [32051]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng11326 pg35 [32052]
+01 1
+.names ng2476 ng2453 ng2518 ng2504 [32056]
+--01 1
+10-1 1
+.names ng2518 pg35 [32057]
+11 1
+.names pg35 ng2504 ng22472 ng14713 [32058]
+01-- 1
+1011 1
+.names pg35 ng4616 ng30583 [6408] [32061]
+1000 1
+.names pg35 ng4616 ng30583 [6408] [32063]
+1100 1
+.names pg35 ng2518 ng2514 [32066]
+101 1
+.names ng2523 pg35 [32068]
+11 1
+.names ng2518 ng2514 ng25495 [32068] [32070]
+--11 1
+100- 1
+.names pg35 ng2541 ng2547 [32072]
+100 1
+.names pg35 ng2541 ng2547 [32074]
+111 1
+.names pg35 ng2551 ng25400 [32074] [32077]
+--01 1
+111- 1
+.names ng2555 ng2599 [32078]
+1- 1
+-0 1
+.names ng2579 pg35 [32079]
+11 1
+.names pg35 ng26793 ng14506 [32078] [32080]
+11-0 1
+1-10 1
+.names pg35 ng4284 ng4180 [32082]
+11- 1
+1-0 1
+.names ng3929 pg35 [32083]
+11 1
+.names ng2040 ng2070 [32085]
+0- 1
+-1 1
+.names pg35 ng26759 ng14438 [32085] [32086]
+11-0 1
+1-10 1
+.names ng2012 pg35 [32087]
+11 1
+.names pg35 ng4864 ng4871 ng4836 [32091]
+1000 1
+.names ng2108 pg35 [32093]
+11 1
+.names ng2629 ng2599 [32095]
+1- 1
+-0 1
+.names pg35 ng26793 ng14506 [32095] [32096]
+11-0 1
+1-10 1
+.names ng2571 pg35 [32097]
+11 1
+.names ng2079 ng2093 ng2051 ng2028 [32101]
+10-- 1
+1-10 1
+.names ng2093 pg35 [32102]
+11 1
+.names pg35 ng2079 ng22457 ng14712 [32103]
+01-- 1
+1011 1
+.names ng1554 pg35 [32105]
+01 1
+.names ng1554 pg35 [32107]
+11 1
+.names ng11171 ng13597 [4873] [32105] [32109]
+--1- 1
+00-1 1
+.names ng3207 pg35 [32110]
+11 1
+.names pg35 ng4284 ng4180 [32111]
+11- 1
+1-0 1
+.names ng11473 ng11514 [4870] [32110] [32112]
+--1- 1
+0--1 1
+-0-1 1
+.names ng1193 pg35 [32117]
+11 1
+.names pg35 ng1070 ng1193 ng1189 [32118]
+0--1 1
+101- 1
+.names pg35 ng4284 ng4180 [32120]
+11- 1
+1-0 1
+.names ng3255 pg35 [32121]
+11 1
+.names pg35 ng4284 ng4180 [32123]
+11- 1
+1-0 1
+.names ng5893 pg35 [32124]
+11 1
+.names ng12609 ng12824 [4857] [32123] [32125]
+--1- 1
+11-1 1
+.names ng1300 ng1484 [32126]
+01 1
+.names ng1300 pg35 [32127]
+11 1
+.names pg35 ng1484 ng1300 [32129]
+01- 1
+101 1
+.names ng10939 ng10961 [32126] [32129] [32130]
+---1 1
+001- 1
+.names pg35 ng4549 ng4581 [32133]
+01- 1
+-10 1
+.names pg35 ng4284 ng4180 [32135]
+11- 1
+1-0 1
+.names ng3187 pg35 [32136]
+11 1
+.names ng8864 ng11514 [4839] [32135] [32137]
+--1- 1
+11-1 1
+.names ng2040 ng1996 [32138]
+0- 1
+-1 1
+.names ng2070 pg35 [32139]
+01 1
+.names ng26759 ng14438 ng28833 [32139] [32141]
+1-01 1
+-101 1
+.names pg16744 pg16656 [32145]
+00 1
+.names pg35 pg13926 pg14451 pg16627 [32146]
+1000 1
+.names pg35 pg13926 pg14451 pg11388 [32151]
+1101 1
+.names ng269 ng255 [32154]
+11 1
+.names pg73 pg72 pg35 [32155]
+001 1
+.names pg73 pg72 pg35 [32158]
+101 1
+.names pg35 ng102 [32154] [32155] [32166]
+01-- 1
+--11 1
+.names ng262 ng255 [4826] [32158] [32167]
+--1- 1
+11-1 1
+.names ng6381 pg17845 [32170]
+01 1
+.names ng6336 ng6395 ng6271 [32171]
+111 1
+.names ng6381 pg17743 [32172]
+11 1
+.names ng6336 ng6295 ng6395 [32173]
+111 1
+.names pg17760 ng6283 ng6336 ng6395 [32175]
+1111 1
+.names ng6381 pg17845 [32176]
+11 1
+.names ng6336 ng6395 ng6263 [32177]
+011 1
+.names pg17649 ng6299 ng6336 ng6395 [32179]
+1100 1
+.names ng6381 pg13085 [32180]
+11 1
+.names ng6235 ng6336 ng6395 [32181]
+100 1
+.names ng6243 ng6381 [32182]
+11 1
+.names ng6336 ng6395 ng6377 [32183]
+001 1
+.names pg14779 ng6267 ng6336 ng6395 [32185]
+1110 1
+.names ng6381 pg13085 [32186]
+01 1
+.names ng6247 ng6336 ng6395 [32187]
+110 1
+.names ng6381 pg14705 [32188]
+11 1
+.names ng6279 ng6336 ng6395 [32189]
+110 1
+.names ng6381 pg12422 [32190]
+11 1
+.names ng6239 ng6336 ng6395 [32191]
+101 1
+.names ng6381 pg17685 [32192]
+01 1
+.names ng6251 ng6336 ng6395 [32193]
+101 1
+.names [32170] [32171] [32172] [32173] [32194]
+11-- 1
+--11 1
+.names ng12423 [32175] [32176] [32177] [32195]
+01-- 1
+--11 1
+.names ng12423 [32179] [32180] [32181] [32196]
+01-- 1
+--11 1
+.names ng12423 [32182] [32183] [32185] [32197]
+-11- 1
+0--1 1
+.names [32186] [32187] [32188] [32189] [32198]
+11-- 1
+--11 1
+.names [32190] [32191] [32192] [32193] [32199]
+11-- 1
+--11 1
+.names [32199] [32198] [32202]
+1- 1
+-1 1
+.names [32194] [32195] [32196] [32197] [32203]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng6381 pg17685 [32204]
+11 1
+.names ng6311 ng6336 ng6395 [32205]
+111 1
+.names ng6255 pg12422 [32206]
+11 1
+.names ng6381 ng6336 ng6395 [32207]
+011 1
+.names ng6381 pg14705 [32208]
+01 1
+.names ng6336 ng6395 ng6287 [32209]
+001 1
+.names pg14779 ng6275 ng6336 ng6395 [32211]
+1100 1
+.names ng6377 ng6381 [32212]
+10 1
+.names ng6336 ng6395 ng6259 [32213]
+101 1
+.names pg17760 ng6336 ng6395 ng6291 [32215]
+1011 1
+.names pg17649 ng6307 ng6336 ng6395 [32217]
+1110 1
+.names ng6303 pg17743 [32218]
+11 1
+.names ng6381 ng6336 ng6395 [32219]
+001 1
+.names [32204] [32205] [32206] [32207] [32220]
+11-- 1
+--11 1
+.names ng12423 [32208] [32209] [32211] [32221]
+-11- 1
+1--1 1
+.names ng12423 [32212] [32213] [32215] [32222]
+-11- 1
+1--1 1
+.names ng12423 [32217] [32218] [32219] [32223]
+11-- 1
+--11 1
+.names [32220] [32221] [32222] [32223] [32226]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng6154 ng11160 ng21012 [32228]
+10-1 1
+1-11 1
+.names pg35 ng6154 ng11160 ng21012 [32230]
+1101 1
+.names ng6154 pg35 [32231]
+11 1
+.names ng5264 pg35 [32234]
+11 1
+.names pg35 ng4284 ng4180 [32235]
+11- 1
+1-0 1
+.names ng4349 ng4358 ng24380 [29233] [32239]
+1101 1
+.names pg35 ng4054 [28765] [28766] [32242]
+101- 1
+10-1 1
+.names ng4054 pg35 [32243]
+11 1
+.names [4783] [28765] [28766] [32243] [32244]
+1--- 1
+-001 1
+.names ng4785 ng4776 ng4709 [32251]
+101 1
+.names pg35 ng4801 ng4674 ng4681 [32252]
+1000 1
+.names ng4646 ng4737 ng4793 ng4688 [32253]
+0000 1
+.names pg35 ng4801 ng4785 ng4709 [32259]
+1010 1
+.names ng4674 ng4681 ng4646 ng4793 [32260]
+0000 1
+.names pg35 ng4801 ng4785 ng4709 [32266]
+1001 1
+.names ng4674 ng4681 ng4646 ng4793 [32267]
+0000 1
+.names ng4785 ng4698 ng4743 ng4709 [32269]
+01-0 1
+1-10 1
+.names ng4765 ng4785 ng4754 ng4709 [32270]
+11-1 1
+-011 1
+.names ng4785 ng4722 ng4717 ng4709 [32271]
+01-0 1
+1-10 1
+.names ng4727 ng4785 ng4732 ng4709 [32272]
+11-1 1
+-011 1
+.names pg35 ng4674 ng4688 [32275]
+100 1
+.names ng4681 ng4646 ng11155 [32275] [32277]
+0001 1
+.names pg35 ng4674 ng4688 [32281]
+100 1
+.names ng4681 ng4646 ng11155 [32281] [32283]
+0001 1
+.names pg35 ng4674 ng4776 [32288]
+100 1
+.names ng4681 ng4646 ng4793 ng4688 [32289]
+0010 1
+.names pg35 ng4674 ng4688 [32293]
+100 1
+.names [4766] [4767] [4768] [4769] [32301]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names [4764] [32301] [32304]
+1- 1
+-1 1
+.names [4759] [4760] [4761] [4765] [32305]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng16663 ng16728 [32277] [32283] [32306]
+101- 1
+01-1 1
+.names pg35 ng4284 ng4180 [32313]
+11- 1
+1-0 1
+.names ng6311 pg35 [32314]
+11 1
+.names ng4826 pg35 [32316]
+11 1
+.names pg35 [7248] [7249] [28843] [32317]
+11-- 1
+1-1- 1
+1--1 1
+.names pg35 ng1691 ng1687 [32323]
+101 1
+.names ng1696 pg35 [32325]
+11 1
+.names ng1691 ng1687 ng25382 [32325] [32327]
+--11 1
+100- 1
+.names ng3578 pg35 [32328]
+11 1
+.names pg35 ng4284 ng4180 [32329]
+11- 1
+1-0 1
+.names ng2380 pg35 [32331]
+11 1
+.names ng2648 pg35 [32333]
+11 1
+.names pg35 ng4601 ng4593 ng24411 [32336]
+1011 1
+.names pg35 ng4601 ng4593 ng24411 [32338]
+110- 1
+11-0 1
+.names pg35 ng26793 ng14506 ng9835 [32340]
+11-1 1
+1-11 1
+.names ng2567 pg35 [32341]
+11 1
+.names pg35 ng862 ng8721 [32344]
+110 1
+.names ng862 pg35 [32345]
+11 1
+.names pg35 ng862 ng703 [32348]
+111 1
+.names pg35 ng896 ng446 ng890 [32350]
+0-1- 1
+11-1 1
+.names ng8721 ng11326 [32345] [32350] [32352]
+---1 1
+011- 1
+.names ng8721 [4708] [32348] [32352] [32353]
+-1-- 1
+---1 1
+0-1- 1
+.names pg35 ng3817 ng3466 [32354]
+11- 1
+1-1 1
+.names pg35 ng4427 ng4420 ng3115 [32355]
+11-- 1
+1-1- 1
+1--1 1
+.names pg35 ng5124 ng5817 [32357]
+11- 1
+1-1 1
+.names pg35 ng6509 ng6163 ng5471 [32358]
+11-- 1
+1-1- 1
+1--1 1
+.names ng2273 pg35 [32363]
+01 1
+.names ng2273 pg35 [32364]
+11 1
+.names pg35 ng6215 ng6227 ng6219 [32367]
+1101 1
+.names pg35 ng6215 ng6227 ng6219 [32368]
+101- 1
+1-10 1
+.names pg35 ng4332 ng4349 ng4358 [32377]
+1000 1
+.names ng4584 ng4340 ng4322 ng4311 [32378]
+0100 1
+.names ng4616 ng4601 ng4608 ng4593 [32379]
+0000 1
+.names pg35 ng9649 ng26703 ng17321 [32382]
+111- 1
+11-1 1
+.names ng2165 pg35 [32383]
+11 1
+.names ng4141 ng4064 ng4057 ng4082 [32385]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng4112 pg35 [32386]
+11 1
+.names ng13806 [4681] [32385] [32386] [32387]
+-1-- 1
+0--1 1
+--11 1
+.names ng1982 pg35 [32388]
+01 1
+.names ng1982 pg35 [32389]
+11 1
+.names ng3215 pg35 [32391]
+11 1
+.names pg35 ng4284 ng4180 [32392]
+11- 1
+1-0 1
+.names ng1367 pg35 [32395]
+11 1
+.names pg35 ng1361 ng25917 [4669] [32396]
+01-- 1
+1-01 1
+.names pg35 ng14367 [6319] [30342] [32398]
+1-1- 1
+11-1 1
+.names ng2051 pg35 [32399]
+11 1
+.names ng27882 [4664] [32398] [32401]
+-1- 1
+0-1 1
+.names ng1677 ng1624 ng1691 ng1648 [32404]
+1-0- 1
+10-1 1
+.names ng1691 pg35 [32405]
+11 1
+.names pg35 ng1677 ng22342 ng14611 [32406]
+01-- 1
+1011 1
+.names ng1105 pg35 [32408]
+11 1
+.names ng1146 ng1111 ng1099 [32409]
+11- 1
+-11 1
+.names ng1105 pg35 [32412]
+01 1
+.names ng1146 ng1111 ng1099 [32413]
+11- 1
+-11 1
+.names pg35 ng1146 ng1105 ng1099 [32417]
+1010 1
+.names pg35 ng1146 ng1105 ng1099 [32420]
+1000 1
+.names pg35 ng1135 ng1111 ng13260 [32423]
+01-- 1
+1-11 1
+.names ng13336 ng13260 [32417] [32420] [32424]
+001- 1
+10-1 1
+.names pg35 ng417 ng8806 [32431]
+100 1
+.names ng8806 ng417 [32432]
+01 1
+.names pg35 ng411 ng417 ng8806 [32434]
+0-1- 1
+11-1 1
+.names ng2587 ng2619 [32438]
+0- 1
+-0 1
+.names pg35 ng4639 ng4628 ng4621 [32443]
+1101 1
+.names pg35 ng4639 ng4628 ng4621 [32445]
+101- 1
+1-10 1
+.names ng2767 pg35 [32447]
+01 1
+.names ng2724 ng2729 ng11405 [32447] [32448]
+0001 1
+.names ng85 ng29503 ng12026 ng11405 [32450]
+0-10 1
+-010 1
+.names ng2771 pg35 [32451]
+11 1
+.names ng12026 ng11405 [4630] [32451] [32452]
+--1- 1
+0--1 1
+-1-1 1
+.names ng85 ng29503 [32448] [32452] [32453]
+---1 1
+0-1- 1
+-01- 1
+.names ng3570 pg35 [32454]
+11 1
+.names pg35 ng4284 ng4180 [32455]
+11- 1
+1-0 1
+.names pg35 pg9048 ng559 ng622 [32458]
+10-1 1
+1-11 1
+.names ng622 pg35 [32459]
+01 1
+.names ng33851 [4623] [30331] [32458] [32460]
+-1-- 1
+0--1 1
+--11 1
+.names pg35 ng2927 ng4153 [32462]
+01- 1
+1-1 1
+.names ng4760 pg35 [32463]
+11 1
+.names [1421] ng4818 ng24374 [32463] [32464]
+1--1 1
+-1-1 1
+--01 1
+.names pg35 ng101 ng24374 [29730] [32466]
+1110 1
+.names pg35 ng4754 ng29694 [32466] [32468]
+--11 1
+110- 1
+.names pg35 ng4983 ng10862 [32470]
+110 1
+.names pg35 ng4983 ng10862 [32472]
+101 1
+.names ng28349 ng13486 [4604] [32470] [32473]
+--1- 1
+11-1 1
+.names pg35 ng4049 ng4054 ng3990 [32475]
+1010 1
+.names ng4975 ng4899 ng11283 [32475] [32476]
+0111 1
+.names pg35 ng4045 ng4054 ng3990 [32478]
+1000 1
+.names ng4975 ng4899 ng11283 [32478] [32479]
+0111 1
+.names pg35 ng4049 ng4054 ng3990 [32481]
+1111 1
+.names ng4975 ng4899 ng11283 [32481] [32482]
+0111 1
+.names pg35 ng4045 ng4054 ng3990 [32484]
+1101 1
+.names ng4975 ng4899 ng11283 [32484] [32485]
+0111 1
+.names ng4961 pg35 [32486]
+11 1
+.names ng4961 pg35 [32487]
+11 1
+.names [4600] [28765] [28766] [32479] [32488]
+1--- 1
+-1-1 1
+--11 1
+.names [28765] [28766] [32485] [32487] [32489]
+1-1- 1
+-11- 1
+00-1 1
+.names pg35 ng3484 ng3490 [32493]
+100 1
+.names pg35 ng3484 ng3490 [32495]
+111 1
+.names pg35 ng3494 ng12692 [32495] [32498]
+--11 1
+110- 1
+.names pg35 ng5703 ng5698 ng5644 [32500]
+1100 1
+.names ng4785 ng4709 ng11261 [32500] [32501]
+0011 1
+.names pg35 ng5703 ng5694 ng5644 [32503]
+1000 1
+.names ng4785 ng4709 ng11261 [32503] [32504]
+0011 1
+.names pg35 ng5703 ng5694 ng5644 [32506]
+1011 1
+.names ng4785 ng4709 ng11261 [32506] [32507]
+0011 1
+.names pg35 ng5703 ng5698 ng5644 [32509]
+1111 1
+.names ng4785 ng4709 ng11261 [32509] [32510]
+0011 1
+.names ng4749 pg35 [32511]
+11 1
+.names ng20739 [4590] [32504] [32513]
+-1- 1
+1-1 1
+.names pg35 ng4749 ng20739 [32507] [32514]
+--11 1
+110- 1
+.names ng23909 [32501] [32510] [32515]
+01- 1
+0-1 1
+.names ng2421 pg35 [32517]
+11 1
+.names ng1802 ng1728 [32521]
+0- 1
+-0 1
+.names pg35 ng17317 ng26694 [32521] [32522]
+11-0 1
+1-10 1
+.names ng1748 pg35 [32523]
+11 1
+.names pg35 pg11678 ng758 ng736 [32526]
+101- 1
+1-11 1
+.names ng758 pg35 [32527]
+01 1
+.names ng29503 ng14367 [7041] [29097] [32529]
+1-1- 1
+11-1 1
+.names pg35 ng110 ng1657 ng1648 [32531]
+110- 1
+11-1 1
+.names pg35 ng110 ng1657 ng1648 [32533]
+1010 1
+.names ng1664 pg35 [32534]
+11 1
+.names ng26148 [4574] [32529] [32531] [32535]
+-1-- 1
+1-11 1
+.names ng26148 [32529] [32533] [32534] [32536]
+0--1 1
+-0-1 1
+111- 1
+.names pg35 ng667 ng528 ng686 [32538]
+101- 1
+1-11 1
+.names pg35 ng667 ng686 [32539]
+10- 1
+1-1 1
+.names ng513 ng518 ng11607 [32539] [32540]
+0111 1
+.names ng11607 ng12812 [4570] [32538] [32541]
+--1- 1
+0--1 1
+-0-1 1
+.names pg35 ng1964 ng1830 [32542]
+11- 1
+1-1 1
+.names pg35 ng2098 ng1696 [32543]
+11- 1
+1-1 1
+.names pg35 ng2523 ng2657 [32544]
+11- 1
+1-1 1
+.names pg35 ng2255 ng2389 [32545]
+11- 1
+1-1 1
+.names ng962 pg35 [32550]
+11 1
+.names ng996 pg35 [32551]
+11 1
+.names pg35 ng3821 ng3827 [32554]
+100 1
+.names ng3831 pg35 [32555]
+11 1
+.names ng3827 ng3821 [32556]
+11 1
+.names pg35 ng4793 ng10831 [32560]
+101 1
+.names pg35 ng4793 ng10831 [32562]
+110 1
+.names ng28336 ng13464 [4537] [32560] [32563]
+--1- 1
+11-1 1
+.names pg35 ng5808 ng20875 ng11139 [32565]
+101- 1
+1-11 1
+.names pg35 ng5808 ng20875 ng11139 [32567]
+1110 1
+.names ng5808 pg35 [32568]
+11 1
+.names ng1890 pg35 [32571]
+11 1
+.names pg35 ng26725 ng17401 ng11937 [32572]
+11-1 1
+1-11 1
+.names pg35 ng4284 ng4180 [32574]
+11- 1
+1-0 1
+.names ng5897 pg35 [32575]
+11 1
+.names pg35 ng2841 ng4093 [32578]
+110 1
+.names pg35 ng2841 ng4093 [32580]
+111 1
+.names pg35 ng14367 [5887] [31005] [32582]
+1-1- 1
+11-1 1
+.names ng2619 pg35 [32583]
+11 1
+.names ng2610 pg35 [32584]
+11 1
+.names ng27933 [4515] [32582] [32586]
+-1- 1
+0-1 1
+.names ng1413 pg35 [32589]
+01 1
+.names ng1542 ng10918 [28896] [32589] [32590]
+1011 1
+.names ng1413 pg35 [32591]
+11 1
+.names ng1542 ng10918 [28896] [32591] [32592]
+0--1 1
+-1-1 1
+--01 1
+.names ng2331 ng2287 [32594]
+0- 1
+-1 1
+.names pg35 ng17405 ng26737 [32594] [32595]
+11-0 1
+1-10 1
+.names ng2311 pg35 [32596]
+11 1
+.names pg35 pg11678 ng794 ng736 [32599]
+101- 1
+1-11 1
+.names ng794 pg35 [32600]
+01 1
+.names ng34162 [4499] [31938] [32599] [32601]
+-1-- 1
+1--1 1
+--01 1
+.names ng2667 pg35 [32602]
+11 1
+.names ng2629 pg35 [32604]
+01 1
+.names ng28880 ng26793 ng14506 [32604] [32606]
+01-1 1
+0-11 1
+.names pg35 ng26673 ng17292 [31143] [32609]
+11-0 1
+1-10 1
+.names ng1616 pg35 [32610]
+11 1
+.names ng255 pg35 [32612]
+11 1
+.names pg14201 pg35 [32613]
+11 1
+.names pg35 pg9048 ng559 ng613 [32616]
+10-1 1
+1-11 1
+.names ng613 pg35 [32617]
+01 1
+.names ng817 pg35 [32619]
+01 1
+.names ng817 pg35 [32621]
+11 1
+.names ng8806 ng14279 [4470] [32619] [32623]
+--1- 1
+00-1 1
+.names ng686 pg35 [32624]
+11 1
+.names ng691 ng703 [32625]
+1- 1
+-0 1
+.names pg35 ng385 ng358 ng376 [32626]
+1110 1
+.names ng4955 pg35 [32628]
+11 1
+.names [1421] ng4818 ng4961 ng24374 [32629]
+1-1- 1
+-11- 1
+--10 1
+.names pg35 ng71 ng24374 [28575] [32630]
+1110 1
+.names ng29737 [32629] [32630] [32632]
+11- 1
+1-1 1
+.names ng2675 pg35 [32633]
+01 1
+.names ng2675 pg35 [32634]
+11 1
+.names ng2533 pg35 [32636]
+11 1
+.names ng6299 pg35 [32638]
+11 1
+.names pg35 ng4284 ng4180 [32639]
+11- 1
+1-0 1
+.names pg35 ng1361 ng1351 ng1373 [32642]
+101- 1
+1-10 1
+.names pg35 ng1361 ng1351 ng1373 [32644]
+101- 1
+1-10 1
+.names ng13242 [4429] [4431] [32644] [32647]
+-1-- 1
+--1- 1
+1--1 1
+.names pg35 ng2070 ng1996 ng2084 [32651]
+11-1 1
+1-11 1
+.names ng26759 ng14438 [32651] [32652]
+1-1 1
+-11 1
+.names pg35 ng2070 ng1996 ng2084 [32653]
+1--0 1
+100- 1
+.names ng26759 ng14438 [32653] [32654]
+1-1 1
+-11 1
+.names ng2084 pg35 [32655]
+11 1
+.names ng26759 ng14438 [4421] [32655] [32656]
+--1- 1
+00-1 1
+.names pg35 ng691 ng11607 [32661]
+101 1
+.names ng691 pg35 [32662]
+11 1
+.names ng11607 [4414] [4417] [32662] [32664]
+-1-- 1
+--1- 1
+0--1 1
+.names ng4521 pg35 [32665]
+01 1
+.names pg35 ng4515 ng4527 ng4521 [32667]
+0-1- 1
+11-1 1
+.names ng1862 ng1936 [32668]
+0- 1
+-0 1
+.names ng1882 pg35 [32669]
+11 1
+.names pg35 ng26725 ng17401 [32668] [32670]
+11-0 1
+1-10 1
+.names ng93 ng4349 ng4358 ng29503 [32672]
+1111 1
+.names pg35 ng6336 ng23949 [32675]
+100 1
+.names pg35 ng6336 ng23949 [32677]
+111 1
+.names pg35 ng2841 ng4082 [32683]
+10- 1
+0-1 1
+.names pg35 pg7916 ng1178 ng962 [32689]
+0--1 1
+111- 1
+.names ng3965 pg35 [32694]
+11 1
+.names pg35 ng4284 ng4180 [32695]
+11- 1
+1-0 1
+.names ng914 pg35 [32699]
+01 1
+.names pg35 pg12919 ng914 [32700]
+111 1
+.names pg35 ng4284 ng4180 [32702]
+11- 1
+1-0 1
+.names ng5551 pg35 [32703]
+11 1
+.names ng1373 pg35 [32706]
+11 1
+.names ng25917 [4361] [4669] [32706] [32707]
+-1-- 1
+1--1 1
+--11 1
+.names pg9048 ng626 ng559 [32708]
+-0- 1
+1-0 1
+.names pg35 pg9048 ng559 ng632 [32710]
+10-1 1
+1-11 1
+.names ng632 pg35 [32711]
+01 1
+.names pg72 pg35 ng4581 ng59 [32717]
+111- 1
+-111 1
+.names pg73 pg35 ng4495 ng4581 [32718]
+-01- 1
+--10 1
+01-1 1
+.names pg35 ng2153 ng2227 ng2241 [32719]
+1--0 1
+100- 1
+.names ng26703 ng17321 [32719] [32720]
+1-1 1
+-11 1
+.names pg35 ng2153 ng2227 ng2241 [32721]
+11-1 1
+1-11 1
+.names ng26703 ng17321 [32721] [32722]
+1-1 1
+-11 1
+.names ng2241 pg35 [32723]
+11 1
+.names ng26703 ng17321 [4343] [32723] [32724]
+--1- 1
+00-1 1
+.names pg35 ng2307 ng2319 ng2351 [32728]
+1100 1
+.names pg35 ng2342 ng2319 ng2311 [32731]
+1011 1
+.names pg35 ng2342 ng2319 ng2295 [32733]
+1101 1
+.names ng2342 ng2351 ng2303 [32734]
+011 1
+.names ng2370 pg35 [32735]
+11 1
+.names ng2315 pg35 [32736]
+11 1
+.names ng2299 ng25349 ng25435 [32736] [32740]
+10-- 1
+--01 1
+.names [4332] [4333] [4334] [4339] [32741]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng2841 ng2748 [32745]
+10- 1
+0-1 1
+.names ng2514 pg35 [32747]
+11 1
+.names ng2763 pg35 [32749]
+01 1
+.names ng2763 pg35 [32750]
+11 1
+.names pg35 ng2759 ng2841 [32751]
+01- 1
+1-0 1
+.names pg35 ng4284 ng4180 [32753]
+11- 1
+1-0 1
+.names ng6645 pg35 [32754]
+11 1
+.names pg35 ng3857 ng3863 ng3869 [32757]
+1110 1
+.names ng2629 pg35 [32758]
+11 1
+.names ng26793 ng14506 [4309] [32758] [32760]
+--1- 1
+00-1 1
+.names pg35 ng3639 ng23309 [32762]
+100 1
+.names pg35 ng3639 ng23309 [32764]
+111 1
+.names ng269 pg35 [32766]
+11 1
+.names pg14147 pg35 [32767]
+11 1
+.names pg35 ng4284 ng4180 [32769]
+11- 1
+1-0 1
+.names ng3957 pg35 [32770]
+11 1
+.names pg35 pg7916 ng1171 ng1183 [32775]
+0-1- 1
+10-1 1
+1-01 1
+1110 1
+.names pg35 ng4669 ng13330 [32777]
+100 1
+.names pg35 ng4669 ng13330 [32779]
+111 1
+.names ng31003 ng10831 [4291] [32777] [32780]
+--1- 1
+10-1 1
+.names pg35 ng4284 ng4180 [32781]
+11- 1
+1-0 1
+.names ng3602 pg35 [32782]
+11 1
+.names ng3227 pg35 [32784]
+11 1
+.names pg35 ng4284 ng4180 [32785]
+11- 1
+1-0 1
+.names ng1996 pg35 [32787]
+11 1
+.names ng2036 pg35 [32795]
+01 1
+.names pg35 ng2791 ng2795 ng12377 [32798]
+01-- 1
+1-10 1
+.names ng6049 pg35 [32802]
+01 1
+.names ng6049 pg35 [32804]
+11 1
+.names pg35 ng4141 ng2841 [32808]
+01- 1
+1-0 1
+.names pg35 pg12923 ng1252 [32810]
+111 1
+.names ng1252 pg35 [32811]
+01 1
+.names ng5224 pg35 [32817]
+11 1
+.names pg35 ng4284 ng4180 [32818]
+11- 1
+1-0 1
+.names pg35 ng1668 ng1636 ng112 [32823]
+10-1 1
+1-11 1
+.names pg35 ng1668 ng1636 ng112 [32825]
+1100 1
+.names ng1644 pg35 [32826]
+11 1
+.names pg35 ng5170 ng5176 ng5164 [32830]
+1101 1
+.names ng1536 pg35 [32832]
+11 1
+.names pg35 ng1532 ng1413 ng1536 [32834]
+01-- 1
+1-01 1
+.names ng5228 pg35 [32836]
+11 1
+.names pg35 ng4284 ng4180 [32837]
+11- 1
+1-0 1
+.names ng2331 ng2361 [32841]
+0- 1
+-1 1
+.names pg35 ng17405 ng26737 [32841] [32842]
+11-0 1
+1-10 1
+.names ng2303 pg35 [32843]
+11 1
+.names pg35 ng336 ng305 [32846]
+01- 1
+1-1 1
+.names pg35 ng5644 ng23909 [32851]
+100 1
+.names pg35 ng5644 ng23909 [32853]
+111 1
+.names pg35 ng4284 ng4180 [32855]
+11- 1
+1-0 1
+.names ng3953 pg35 [32856]
+11 1
+.names ng164 pg35 [32858]
+11 1
+.names ng164 pg35 [32860]
+01 1
+.names ng23042 [4204] [28708] [32858] [32861]
+-1-- 1
+1-01 1
+.names pg35 ng14367 [7041] [29097] [32862]
+1-1- 1
+11-1 1
+.names ng1648 pg35 [32863]
+11 1
+.names ng27738 [4200] [32862] [32865]
+-1- 1
+0-1 1
+.names pg35 ng4284 ng4180 [32866]
+11- 1
+1-0 1
+.names ng6295 pg35 [32867]
+11 1
+.names ng1792 pg35 [32869]
+11 1
+.names pg35 ng14367 [7257] [28834] [32870]
+1-1- 1
+11-1 1
+.names ng1783 pg35 [32871]
+11 1
+.names ng27775 [4193] [32870] [32873]
+-1- 1
+0-1 1
+.names pg35 ng26793 ng14506 ng11978 [32874]
+11-1 1
+1-11 1
+.names ng2583 pg35 [32875]
+11 1
+.names pg35 [28555] [28556] [32878]
+111 1
+.names ng6395 pg35 [32879]
+01 1
+.names ng6395 pg35 [32881]
+11 1
+.names pg35 pg11678 ng763 ng736 [32884]
+101- 1
+1-11 1
+.names ng763 pg35 [32885]
+01 1
+.names ng1592 pg35 [32887]
+11 1
+.names pg35 ng1636 ng1632 ng25337 [32891]
+1-11 1
+10-0 1
+.names pg35 pg11678 ng744 ng736 [32893]
+101- 1
+1-11 1
+.names ng744 pg35 [32894]
+01 1
+.names ng1448 pg35 [32898]
+11 1
+.names ng1442 ng1454 ng1489 [32899]
+11- 1
+-11 1
+.names ng1448 pg35 [32902]
+01 1
+.names ng1442 ng1454 ng1489 [32903]
+11- 1
+-11 1
+.names pg35 ng1448 ng1442 ng1489 [32907]
+1100 1
+.names pg35 ng1448 ng1442 ng1489 [32910]
+1000 1
+.names pg35 ng1478 ng1454 ng13273 [32913]
+01-- 1
+1-11 1
+.names ng13378 ng13273 [32907] [32910] [32914]
+001- 1
+10-1 1
+.names ng2361 pg35 [32917]
+01 1
+.names ng17405 ng26737 ng28799 [32917] [32919]
+1-01 1
+-101 1
+.names ng3566 pg35 [32921]
+11 1
+.names pg35 ng4284 ng4180 [32922]
+11- 1
+1-0 1
+.names pg35 ng3506 ng3518 ng3512 [32927]
+1101 1
+.names ng3835 pg35 [32928]
+01 1
+.names ng3835 pg35 [32929]
+11 1
+.names ng2791 pg35 [32933]
+01 1
+.names ng2724 ng2729 ng11405 [32933] [32934]
+0101 1
+.names ng85 ng29503 ng11405 [28567] [32936]
+0-00 1
+-000 1
+.names ng2783 pg35 [32937]
+11 1
+.names ng11405 [4137] [28567] [32937] [32938]
+-1-- 1
+1--1 1
+--11 1
+.names ng85 ng29503 [32934] [32938] [32939]
+---1 1
+0-1- 1
+-01- 1
+.names pg35 ng4284 ng4180 [32940]
+11- 1
+1-0 1
+.names ng6243 pg35 [32941]
+11 1
+.names ng239 pg35 [32943]
+11 1
+.names pg14125 pg35 [32944]
+11 1
+.names ng2476 ng2485 [32948]
+0- 1
+-1 1
+.names ng2465 pg35 [32949]
+01 1
+.names pg35 ng2421 ng2461 ng25476 [32953]
+1-11 1
+11-0 1
+.names pg35 ng3288 ng23286 [32955]
+100 1
+.names pg35 ng3288 ng23286 [32957]
+111 1
+.names ng1263 ng22862 ng25895 [4115] [32961]
+---1 1
+111- 1
+.names pg35 ng4664 ng11006 [32963]
+110 1
+.names pg35 ng4664 ng11006 [32965]
+101 1
+.names ng31003 ng10831 [4112] [32963] [32966]
+--1- 1
+10-1 1
+.names pg35 ng2070 ng112 ng2040 [32969]
+101- 1
+1-11 1
+.names pg35 ng2070 ng112 ng2040 [32971]
+1100 1
+.names ng2047 pg35 [32972]
+11 1
+.names ng4434 ng4392 [32975]
+11 1
+.names pg35 ng4443 ng4434 [32976]
+11- 1
+0-1 1
+.names pg35 pg9048 ng559 ng572 [32978]
+10-1 1
+1-11 1
+.names ng572 pg35 [32979]
+01 1
+.names ng3990 pg35 [32981]
+01 1
+.names ng3990 pg35 [32983]
+11 1
+.names ng28484 ng23342 [4099] [32981] [32985]
+--1- 1
+00-1 1
+.names pg35 ng837 ng812 [32987]
+110 1
+.names pg35 ng837 ng812 [32989]
+111 1
+.names ng3684 pg35 [32991]
+11 1
+.names ng3689 pg16656 [32992]
+01 1
+.names ng3703 ng3639 ng3554 [32993]
+101 1
+.names ng3689 pg16924 [32994]
+11 1
+.names ng3703 ng3639 ng3566 [32995]
+101 1
+.names ng3703 ng3639 ng3542 [32997]
+101 1
+.names pg16627 ng3703 ng3639 ng3602 [32999]
+1001 1
+.names ng3689 pg14451 [33000]
+11 1
+.names ng3703 ng3538 ng3639 [33001]
+010 1
+.names ng3546 ng3689 [33002]
+11 1
+.names ng3703 ng3680 ng3639 [33003]
+010 1
+.names pg13926 ng3703 ng3570 ng3639 [33005]
+1011 1
+.names pg16744 ng3586 ng3703 ng3639 [33007]
+1111 1
+.names ng3689 pg14451 [33008]
+01 1
+.names ng3703 ng3639 ng3550 [33009]
+011 1
+.names ng3689 pg16722 [33010]
+11 1
+.names ng3703 ng3639 ng3598 [33011]
+111 1
+.names ng3689 pg13881 [33012]
+11 1
+.names ng3703 ng3639 ng3582 [33013]
+011 1
+.names ng3689 pg16924 [33014]
+01 1
+.names ng3574 ng3703 ng3639 [33015]
+111 1
+.names [32992] [32993] [32994] [32995] [33016]
+11-- 1
+--11 1
+.names pg11388 ng3689 [32997] [32999] [33017]
+111- 1
+11-1 1
+00-1 1
+.names [33000] [33001] [33002] [33003] [33018]
+11-- 1
+--11 1
+.names pg11388 ng3689 [33005] [33007] [33019]
+111- 1
+001- 1
+11-1 1
+00-1 1
+.names [33008] [33009] [33010] [33011] [33020]
+11-- 1
+--11 1
+.names [33012] [33013] [33014] [33015] [33021]
+11-- 1
+--11 1
+.names [33021] [33020] [33024]
+1- 1
+-1 1
+.names [33016] [33017] [33018] [33019] [33025]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng3689 pg16656 [33026]
+11 1
+.names ng3703 ng3639 ng3614 [33027]
+111 1
+.names pg16744 ng3594 ng3703 ng3639 [33029]
+1110 1
+.names ng3689 pg16722 [33030]
+01 1
+.names ng3606 ng3703 ng3639 [33031]
+110 1
+.names pg13926 ng3703 ng3578 ng3639 [33033]
+1010 1
+.names ng3689 pg13881 [33034]
+01 1
+.names ng3703 ng3639 ng3590 [33035]
+001 1
+.names pg16627 ng3610 ng3703 ng3639 [33037]
+1101 1
+.names ng3689 pg11388 [33038]
+01 1
+.names ng3703 ng3639 ng3558 [33039]
+111 1
+.names ng3562 ng3689 [33040]
+10 1
+.names ng3703 ng3680 ng3639 [33041]
+011 1
+.names ng11389 [33026] [33027] [33029] [33042]
+-11- 1
+1--1 1
+.names ng11389 [33030] [33031] [33033] [33043]
+-11- 1
+1--1 1
+.names ng11389 [33034] [33035] [33037] [33044]
+-11- 1
+1--1 1
+.names [33038] [33039] [33040] [33041] [33045]
+11-- 1
+--11 1
+.names [33042] [33043] [33044] [33045] [33048]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 [6966] [6967] [29216] [33049]
+11-- 1
+1-1- 1
+1--1 1
+.names pg35 pg9048 ng559 ng586 [33054]
+10-1 1
+1-11 1
+.names ng586 pg35 [33055]
+01 1
+.names pg35 ng2610 ng2619 ng2587 [33061]
+100- 1
+1-01 1
+.names pg35 ng14367 [5887] [31005] [33062]
+1-1- 1
+11-1 1
+.names ng2587 pg35 [33063]
+11 1
+.names ng27933 [4053] [33062] [33065]
+-1- 1
+0-1 1
+.names pg35 ng4284 ng4180 [33066]
+11- 1
+1-0 1
+.names ng6271 pg35 [33067]
+11 1
+.names ng2020 pg35 [33069]
+11 1
+.names pg35 ng26759 ng14438 [32138] [33070]
+11-0 1
+1-10 1
+.names ng246 pg35 [33072]
+11 1
+.names ng460 pg35 [33073]
+11 1
+.names ng3247 pg35 [33075]
+11 1
+.names pg35 ng4284 ng4180 [33076]
+11- 1
+1-0 1
+.names pg35 ng5073 ng5077 ng5084 [33081]
+0-1- 1
+1010 1
+.names pg91 pg35 ng2965 ng2955 [33083]
+01-- 1
+-11- 1
+-0-1 1
+.names pg35 ng1322 ng1404 [33085]
+100 1
+.names pg35 ng1322 ng1404 [33087]
+101 1
+.names pg35 ng1395 ng13134 [33085] [33088]
+01-- 1
+-101 1
+.names pg35 pg9048 ng559 ng617 [33090]
+10-1 1
+1-11 1
+.names ng617 pg35 [33091]
+01 1
+.names pg35 ng1834 ng1840 [33096]
+100 1
+.names pg35 ng1834 ng1840 [33098]
+111 1
+.names ng1844 pg35 [33099]
+11 1
+.names ng1955 pg35 [33102]
+11 1
+.names ng671 pg35 [33104]
+11 1
+.names ng8806 ng11185 [30776] [33104] [33105]
+1--1 1
+-0-1 1
+--01 1
+.names ng671 pg35 [33106]
+01 1
+.names ng8806 ng11185 [30776] [33106] [33107]
+0111 1
+.names pg35 pg12923 ng1270 [33109]
+111 1
+.names pg35 ng1263 ng25895 [33109] [33111]
+01-- 1
+-0-1 1
+--11 1
+.names ng5925 pg35 [33112]
+11 1
+.names pg35 ng4284 ng4180 [33113]
+11- 1
+1-0 1
+.names ng2795 pg35 [33115]
+01 1
+.names ng2724 ng2729 ng11405 [33115] [33116]
+1101 1
+.names ng85 ng29503 ng11405 [29883] [33118]
+0-00 1
+-000 1
+.names ng2787 pg35 [33119]
+11 1
+.names ng11405 [3998] [29883] [33119] [33120]
+-1-- 1
+1--1 1
+--11 1
+.names ng85 ng29503 [33116] [33120] [33121]
+---1 1
+0-1- 1
+-01- 1
+.names pg35 ng4284 ng4180 [33122]
+11- 1
+1-0 1
+.names ng6601 pg35 [33123]
+11 1
+.names ng12716 ng12680 [3994] [33122] [33124]
+--1- 1
+11-1 1
+.names ng4141 ng4064 ng4057 ng4082 [33126]
+1--- 1
+-1-- 1
+--0- 1
+---1 1
+.names ng4145 pg35 [33127]
+11 1
+.names ng4119 pg35 [33128]
+11 1
+.names ng13806 [3991] [33126] [33127] [33129]
+-1-- 1
+1-01 1
+.names pg35 ng5835 ng5841 [33131]
+100 1
+.names pg35 ng5835 ng5841 [33133]
+111 1
+.names pg35 ng5845 ng10869 [33133] [33136]
+--11 1
+110- 1
+.names ng3550 pg35 [33137]
+11 1
+.names pg35 ng4284 ng4180 [33138]
+11- 1
+1-0 1
+.names ng11483 ng11571 [3984] [33137] [33139]
+--1- 1
+0--1 1
+-0-1 1
+.names ng1687 pg35 [33140]
+11 1
+.names pg35 ng1700 ng1706 [33143]
+100 1
+.names pg35 ng1700 ng1706 [33145]
+111 1
+.names ng1710 pg35 [33146]
+11 1
+.names pg35 ng5142 ng5148 [33150]
+100 1
+.names pg35 ng5142 ng5148 [33152]
+111 1
+.names pg35 ng5152 ng10823 [33152] [33155]
+--11 1
+110- 1
+.names ng2060 pg35 [33156]
+11 1
+.names pg35 ng14367 [6319] [30342] [33157]
+1-1- 1
+11-1 1
+.names ng2051 pg35 [33158]
+11 1
+.names ng27882 [3969] [33157] [33160]
+-1- 1
+0-1 1
+.names ng5046 pg35 [33161]
+11 1
+.names pg35 ng4284 ng4180 [33165]
+11- 1
+1-0 1
+.names ng3614 pg35 [33166]
+11 1
+.names ng5272 pg35 [33168]
+11 1
+.names pg35 ng4284 ng4180 [33169]
+11- 1
+1-0 1
+.names pg35 ng4349 ng4358 ng12925 [33172]
+1100 1
+.names pg35 ng4349 ng4358 ng12925 [33174]
+101- 1
+1-11 1
+.names ng5260 pg35 [33176]
+11 1
+.names pg35 ng4284 ng4180 [33177]
+11- 1
+1-0 1
+.names pg35 ng17405 ng26737 ng9700 [33180]
+11-1 1
+1-11 1
+.names ng2299 pg35 [33181]
+11 1
+.names pg35 ng4284 ng4180 [33183]
+11- 1
+1-0 1
+.names ng3905 pg35 [33184]
+11 1
+.names pg35 pg17577 pg17674 pg14662 [33189]
+1000 1
+.names pg35 pg17577 pg17674 pg14662 [33194]
+1011 1
+.names pg35 pg17577 pg17674 pg14662 [33199]
+1111 1
+.names pg17674 pg14662 pg17519 pg12238 [33200]
+0-11 1
+-011 1
+.names pg35 pg17577 pg14662 pg17519 [33204]
+1010 1
+.names ng1917 pg35 [33208]
+11 1
+.names pg35 ng14367 [6655] [29571] [33209]
+1-1- 1
+11-1 1
+.names ng27833 [3924] [33209] [33211]
+-1- 1
+0-1 1
+.names pg35 ng4284 ng4180 [33212]
+11- 1
+1-0 1
+.names ng5965 pg35 [33213]
+11 1
+.names ng5933 pg35 [33215]
+11 1
+.names pg35 ng4284 ng4180 [33216]
+11- 1
+1-0 1
+.names pg35 ng4284 ng4180 [33218]
+11- 1
+1-0 1
+.names ng5611 pg35 [33219]
+11 1
+.names ng4555 ng4561 [33222]
+11 1
+.names pg73 pg72 ng4558 ng4564 [33223]
+0011 1
+.names pg73 pg72 pg35 [33225]
+1-1 1
+-11 1
+.names [3910] [3912] [33222] [33223] [33227]
+1--- 1
+-1-- 1
+--11 1
+.names pg35 ng26673 ng9586 ng17292 [33230]
+111- 1
+1-11 1
+.names ng1604 pg35 [33231]
+11 1
+.names pg35 ng26759 ng14438 ng9755 [33233]
+11-1 1
+1-11 1
+.names ng2008 pg35 [33234]
+11 1
+.names ng2433 pg35 [33238]
+11 1
+.names pg35 ng26770 ng17424 ng9762 [33239]
+11-1 1
+1-11 1
+.names ng6637 pg35 [33241]
+11 1
+.names pg35 ng4284 ng4180 [33242]
+11- 1
+1-0 1
+.names ng3558 pg35 [33244]
+11 1
+.names pg35 ng4284 ng4180 [33245]
+11- 1
+1-0 1
+.names ng11527 ng11571 [3889] [33244] [33246]
+--1- 1
+0--1 1
+-0-1 1
+.names pg35 ng157 ng23042 [33248]
+111 1
+.names ng157 pg35 [33249]
+01 1
+.names ng28353 [3886] [28711] [33248] [33250]
+-1-- 1
+0--1 1
+--11 1
+.names pg35 ng4284 ng4180 [33251]
+11- 1
+1-0 1
+.names ng5961 pg35 [33252]
+11 1
+.names pg35 ng4284 ng4180 [33254]
+11- 1
+1-0 1
+.names ng6629 pg35 [33255]
+11 1
+.names ng1216 pg35 [33257]
+01 1
+.names ng1216 pg35 [33259]
+11 1
+.names ng11130 ng11148 [3874] [33257] [33261]
+--1- 1
+00-1 1
+.names pg35 ng4284 ng4180 [33262]
+11- 1
+1-0 1
+.names ng5208 pg35 [33263]
+11 1
+.names ng12405 ng12492 [3868] [33262] [33264]
+--1- 1
+11-1 1
+.names pg35 ng1728 ng1816 ng1802 [33265]
+1-0- 1
+10-0 1
+.names ng17317 ng26694 [33265] [33266]
+1-1 1
+-11 1
+.names pg35 ng1728 ng1816 ng1802 [33267]
+111- 1
+1-11 1
+.names ng17317 ng26694 [33267] [33268]
+1-1 1
+-11 1
+.names ng1816 pg35 [33269]
+11 1
+.names ng17317 ng26694 [3860] [33269] [33270]
+--1- 1
+00-1 1
+.names pg35 ng2399 ng2393 [33273]
+100 1
+.names pg35 ng2399 ng2393 [33275]
+111 1
+.names ng2403 pg35 [33276]
+11 1
+.names ng29503 ng14367 [6172] [30555] [33280]
+1-1- 1
+11-1 1
+.names pg35 ng110 ng2217 ng2208 [33282]
+110- 1
+11-1 1
+.names pg35 ng110 ng2217 ng2208 [33284]
+1010 1
+.names ng2223 pg35 [33285]
+11 1
+.names ng26171 [3849] [33280] [33282] [33286]
+-1-- 1
+1-11 1
+.names ng26171 [33280] [33284] [33285] [33287]
+0--1 1
+-0-1 1
+111- 1
+.names pg35 ng4284 ng4180 [33288]
+11- 1
+1-0 1
+.names ng5957 pg35 [33289]
+11 1
+.names ng832 pg35 [33291]
+01 1
+.names ng832 pg35 [33293]
+11 1
+.names ng2461 pg35 [33296]
+01 1
+.names pg35 ng2811 ng2823 ng12377 [33299]
+01-- 1
+1-10 1
+.names pg35 ng1783 ng1792 ng1760 [33302]
+100- 1
+1-01 1
+.names ng1760 pg35 [33303]
+11 1
+.names pg35 ng14367 [7257] [28834] [33304]
+1-1- 1
+11-1 1
+.names ng27775 [3829] [33304] [33306]
+-1- 1
+0-1 1
+.names ng2208 ng2217 [33307]
+0- 1
+-1 1
+.names ng2193 pg35 [33308]
+11 1
+.names pg35 ng2197 ng2153 ng25396 [33312]
+10-0 1
+1-10 1
+.names pg35 ng4477 ng4581 ng59 [33316]
+01-- 1
+1-11 1
+.names pg73 pg72 pg35 ng4581 [33317]
+0-11 1
+-011 1
+.names pg35 ng4284 ng4180 [33319]
+11- 1
+1-0 1
+.names ng3582 pg35 [33320]
+11 1
+.names pg35 ng4608 ng30583 [6408] [33325]
+1000 1
+.names pg35 ng4608 ng30583 [6408] [33327]
+1100 1
+.names pg35 ng1926 ng1917 ng1894 [33330]
+100- 1
+10-1 1
+.names ng1894 pg35 [33331]
+11 1
+.names pg35 ng14367 [6655] [29571] [33332]
+1-1- 1
+11-1 1
+.names ng27833 [3805] [33332] [33334]
+-1- 1
+0-1 1
+.names ng5011 pg35 [33335]
+11 1
+.names pg35 [7046] [7047] [29091] [33336]
+11-- 1
+1-1- 1
+1--1 1
+.names pg35 pg9817 pg9743 ng6494 [33343]
+0--1 1
+1010 1
+.names pg35 ng4284 ng4180 [33344]
+11- 1
+1-0 1
+.names ng5220 pg35 [33345]
+11 1
+.names ng2342 ng2319 ng2370 ng2384 [33349]
+--10 1
+101- 1
+.names ng2384 pg35 [33350]
+11 1
+.names pg35 ng2370 ng22432 ng14679 [33351]
+01-- 1
+1011 1
+.names ng4521 pg35 [33353]
+01 1
+.names pg35 ng4527 ng4521 ng12228 [33354]
+0-1- 1
+-011 1
+-110 1
+.names ng1489 pg35 [33355]
+11 1
+.names ng1442 pg35 [33357]
+01 1
+.names ng2265 pg35 [33362]
+11 1
+.names ng1974 pg35 [33364]
+11 1
+.names pg35 ng1146 ng1099 [33366]
+100 1
+.names pg35 ng1105 ng1124 ng13307 [33370]
+01-- 1
+1-11 1
+.names ng2465 ng2421 [33372]
+1- 1
+-0 1
+.names pg35 ng26770 ng17424 [33372] [33373]
+11-0 1
+1-10 1
+.names ng2429 pg35 [33374]
+11 1
+.names pg35 ng1974 ng1968 [33377]
+100 1
+.names ng1968 ng1974 [33378]
+11 1
+.names ng1978 pg35 [33379]
+11 1
+.names ng3199 pg35 [33382]
+11 1
+.names pg35 ng4284 ng4180 [33383]
+11- 1
+1-0 1
+.names ng11514 ng11435 [3752] [33382] [33384]
+--1- 1
+0--1 1
+-0-1 1
+.names pg35 ng17317 ng26694 ng9640 [33385]
+11-1 1
+1-11 1
+.names ng1740 pg35 [33386]
+11 1
+.names pg35 ng4284 ng4180 [33392]
+11- 1
+1-0 1
+.names ng6617 pg35 [33393]
+11 1
+.names ng2185 ng2250 ng2236 ng2208 [33397]
+-01- 1
+0-11 1
+.names ng2250 pg35 [33398]
+11 1
+.names pg35 ng2236 ng22384 ng14642 [33399]
+01-- 1
+1011 1
+.names ng29503 ng14367 [7030] [29111] [33401]
+1-1- 1
+11-1 1
+.names pg35 ng110 ng2342 ng2351 [33403]
+111- 1
+11-0 1
+.names pg35 ng110 ng2342 ng2351 [33405]
+1001 1
+.names ng2357 pg35 [33406]
+11 1
+.names ng26195 [3727] [33401] [33403] [33407]
+-1-- 1
+1-11 1
+.names ng26195 [33401] [33405] [33406] [33408]
+0--1 1
+-0-1 1
+111- 1
+.names pg35 ng5115 ng20682 ng11111 [33410]
+101- 1
+1-11 1
+.names pg35 ng5115 ng20682 ng11111 [33412]
+1110 1
+.names ng5115 pg35 [33413]
+11 1
+.names pg35 ng4284 ng4180 [33416]
+11- 1
+1-0 1
+.names ng5595 pg35 [33417]
+11 1
+.names pg35 ng2841 ng2729 [33421]
+10- 1
+0-1 1
+.names pg35 ng4653 ng4688 ng4659 [33424]
+1110 1
+.names pg35 ng4653 ng4688 ng4659 [33426]
+10-1 1
+1-01 1
+.names ng31003 ng10831 [3712] [33424] [33427]
+--1- 1
+10-1 1
+.names ng1135 pg35 [33428]
+11 1
+.names ng1146 ng1094 ng1099 [33429]
+11- 1
+-11 1
+.names ng1135 pg35 [33432]
+01 1
+.names ng1146 ng1094 ng1099 [33433]
+11- 1
+-11 1
+.names pg35 ng1135 ng1146 ng1099 [33437]
+1100 1
+.names pg35 ng1135 ng1146 ng1099 [33440]
+1000 1
+.names pg35 ng1094 ng1099 ng13846 [33443]
+0-1- 1
+11-1 1
+.names ng13336 ng13846 [33437] [33440] [33444]
+001- 1
+10-1 1
+.names pg35 pg7946 ng1526 ng1521 [33450]
+0-1- 1
+10-1 1
+.names pg35 pg11678 ng736 ng772 [33452]
+10-1 1
+1-11 1
+.names ng772 pg35 [33453]
+01 1
+.names ng2555 ng2599 [33455]
+0- 1
+-1 1
+.names pg35 ng26793 ng14506 [33455] [33456]
+11-0 1
+1-10 1
+.names ng2563 pg35 [33457]
+11 1
+.names pg35 ng4284 ng4180 [33459]
+11- 1
+1-0 1
+.names ng3598 pg35 [33460]
+11 1
+.names pg35 ng294 ng23204 [33463]
+111 1
+.names ng294 pg35 [33464]
+01 1
+.names pg35 ng1379 ng15748 [33472]
+100 1
+.names ng1379 pg35 [33473]
+11 1
+.names pg35 ng4284 ng4180 [33475]
+11- 1
+1-0 1
+.names ng5587 pg35 [33476]
+11 1
+.names pg13272 pg19357 ng1333 [33480]
+1-- 1
+-1- 1
+--1 1
+.names ng6291 pg35 [33485]
+11 1
+.names pg35 ng4284 ng4180 [33486]
+11- 1
+1-0 1
+.names pg35 ng2946 ng2941 ng2955 [33489]
+11-- 1
+0-1- 1
+1--1 1
+.names pg35 ng28220 ng22585 [33489] [33492]
+---1 1
+11-- 1
+1-1- 1
+.names pg35 ng3106 ng3111 [33494]
+101 1
+.names ng3111 ng3106 [33495]
+01 1
+.names pg35 ng3115 ng23067 [33495] [33497]
+--01 1
+111- 1
+.names pg35 ng1720 ng1714 [33499]
+100 1
+.names ng1724 pg35 [33501]
+11 1
+.names ng1720 ng1714 ng25275 [33501] [33503]
+--11 1
+110- 1
+.names pg35 ng6173 ng6167 [33505]
+100 1
+.names ng6167 ng6173 [33507]
+11 1
+.names pg35 ng6177 ng23699 [33507] [33509]
+--01 1
+111- 1
+.names ng4593 pg35 [33510]
+01 1
+.names ng4593 pg35 [33512]
+11 1
+.names ng1024 pg35 [33515]
+11 1
+.names ng25911 [3642] [7652] [33515] [33517]
+-1-- 1
+1--1 1
+--11 1
+.names pg35 ng5057 [29550] [29551] [33519]
+1100 1
+.names ng5057 pg35 [33520]
+01 1
+.names ng4776 pg35 [33522]
+01 1
+.names ng4801 ng4793 ng10831 [33522] [33523]
+1111 1
+.names ng4776 pg35 [33524]
+11 1
+.names ng4801 ng4793 ng10831 [33524] [33525]
+0--1 1
+-0-1 1
+--01 1
+.names ng28336 ng13464 [3632] [33523] [33526]
+--1- 1
+11-1 1
+.names ng5591 pg35 [33527]
+11 1
+.names pg35 ng4284 ng4180 [33528]
+11- 1
+1-0 1
+.names pg35 pg11678 ng736 ng807 [33533]
+10-1 1
+1-11 1
+.names ng807 pg35 [33534]
+01 1
+.names ng1592 ng1636 [33536]
+0- 1
+-1 1
+.names pg35 ng26673 ng17292 [33536] [33537]
+11-0 1
+1-10 1
+.names ng1600 pg35 [33538]
+11 1
+.names pg35 ng26759 ng14438 ng11956 [33544]
+11-1 1
+1-11 1
+.names ng2024 pg35 [33545]
+11 1
+.names pg8919 pg8918 pg11770 pg8920 [33551]
+0000 1
+.names pg8915 pg8917 pg8916 ng4235 [33552]
+0000 1
+.names pg8870 ng4235 [33553]
+01 1
+10 1
+.names pg35 ng4145 ng4253 ng4164 [33554]
+100- 1
+1-10 1
+.names pg35 ng4145 ng4253 ng4164 [33555]
+110- 1
+11-1 1
+1-11 1
+.names pg35 ng2841 ng2741 [33558]
+110 1
+.names pg35 ng2841 ng2741 [33560]
+111 1
+.names pg35 ng2735 ng17297 [33558] [33561]
+01-- 1
+-101 1
+.names pg35 ng14367 [6172] [30555] [33562]
+1-1- 1
+11-1 1
+.names ng2217 pg35 [33563]
+11 1
+.names ng2208 pg35 [33564]
+11 1
+.names ng27796 [3595] [33562] [33566]
+-1- 1
+0-1 1
+.names ng1714 pg35 [33571]
+01 1
+.names ng1714 pg35 [33572]
+11 1
+.names pg14421 pg11349 [33579]
+01 1
+.names pg35 pg16624 pg16603 pg13895 [33580]
+1001 1
+.names pg35 pg16718 pg16624 pg16603 [33585]
+1000 1
+.names pg35 pg9048 ng559 ng595 [33590]
+10-1 1
+1-11 1
+.names ng595 pg35 [33591]
+01 1
+.names ng27629 [3574] [28803] [33590] [33592]
+-1-- 1
+0--1 1
+--11 1
+.names pg35 ng4284 ng4180 [33593]
+11- 1
+1-0 1
+.names ng3542 pg35 [33594]
+11 1
+.names ng11747 ng11571 [3571] [33593] [33595]
+--1- 1
+11-1 1
+.names pg12350 pg17646 [33600]
+10 1
+.names pg35 pg13068 pg14738 pg17607 [33601]
+1010 1
+.names pg35 pg13068 pg14738 pg17607 [33606]
+1000 1
+.names ng1728 ng1772 [33608]
+0- 1
+-1 1
+.names pg35 ng17317 ng26694 [33608] [33609]
+11-0 1
+1-10 1
+.names ng1736 pg35 [33610]
+11 1
+.names pg35 ng2380 ng2384 [33613]
+110 1
+.names ng2389 pg35 [33615]
+11 1
+.names ng2380 ng2384 ng25473 [33615] [33617]
+--11 1
+010- 1
+.names pg35 ng2575 ng2619 ng2587 [33620]
+1100 1
+.names pg35 ng2610 ng2579 ng2587 [33623]
+1011 1
+.names pg35 ng2610 ng2587 ng2563 [33625]
+1101 1
+.names ng2610 ng2571 ng2619 [33626]
+011 1
+.names ng2583 pg35 [33627]
+11 1
+.names ng2638 pg35 [33628]
+11 1
+.names ng2567 ng25498 ng25439 [33627] [33632]
+1-0- 1
+-0-1 1
+.names [3546] [3547] [3548] [3553] [33633]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng29503 ng14367 [6319] [30342] [33635]
+1-1- 1
+11-1 1
+.names pg35 ng110 ng2051 ng2060 [33637]
+111- 1
+11-0 1
+.names pg35 ng110 ng2051 ng2060 [33639]
+1001 1
+.names ng2066 pg35 [33640]
+11 1
+.names ng26213 [3545] [33635] [33637] [33641]
+-1-- 1
+1-11 1
+.names ng26213 [33635] [33639] [33640] [33642]
+0--1 1
+-0-1 1
+111- 1
+.names pg35 ng4284 ng4180 [33643]
+11- 1
+1-0 1
+.names ng5232 pg35 [33644]
+11 1
+.names pg35 ng4284 ng4180 [33648]
+11- 1
+1-0 1
+.names ng5547 pg35 [33649]
+11 1
+.names ng12798 ng12558 [3533] [33648] [33650]
+--1- 1
+11-1 1
+.names ng4141 ng4064 ng4057 ng4082 [33651]
+1--- 1
+-0-- 1
+--0- 1
+---1 1
+.names ng4122 pg35 [33652]
+11 1
+.names ng4145 pg35 [33653]
+11 1
+.names ng13806 [3530] [33651] [33652] [33654]
+-1-- 1
+0--1 1
+--11 1
+.names pg35 pg19357 ng1404 [33656]
+10- 1
+0-1 1
+.names pg35 pg12923 ng1404 [33657]
+111 1
+100 1
+.names ng1592 ng1668 [33659]
+0- 1
+-0 1
+.names pg35 ng26673 ng17292 [33659] [33660]
+11-0 1
+1-10 1
+.names ng1612 pg35 [33661]
+11 1
+.names ng490 pg35 [33665]
+01 1
+.names ng490 pg35 [33666]
+11 1
+.names pg35 ng482 ng667 ng686 [33667]
+01-- 1
+1-10 1
+.names ng482 ng20000 [33665] [33667] [33668]
+---1 1
+111- 1
+.names pg35 ng3457 ng21024 ng10733 [33670]
+101- 1
+1-11 1
+.names pg35 ng3457 ng21024 ng10733 [33672]
+1110 1
+.names ng3457 pg35 [33673]
+11 1
+.names ng4709 pg35 [33676]
+01 1
+.names ng4709 pg35 [33678]
+11 1
+.names ng28336 ng16173 [3501] [33676] [33680]
+--1- 1
+10-1 1
+.names pg35 ng26770 ng17424 ng11960 [33681]
+11-1 1
+1-11 1
+.names ng2449 pg35 [33682]
+11 1
+.names ng5212 pg35 [33684]
+11 1
+.names pg35 ng4284 ng4180 [33685]
+11- 1
+1-0 1
+.names pg35 ng1821 ng1825 [33688]
+110 1
+.names pg35 ng1821 ng1825 [33690]
+101 1
+.names pg35 ng1830 ng25426 [33690] [33693]
+--01 1
+111- 1
+.names pg35 ng4375 ng4382 [33694]
+110 1
+.names ng4392 pg35 [33695]
+01 1
+.names [3485] [29325] [29326] [33694] [33696]
+1--- 1
+-0-1 1
+--01 1
+.names pg35 pg12919 ng1061 ng1052 [33699]
+100- 1
+11-1 1
+.names pg35 pg19334 pg12919 ng1061 [33700]
+10-- 1
+0--1 1
+1-11 1
+.names pg35 ng2173 ng2185 ng2217 [33703]
+1100 1
+.names pg35 ng2177 ng2185 ng2208 [33706]
+1110 1
+.names pg35 ng2161 ng2185 ng2208 [33708]
+1101 1
+.names ng2217 ng2208 ng2169 [33709]
+101 1
+.names ng2181 pg35 [33710]
+11 1
+.names ng2236 pg35 [33711]
+11 1
+.names ng2165 ng25309 ng25396 [33710] [33715]
+10-- 1
+--01 1
+.names [3465] [3466] [3467] [3471] [33716]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg13049 pg12300 [33720]
+01 1
+.names pg35 pg14694 pg17580 pg17604 [33721]
+1100 1
+.names pg35 pg14694 pg17580 pg17711 [33726]
+1000 1
+.names pg35 ng4284 ng4180 [33728]
+11- 1
+1-0 1
+.names ng6287 pg35 [33729]
+11 1
+.names ng918 pg35 [33735]
+01 1
+.names pg35 pg12919 ng918 [33736]
+111 1
+.names pg35 ng4284 ng4180 [33738]
+11- 1
+1-0 1
+.names ng5945 pg35 [33739]
+11 1
+.names ng2246 pg35 [33743]
+11 1
+.names ng29503 ng25357 [28614] [33745]
+111 1
+.names pg35 ng110 ng1926 ng1917 [33747]
+110- 1
+11-1 1
+.names pg35 ng110 ng1926 ng1917 [33749]
+1010 1
+.names ng1932 pg35 [33750]
+11 1
+.names ng22417 [3442] [33745] [33747] [33751]
+-1-- 1
+1-11 1
+.names ng22417 [33745] [33749] [33750] [33752]
+0--1 1
+-0-1 1
+111- 1
+.names pg35 pg17423 pg10527 ng1589 [33754]
+0--1 1
+101- 1
+.names ng3941 pg35 [33755]
+11 1
+.names pg35 ng4284 ng4180 [33756]
+11- 1
+1-0 1
+.names ng1802 ng1772 [33758]
+1- 1
+-0 1
+.names pg35 ng17317 ng26694 [33758] [33759]
+11-0 1
+1-10 1
+.names ng1744 pg35 [33760]
+11 1
+.names pg35 ng2652 ng2648 [33765]
+110 1
+.names pg35 ng2652 ng2648 [33767]
+101 1
+.names pg35 ng2657 ng25514 [33767] [33770]
+--01 1
+111- 1
+.names [1421] ng4939 ng4818 ng24374 [33771]
+11-- 1
+-11- 1
+-1-0 1
+.names pg35 ng71 ng24374 [28575] [33773]
+1110 1
+.names pg35 ng4933 ng29702 [33773] [33775]
+--11 1
+110- 1
+.names pg35 pg9048 ng559 ng608 [33777]
+10-1 1
+1-11 1
+.names ng608 pg35 [33778]
+01 1
+.names ng31509 [3418] [30328] [33777] [33779]
+-1-- 1
+1--1 1
+--01 1
+.names pg35 ng26725 ng17401 [30477] [33780]
+11-0 1
+1-10 1
+.names ng1886 pg35 [33781]
+11 1
+.names pg35 ng1030 ng1018 ng1008 [33784]
+10-1 1
+1-01 1
+.names pg35 ng1030 ng1018 ng1008 [33786]
+10-1 1
+1-01 1
+.names ng7598 [3407] [3409] [33784] [33789]
+-1-- 1
+--1- 1
+0--1 1
+.names pg35 ng703 ng854 [33794]
+101 1
+.names ng392 pg35 [33795]
+11 1
+.names pg35 ng146 ng13756 [33798]
+100 1
+.names pg35 ng146 ng13756 [33800]
+111 1
+.names pg35 ng2661 ng2667 [33803]
+100 1
+.names ng2667 ng2661 [33804]
+11 1
+.names ng2671 pg35 [33805]
+11 1
+.names ng5909 pg35 [33812]
+11 1
+.names pg35 ng4284 ng4180 [33813]
+11- 1
+1-0 1
+.names ng12609 ng12571 [3389] [33812] [33814]
+--1- 1
+0--1 1
+-0-1 1
+.names ng4349 ng4322 ng4358 [33817]
+000 1
+.names pg90 pg35 ng4332 ng2994 [33818]
+1100 1
+.names pg73 pg72 ng4322 [33820]
+1-0 1
+-10 1
+.names pg35 ng4332 ng4349 ng4358 [33821]
+1000 1
+.names pg73 pg72 ng4322 [33823]
+1-1 1
+-11 1
+.names pg35 ng4332 ng4349 ng4358 [33824]
+1000 1
+.names ng4311 ng4322 [33826]
+10 1
+.names pg35 ng4332 ng4349 ng4358 [33827]
+1100 1
+.names pg35 ng4332 ng4349 ng4358 [33830]
+1000 1
+.names pg35 ng4340 ng4358 [33832]
+101 1
+.names pg35 ng4340 ng4349 ng4358 [33834]
+1010 1
+.names pg35 ng4366 [3384] [33836]
+--1 1
+01- 1
+.names [33817] [33818] [33820] [33821] [33837]
+11-- 1
+--11 1
+.names [33823] [33824] [33826] [33827] [33838]
+11-- 1
+--11 1
+.names ng4322 ng4515 [3385] [33830] [33839]
+--1- 1
+10-1 1
+.names [33836] [33837] [33838] [33839] [33842]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 ng4284 ng4180 [33846]
+11- 1
+1-0 1
+.names ng5607 pg35 [33847]
+11 1
+.names ng632 pg35 [33850]
+01 1
+.names pg9048 ng559 ng562 [33851]
+0-0 1
+-10 1
+.names pg9048 ng559 ng562 [33854]
+0-0 1
+-10 1
+.names pg9048 ng559 ng562 [33857]
+0-1 1
+-11 1
+.names pg9048 ng559 ng562 [33860]
+0-1 1
+-11 1
+.names ng14708 [3370] [33850] [33851] [33862]
+-1-- 1
+1-11 1
+.names pg35 ng4284 ng4180 [33865]
+11- 1
+1-0 1
+.names ng3590 pg35 [33866]
+11 1
+.names pg35 ng2051 ng2060 ng2028 [33869]
+100- 1
+1-01 1
+.names ng2028 pg35 [33870]
+11 1
+.names pg35 ng14367 [6319] [30342] [33871]
+1-1- 1
+11-1 1
+.names ng27882 [3351] [33871] [33873]
+-1- 1
+0-1 1
+.names pg35 ng2675 ng2681 [33875]
+100 1
+.names ng2685 pg35 [33877]
+11 1
+.names ng2675 ng2681 ng25439 [33877] [33879]
+--11 1
+110- 1
+.names pg35 ng3161 ng3155 ng3167 [33886]
+1110 1
+.names ng2331 ng2287 [33887]
+1- 1
+-0 1
+.names pg35 ng17405 ng26737 [33887] [33888]
+11-0 1
+1-10 1
+.names ng2295 pg35 [33889]
+11 1
+.names pg35 ng14367 [6172] [30555] [33895]
+1-1- 1
+11-1 1
+.names ng2208 pg35 [33896]
+11 1
+.names ng27796 [3327] [33895] [33898]
+-1- 1
+0-1 1
+.names ng6263 pg35 [33902]
+11 1
+.names pg35 ng4284 ng4180 [33903]
+11- 1
+1-0 1
+.names pg35 ng4423 ng4575 ng4581 [33908]
+01-- 1
+1-11 1
+.names pg73 pg72 pg35 ng4581 [33909]
+0-11 1
+-011 1
+.names ng3554 pg35 [33912]
+11 1
+.names pg35 ng4284 ng4180 [33913]
+11- 1
+1-0 1
+.names pg35 pg11678 ng736 ng749 [33916]
+10-1 1
+1-11 1
+.names ng749 pg35 [33917]
+01 1
+.names ng24875 [3292] [28810] [33916] [33918]
+-1-- 1
+0--1 1
+--11 1
+.names ng5615 pg35 [33919]
+11 1
+.names pg35 ng4284 ng4180 [33920]
+11- 1
+1-0 1
+.names ng2089 pg35 [33922]
+11 1
+.names pg35 ng4284 ng4180 [33924]
+11- 1
+1-0 1
+.names ng3909 pg35 [33925]
+11 1
+.names ng11626 ng11584 [3281] [33924] [33926]
+--1- 1
+11-1 1
+.names pg35 ng2902 ng2917 [33927]
+01- 1
+1-1 1
+.names pg35 ng2485 ng2453 ng2441 [33931]
+1001 1
+.names pg35 ng2445 ng2476 ng2453 [33934]
+1101 1
+.names pg35 ng2476 ng2453 ng2429 [33936]
+1101 1
+.names ng2449 pg35 [33937]
+11 1
+.names ng2504 pg35 [33938]
+11 1
+.names ng2485 ng2437 ng2476 [33939]
+110 1
+.names ng2433 ng25400 ng25476 [33937] [33943]
+10-- 1
+--01 1
+.names [3267] [3268] [3269] [3274] [33944]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg35 pg16693 pg14518 pg16659 [33949]
+1000 1
+.names pg16775 pg13966 [33950]
+00 1
+.names pg35 pg16693 pg14518 pg11418 [33954]
+1001 1
+.names pg16659 pg13966 [33955]
+01 1
+.names ng2287 pg35 [33956]
+11 1
+.names pg35 ng4284 ng4180 [33960]
+11- 1
+1-0 1
+.names ng6585 pg35 [33961]
+11 1
+.names ng10491 ng12716 [3256] [33960] [33962]
+--1- 1
+11-1 1
+.names pg35 ng4284 ng4180 [33963]
+11- 1
+1-0 1
+.names ng6633 pg35 [33964]
+11 1
+.names pg72 pg35 ng4575 ng4581 [33970]
+11-1 1
+-111 1
+.names pg73 pg35 ng4543 ng4581 [33971]
+-01- 1
+--10 1
+01-1 1
+.names pg35 pg11678 ng736 ng767 [33973]
+10-1 1
+1-11 1
+.names ng767 pg35 [33974]
+01 1
+.names ng28504 [3240] [28813] [33973] [33975]
+-1-- 1
+1--1 1
+--01 1
+.names ng6259 pg35 [33976]
+11 1
+.names pg35 ng4284 ng4180 [33977]
+11- 1
+1-0 1
+.names pg35 ng4284 ng4180 [33979]
+11- 1
+1-0 1
+.names ng3945 pg35 [33980]
+11 1
+.names pg35 ng2841 ng2748 [33983]
+110 1
+.names pg35 ng2841 ng2748 [33985]
+111 1
+.names pg35 ng2279 ng2273 [33988]
+100 1
+.names pg35 ng2279 ng2273 [33990]
+111 1
+.names pg35 ng2283 ng25309 [33990] [33993]
+--01 1
+111- 1
+.names pg35 ng1379 ng1384 ng13242 [33996]
+01-- 1
+1-11 1
+.names pg35 ng4284 ng4180 [33997]
+11- 1
+1-0 1
+.names ng5559 pg35 [33998]
+11 1
+.names pg35 ng4284 ng4180 [34000]
+11- 1
+1-0 1
+.names ng5905 pg35 [34001]
+11 1
+.names pg35 ng5462 ng5467 [34004]
+101 1
+.names ng5467 ng5462 [34005]
+01 1
+.names pg35 ng5471 ng23630 [34005] [34007]
+--01 1
+111- 1
+.names ng2227 ng2197 [34008]
+1- 1
+-0 1
+.names ng2169 pg35 [34009]
+11 1
+.names pg35 ng26703 ng17321 [34008] [34010]
+11-0 1
+1-10 1
+.names ng20841 ng21193 ng20982 ng19968 [34016]
+0100 1
+.names ng20014 ng19919 ng21127 ng21256 [34017]
+0000 1
+.names ng20841 ng21193 ng20982 ng19968 [34022]
+0010 1
+.names ng20014 ng19919 ng21127 ng21256 [34023]
+0000 1
+.names ng20841 ng21193 ng20982 ng19968 [34028]
+0000 1
+.names ng20014 ng19919 ng21127 ng21256 [34029]
+0010 1
+.names ng20841 ng21193 ng20982 ng19968 [34034]
+0000 1
+.names ng20014 ng19919 ng21127 ng21256 [34035]
+0001 1
+.names ng20841 ng19968 ng20014 ng19919 [34038]
+0000 1
+.names ng20841 ng19968 ng20014 ng19919 [34041]
+1000 1
+.names ng20841 ng19968 ng20014 ng19919 [34044]
+0100 1
+.names ng20841 ng19968 ng20014 ng19919 [34047]
+0010 1
+.names ng20841 ng19968 ng20014 ng19919 [34050]
+0001 1
+.names [34016] [34017] [34022] [34023] [34051]
+11-- 1
+--11 1
+.names [34028] [34029] [34034] [34035] [34052]
+11-- 1
+--11 1
+.names ni24685 [34038] [34041] [34053]
+11- 1
+1-1 1
+.names ni24685 [34044] [34047] [34054]
+11- 1
+1-1 1
+.names ni24685 [34050] [34051] [34054] [34057]
+--1- 1
+---1 1
+11-- 1
+.names ng4064 ng4057 ng4076 [34059]
+001 1
+.names ng4141 ng4125 ng4082 [34061]
+10- 1
+-01 1
+.names pg99 pg134 pg113 ng37 [34062]
+-11- 1
+1-11 1
+.names pg99 pg134 pg113 ng37 [34063]
+-11- 1
+1-11 1
+.names pg35 ng3817 ng5471 [34064]
+0-- 1
+-00 1
+.names pg35 ng3466 ng6163 [34065]
+0-- 1
+-00 1
+.names pg35 ng5124 ng5817 [34066]
+0-- 1
+-00 1
+.names pg35 ng6509 ng3115 [34067]
+0-- 1
+-00 1
+.names ng26365 [34064] [34067] [34070]
+111 1
+.names pg35 ng5124 ng5471 [34071]
+0-- 1
+-00 1
+.names pg35 ng4427 ng5817 ng4420 [34072]
+0--- 1
+-000 1
+.names pg35 ng3466 ng6163 [34073]
+0-- 1
+-00 1
+.names pg35 ng6509 ng3115 [34074]
+0-- 1
+-00 1
+.names [34071] [34072] [34073] [34074] [34076]
+1111 1
+.names pg35 ng3466 ng6509 [34078]
+110 1
+.names pg35 ng3817 ng6163 ng3115 [34079]
+0--- 1
+-000 1
+.names pg35 ng3466 ng6509 [34082]
+0-- 1
+-00 1
+.names pg35 ng3817 ng6163 ng3115 [34083]
+1001 1
+.names pg35 ng5124 ng6163 [34085]
+0-- 1
+-00 1
+.names pg35 ng6509 ng5817 [34086]
+0-- 1
+-00 1
+.names pg35 ng6163 ng5471 [34088]
+0-- 1
+-00 1
+.names pg35 ng6509 ng5817 [34089]
+0-- 1
+-00 1
+.names pg35 ng6163 ng5471 [34091]
+0-- 1
+-00 1
+.names pg35 ng5124 ng6509 [34092]
+0-- 1
+-00 1
+.names pg35 ng6509 [34071] [34072] [34094]
+0-11 1
+-011 1
+.names pg35 ng6163 [34071] [34072] [34095]
+0-11 1
+-011 1
+.names [3183] [34065] [34066] [34070] [34096]
+1--- 1
+-111 1
+.names [32354] [32355] [34076] [34094] [34099]
+1-1- 1
+-11- 1
+00-1 1
+.names [3184] [3185] [3186] [3187] [34101]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng28180 ng13156 [29957] [30003] [34104]
+10-- 1
+1-0- 1
+1--0 1
+.names ng27511 ng17653 ni17529 [30041] [34105]
+110- 1
+11-0 1
+.names ni18740 ni17529 [30000] [30045] [34106]
+00-- 1
+0-0- 1
+-0-0 1
+--00 1
+.names ng31327 [34104] [34105] [34106] [34109]
+0111 1
+.names ng28180 ng13156 [29957] [30003] [34111]
+10-- 1
+1-0- 1
+1--0 1
+.names ng27511 ng17653 ni17529 [30041] [34112]
+0--- 1
+-00- 1
+-0-0 1
+.names ni18740 ni17529 [30000] [30045] [34113]
+00-- 1
+0-0- 1
+-0-0 1
+--00 1
+.names ng31327 [34111] [34112] [34113] [34116]
+0111 1
+.names ng28180 ng13156 [29957] [30003] [34118]
+0--- 1
+-111 1
+.names ng27511 ng17653 ni17529 [30041] [34120]
+0--- 1
+-00- 1
+-0-0 1
+.names ni18740 ni17529 [29997] [30045] [34121]
+00-- 1
+0-0- 1
+-0-0 1
+--00 1
+.names ng28180 ng13156 [29957] [30003] [34124]
+10-- 1
+1-0- 1
+1--0 1
+.names ng27511 ng17653 ni17529 [30041] [34126]
+0--- 1
+-00- 1
+-0-0 1
+.names ni18740 ni17529 [29997] [30045] [34127]
+00-- 1
+0-0- 1
+-0-0 1
+--00 1
+.names ng28180 ng13156 [29957] [30003] [34130]
+10-- 1
+1-0- 1
+1--0 1
+.names ng27511 ng17653 ni17529 [30041] [34132]
+0--- 1
+-00- 1
+-0-0 1
+.names ni18740 ni17529 [29997] [30045] [34133]
+00-- 1
+0-0- 1
+-0-0 1
+--00 1
+.names ng28180 ng13156 [29957] [30003] [34136]
+00-- 1
+0-0- 1
+0--0 1
+.names ng27511 ng17653 ni17529 [30041] [34138]
+0--- 1
+-00- 1
+-0-0 1
+.names ni18740 ni17529 [29997] [30045] [34139]
+00-- 1
+0-0- 1
+-0-0 1
+--00 1
+.names ng28180 ng13156 [29957] [30003] [34142]
+1111 1
+.names ng27511 ng17653 ni17529 [30041] [34144]
+0--- 1
+-00- 1
+-0-0 1
+.names ni18740 ni17529 [29997] [30045] [34145]
+00-- 1
+0-0- 1
+-0-0 1
+--00 1
+.names ng28180 ni17529 [29997] [30000] [34149]
+1110 1
+.names ng27511 ni18740 [29959] [30002] [34150]
+0--- 1
+-0-- 1
+--00 1
+.names ni18740 ni17529 [30042] [30045] [34151]
+00-- 1
+0-0- 1
+-0-0 1
+--00 1
+.names ng28180 ng13156 [29957] [30045] [34154]
+1111 1
+.names ni18740 ni17529 [29997] [30003] [34156]
+00-- 1
+0-0- 1
+-0-0 1
+--00 1
+.names ng28180 ni17529 [30000] [30042] [34159]
+1101 1
+.names ng30614 [29984] [29985] [34159] [34160]
+0001 1
+.names ng31021 ng31376 [34109] [34116] [34161]
+001- 1
+10-1 1
+.names [3170] [3171] [34161] [34166]
+1-- 1
+-1- 1
+--1 1
+.names [3172] [3173] [3174] [3175] [34167]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ng27511 ng17653 ni17529 [29996] [34169]
+0--- 1
+-00- 1
+-0-0 1
+.names ni18740 ni18785 [29962] [29966] [34170]
+00-- 1
+-00- 1
+0--0 1
+--00 1
+.names ng27511 ng17653 ni17529 [29996] [34173]
+0--- 1
+-00- 1
+-0-0 1
+.names ni18740 ni18785 [29962] [29966] [34174]
+00-- 1
+-00- 1
+0--0 1
+--00 1
+.names ng27511 ng17653 ni17529 [29996] [34177]
+0--- 1
+-00- 1
+-0-0 1
+.names ni18740 ni18785 [29962] [29966] [34178]
+00-- 1
+-00- 1
+0--0 1
+--00 1
+.names ng27511 ng17653 ni17529 [29996] [34181]
+0--- 1
+-00- 1
+-0-0 1
+.names ni18740 ni18785 [29962] [29966] [34182]
+00-- 1
+-00- 1
+0--0 1
+--00 1
+.names ng27511 ng17653 ni17529 [29996] [34185]
+0--- 1
+-00- 1
+-0-0 1
+.names ni18740 ni18785 [29962] [29966] [34186]
+00-- 1
+-00- 1
+0--0 1
+--00 1
+.names ng13156 [29957] [29962] [30003] [34188]
+0--- 1
+-0-- 1
+--00 1
+.names ng13156 [29963] [29966] [34188] [34189]
+0--1 1
+-0-1 1
+--01 1
+.names ng30937 [29984] [29985] [34149] [34193]
+0001 1
+.names [3159] [3160] [3167] [34198]
+1-- 1
+-1- 1
+--1 1
+.names [3161] [3162] [3163] [3164] [34199]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names ni18740 ni17529 [30003] [30042] [34201]
+00-- 1
+-00- 1
+0--0 1
+--00 1
+.names ng13156 [29957] [30045] [34201] [34202]
+0--1 1
+-0-1 1
+--01 1
+.names ng28180 ng13156 [29937] [30000] [34203]
+10-- 1
+1-0- 1
+1--0 1
+.names ni18740 ni18785 [29962] [29966] [34204]
+01-1 1
+-101 1
+.names [29984] [29985] [34203] [34204] [34206]
+0011 1
+.names ni18740 ni17529 [30042] [30045] [34207]
+00-- 1
+0-0- 1
+-0-0 1
+--00 1
+.names ni18740 ni18785 [29962] [29966] [34208]
+00-- 1
+-00- 1
+0--0 1
+--00 1
+.names ni18740 ni17529 [30042] [30045] [34211]
+00-- 1
+0-0- 1
+-0-0 1
+--00 1
+.names ni18740 ni18785 [29962] [29966] [34212]
+00-- 1
+-00- 1
+0--0 1
+--00 1
+.names ni18740 ni17529 [30042] [30045] [34215]
+00-- 1
+0-0- 1
+-0-0 1
+--00 1
+.names ni18740 ni18785 [29962] [29966] [34216]
+00-- 1
+-00- 1
+0--0 1
+--00 1
+.names ni18740 ni17529 [30042] [30045] [34219]
+00-- 1
+0-0- 1
+-0-0 1
+--00 1
+.names ni18740 ni18785 [29962] [29966] [34220]
+00-- 1
+-00- 1
+0--0 1
+--00 1
+.names ni18740 ni17529 [30042] [30045] [34225]
+00-- 1
+0-0- 1
+-0-0 1
+--00 1
+.names ni18740 ni18785 [29962] [29966] [34226]
+00-- 1
+-00- 1
+0--0 1
+--00 1
+.names ng28180 ng13156 [29937] [30000] [34229]
+10-- 1
+1-0- 1
+1--0 1
+.names [29984] [29985] [34229] [34230]
+001 1
+.names ni18740 ni17529 [30003] [30042] [34231]
+00-- 1
+-00- 1
+0--0 1
+--00 1
+.names ng13156 [29957] [29962] [30045] [34232]
+0--- 1
+-0-- 1
+--00 1
+.names ni18785 [29966] [34231] [34232] [34234]
+0-11 1
+-011 1
+.names ni18740 ni17529 [30003] [30042] [34235]
+00-- 1
+-00- 1
+0--0 1
+--00 1
+.names ni18740 ni18785 [29962] [29966] [34236]
+00-- 1
+-00- 1
+0--0 1
+--00 1
+.names ng28180 ng13156 [29937] [30000] [34239]
+10-- 1
+1-0- 1
+1--0 1
+.names ng13156 [29957] [30003] [30045] [34241]
+0--- 1
+-0-- 1
+--00 1
+.names ng13156 [29963] [29966] [34241] [34242]
+0--1 1
+-0-1 1
+--01 1
+.names ng31566 [29984] [29985] [34159] [34244]
+0001 1
+.names ng33496 [3148] [3149] [3150] [34248]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg99 pg134 pg113 ng37 [34256]
+--0- 1
+00-- 1
+-0-0 1
+.names ni18740 ni17529 [30042] [30045] [34258]
+00-- 1
+0-0- 1
+-0-0 1
+--00 1
+.names ni18740 ni18785 [29962] [29966] [34259]
+00-- 1
+-00- 1
+0--0 1
+--00 1
+.names ni18740 ni17529 [30003] [30042] [34262]
+00-- 1
+-00- 1
+0--0 1
+--00 1
+.names ng13156 [29957] [29962] [30045] [34263]
+0--- 1
+-0-- 1
+--00 1
+.names ni18785 [29966] [34262] [34263] [34265]
+0-11 1
+-011 1
+.names ni18740 ni17529 [30003] [30042] [34266]
+00-- 1
+-00- 1
+0--0 1
+--00 1
+.names ni18740 ni18785 [29962] [29966] [34267]
+00-- 1
+-00- 1
+0--0 1
+--00 1
+.names ng31566 [29984] [29985] [34159] [34271]
+0001 1
+.names ng33496 [3137] [3138] [3139] [34275]
+1--- 1
+-1-- 1
+--1- 1
+---1 1
+.names pg73 ng4332 ng4366 ng4311 [34278]
+1100 1
+0000 1
+.names ng2912 ng2941 ng2936 ng2917 [34279]
+-11- 1
+1--1 1
+.names ng2902 ng2960 ng2965 ng2907 [34280]
+-11- 1
+1--1 1
+.names ng2950 ng2975 ng2970 ng2955 [34281]
+-11- 1
+1--1 1
+.names pg99 pg134 pg113 ng37 [34290]
+--0- 1
+00-- 1
+-0-0 1
+.names [1457] [1411] [34292]
+0- 1
+-0 1
+.names pg99 pg134 pg113 ng37 [34294]
+--0- 1
+00-- 1
+-0-0 1
+.names [1457] [1411] [34296]
+0- 1
+-0 1
+.end

--- a/tests/test_vpr_xml_patch.py
+++ b/tests/test_vpr_xml_patch.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from lxml import etree
+
+from src.coffe.vpr import print_vpr_file_flut_hard
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ckt(delay: float, sp_name: str | None = None):
+    return SimpleNamespace(delay=delay, sp_name=sp_name)
+
+
+def _mock_fpga():
+    min_width_tran_area = 2.0
+    specs = SimpleNamespace(
+        Rfb=[],
+        Fcin=0.15,
+        Fcout=0.10,
+        Fs=3,
+        N=10,
+        K=6,
+        min_width_tran_area=min_width_tran_area,
+        enable_carry_chain=True,
+    )
+
+    lut_inputs = {
+        name: [
+            SimpleNamespace(
+                driver=_ckt(100e-12),
+                not_driver=_ckt(110e-12),
+                delay=idx * 10e-12,
+            )
+        ]
+        for idx, name in enumerate("abcdefgh", start=1)
+    }
+
+    return SimpleNamespace(
+        specs=specs,
+        area_dict={
+            "logic_cluster": 2468.0,
+            "switch_mux_trans_size_L4": 12.0,
+            "switch_buf_size_L4": 34.0,
+            "switch_mux_trans_size_L16": 20.0,
+            "switch_buf_size_L16": 52.0,
+            "ipin_mux_trans_size": 8.0,
+            "cb_buf_size": 10.0,
+        },
+        lut_inputs=lut_inputs,
+        sb_muxes=[
+            SimpleNamespace(
+                vpr_name="L4_driver",
+                delay=321e-12,
+                sink_wire=SimpleNamespace(type="L4"),
+            ),
+            SimpleNamespace(
+                vpr_name="L16_driver",
+                delay=654e-12,
+                sink_wire=SimpleNamespace(type="L16"),
+            ),
+        ],
+        cb_muxes=[
+            SimpleNamespace(vpr_name="ipin_cblock", delay=87e-12),
+        ],
+        local_muxes=[_ckt(91e-12, "local_mux")],
+        local_ble_outputs=[_ckt(82e-12, "local_ble_output")],
+        general_ble_outputs=[_ckt(73e-12, "general_ble_output")],
+        carry_chain_inter_clusters=[_ckt(11e-12, "carry_inter")],
+        carry_chain_periphs=[_ckt(22e-12, "carry_periph")],
+        carry_chain_muxes=[_ckt(33e-12, "carry_mux")],
+        carry_chains=[],
+    )
+
+
+def _find_vpr_binary() -> Path:
+    candidates = []
+
+    vpr_env = os.environ.get("VPR")
+    if vpr_env:
+        vpr_from_path = shutil.which(vpr_env)
+        candidates.append(Path(vpr_from_path) if vpr_from_path else Path(vpr_env))
+
+    vtr_home = os.environ.get("VTR_HOME")
+    if vtr_home:
+        candidates.append(Path(vtr_home) / "build" / "vpr" / "vpr")
+
+    candidates.extend(
+        [
+            REPO_ROOT / "third_party" / "vtr" / "build" / "vpr" / "vpr",
+            REPO_ROOT / "third_party" / "vtr" / "vpr" / "vpr",
+        ]
+    )
+
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+
+    pytest.skip("VPR binary not found")
+
+
+def _delay_matrix_values(root, in_port: str) -> list[float]:
+    delay_nodes = root.xpath(f"//delay_matrix[@in_port='{in_port}']")
+    assert len(delay_nodes) == 1
+    return [float(value) for value in delay_nodes[0].text.split()]
+
+
+def _switch(root, name: str):
+    switches = root.xpath(f"//switchlist/switch[@name='{name}']")
+    assert len(switches) == 1
+    return switches[0]
+
+
+def test_print_vpr_file_flut_hard_patches_arch_and_vpr_packs(tmp_path):
+    input_arch = REPO_ROOT / "arch.xml"
+    blif = REPO_ROOT / "third_party" / "vtr" / "vtr_flow" / "benchmarks" / "microbenchmarks" / "and.blif"
+    assert input_arch.is_file(), f"Missing VPR architecture fixture: {input_arch}"
+    assert blif.is_file(), f"Missing VPR BLIF fixture: {blif}"
+
+    patched_arch = tmp_path / "patched_arch.xml"
+    lut_delays = {
+        f"lut_{name}": delay
+        for name, delay in zip(
+            "abcdefgh",
+            [101e-12, 202e-12, 303e-12, 404e-12, 505e-12, 606e-12, 707e-12, 808e-12],
+        )
+    }
+
+    print_vpr_file_flut_hard(
+        vpr_file=None,
+        fpga_inst=_mock_fpga(),
+        input_xml=str(input_arch),
+        output_xml=str(patched_arch),
+        delay_dict=lut_delays,
+    )
+
+    tree = etree.parse(str(patched_arch))
+    root = tree.getroot()
+
+    assert root.xpath("string(//device/area/@grid_logic_tile_area)") == "1234.0"
+
+    l4_switch = _switch(root, "L4_driver")
+    assert l4_switch.get("Tdel") == str(321e-12)
+    assert l4_switch.get("mux_trans_size") == "6.0"
+    assert l4_switch.get("buf_size") == "17.0"
+
+    l16_switch = _switch(root, "L16_driver")
+    assert l16_switch.get("Tdel") == str(654e-12)
+    assert l16_switch.get("mux_trans_size") == "10.0"
+    assert l16_switch.get("buf_size") == "26.0"
+
+    cb_switch = _switch(root, "ipin_cblock")
+    assert cb_switch.get("Tdel") == str(87e-12)
+    assert cb_switch.get("mux_trans_size") == "4.0"
+    assert cb_switch.get("buf_size") == "5.0"
+
+    assert _delay_matrix_values(root, "lut4.in") == pytest.approx(
+        [101e-12, 202e-12, 303e-12, 404e-12]
+    )
+    assert _delay_matrix_values(root, "lut5.in") == pytest.approx(
+        [101e-12, 202e-12, 303e-12, 404e-12, 505e-12]
+    )
+    assert _delay_matrix_values(root, "lut6.in") == pytest.approx(
+        [101e-12, 202e-12, 303e-12, 404e-12, 505e-12, 606e-12]
+    )
+
+    local_mux_delays = root.xpath(
+        "//complete/delay_constant[contains(@in_port, 'clb.I') and contains(@out_port, '.in')]/@max"
+    )
+    assert local_mux_delays
+    assert set(local_mux_delays) == {str(91e-12)}
+
+    feedback_delays = root.xpath(
+        "//complete/delay_constant[contains(@in_port, '.out') and contains(@out_port, '.in')]/@max"
+    )
+    assert feedback_delays
+    assert set(feedback_delays) == {str(82e-12)}
+
+    output_mux_delays = root.xpath("//mux[contains(@input, 'ff.Q')]/delay_constant/@max")
+    assert output_mux_delays
+    assert set(output_mux_delays) == {str(73e-12)}
+
+    carry_delays = root.xpath("//direct[@name='carry_in']/delay_constant/@max")
+    assert carry_delays
+    assert set(carry_delays) == {str(66e-12)}
+
+    result = subprocess.run(
+        [str(_find_vpr_binary()), str(patched_arch), str(blif), "--pack"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout[-4000:] + result.stderr[-4000:]


### PR DESCRIPTION
# VPR Arch Patching
## Changes

- Added VPR as a third-party submodule under `third_party`
- Added VPR compile and compile check for the submodule in `env_setup.sh` and `py_install.sh`
- Reworked the `print_vpr_flut_hard` function to patch an input VPR XML with the results of a COFFE run
- Added `k6n10_template` as an example for the architecture style that the VPR XML patcher expects
- Added a unit test for the new `print_vpr_flut_hard` function under the `tests` directory